### PR TITLE
fix(daemon): 持久化 godot 启动日志 + 透出 last exit code (closes #38)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ venv/
 .coverage.*
 coverage.xml
 htmlcov/
+# uv 本地 dev 锁；本项目作为库发布，不入库（避免给下游消费者制造噪音）
+uv.lock
 
 # hatch-vcs generated
 python/godot_cli_control/_version.py

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ import asyncio
 from godot_cli_control import GameClient
 
 async def main():
-    async with GameClient(port=9877) as client:
+    # Omitting port lets GameClient auto-discover from .cli_control/port (written by daemon start)
+    async with GameClient() as client:
         await client.click("/root/Game/StartButton")
         await client.action_press("jump")
         await client.wait_game_time(0.5)
@@ -113,11 +114,13 @@ Pass `--text` (or `--no-json`) to switch back to legacy human-readable output.
 │   ┌──────────────────────────┐     │   JSON-RPC     │   ┌────────────────────────────┐   │
 │   │ godot-cli-control CLI    │     │   127.0.0.1    │   │ addons/godot_cli_control/  │   │
 │   │ GameClient   (async)     │ ◄──────────────────► │   │   GameBridgeNode autoload  │   │
-│   │ GameBridge   (sync)      │     │   :9877        │   │   LowLevelApi              │   │
-│   │ pytest fixtures          │     │   (default)    │   │   InputSimulationApi       │   │
+│   │ GameBridge   (sync)      │     │   :<port>      │   │   LowLevelApi              │   │
+│   │ pytest fixtures          │     │   (auto)       │   │   InputSimulationApi       │   │
 │   └──────────────────────────┘     │                │   └────────────────────────────┘   │
 └────────────────────────────────────┘                └────────────────────────────────────┘
 ```
+
+`<port>` is OS-assigned by default; the actual value is written to `.cli_control/port` when the daemon starts. CLI subcommands and `GameClient()` (no port arg) auto-discover it from there.
 
 The plugin is **off by default** even when enabled — see [Activation modes](addons/godot_cli_control/README.md#activation-modes). The server binds `127.0.0.1` only; PID/port files are mode `0600`; release builds are unconditionally disabled. See [Security model](addons/godot_cli_control/README.md#security-model).
 
@@ -183,6 +186,13 @@ The two `--no-*` flags are mutually exclusive with each other; `--skills-no-clob
 ## Manual install (advanced)
 
 If you don't want `init`, copy the plugin manually and enable it from the editor — see the [plugin README](addons/godot_cli_control/README.md#manual-setup-if-you-prefer) for the long-form walkthrough. The legacy wrappers (`bin/run_cli_control.sh` / `.ps1`) are kept as compatibility shims but **deprecated since 0.1.6 and scheduled for removal in 0.3.0** — new code should call `godot-cli-control <subcommand>` directly.
+
+## Recent changes
+
+- **Default daemon port is now OS-assigned (was 9877).** The actual port is written to `.cli_control/port`; CLI subcommands and `GameClient()` (no port arg) auto-discover it. External scripts that hardcoded `127.0.0.1:9877` should either read `.cli_control/port` or pass `--port 9877` explicitly to `daemon start`.
+- **New: `godot-cli-control daemon ls`** — list daemons across all projects.
+- **New: `godot-cli-control daemon stop --all`** / **`--project <path>`** — batch / cross-project stop.
+- **New: `godot-cli-control daemon start --idle-timeout 30m`** — opt-in: auto-shutdown the Godot process after N minutes of no RPC activity. Default off.
 
 ## Status
 

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -13,6 +13,12 @@ var _active_stream: StreamPeerTCP = null
 var _port: int = DEFAULT_PORT
 var _idle_timeout_secs: int = 0
 var _last_activity_ms: int = 0
+# 正在处理中的请求数。> 0 表示 daemon 没闲着，idle 检查必须放过 —— 否则
+# 一条 wait_game_time(3600) 会被 30m idle-timeout 半路打断，客户端拿不到响应。
+# 入：消息通过参数校验、即将派发到 handler 时 +1。
+# 出：_dispatch_result（sync/async/async_with_id 三条路径的最终响应点）-1。
+# 校验失败的 _send_error 不计数（没进过 handler）。
+var _in_flight: int = 0
 var _outbound_buffer_size: int = DEFAULT_OUTBOUND_BUFFER_MB * 1024 * 1024
 var _low_level_api: LowLevelApi = null
 var _input_sim_api: InputSimulationApi = null
@@ -198,6 +204,7 @@ func _handle_message(raw: String) -> void:
 	var entry: Dictionary = _methods[method] as Dictionary
 	var handler: Callable = entry["callable"] as Callable
 	var kind: String = entry["kind"] as String
+	_in_flight += 1
 	match kind:
 		"sync":
 			var result: Dictionary = handler.call(params)
@@ -214,12 +221,14 @@ func _run_async(id: String, handler: Callable, params: Dictionary) -> void:
 	# 客户端 await 挂死到 timeout。先收原 Variant 自己 type-check。
 	var raw: Variant = await handler.call(params)
 	if not raw is Dictionary:
+		_in_flight = max(0, _in_flight - 1)
 		_send_error(id, -32603, "internal: async handler returned non-dict")
 		return
 	_dispatch_result(id, raw as Dictionary)
 
 
 func _dispatch_result(id: String, result: Dictionary) -> void:
+	_in_flight = max(0, _in_flight - 1)
 	if result.has("error"):
 		var err: Dictionary = result["error"] as Dictionary
 		_send_error(id, err["code"] as int, err["message"] as String)
@@ -304,6 +313,11 @@ func _parse_idle_timeout_from_args() -> int:
 
 
 func _check_idle() -> void:
+	# 有正在处理的请求 → daemon 没闲着；把活动戳推到现在，等所有请求落地后
+	# 再开始计时。否则一个 wait_game_time(idle_timeout+1) 就会被半路 quit。
+	if _in_flight > 0:
+		_last_activity_ms = Time.get_ticks_msec()
+		return
 	var idle_ms: int = Time.get_ticks_msec() - _last_activity_ms
 	if idle_ms / 1000 >= _idle_timeout_secs:
 		print("GameBridge: idle for %ds, shutting down" % (idle_ms / 1000))

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -11,6 +11,8 @@ var _tcp_server: TCPServer = TCPServer.new()
 var _active_peer: WebSocketPeer = null
 var _active_stream: StreamPeerTCP = null
 var _port: int = DEFAULT_PORT
+var _idle_timeout_secs: int = 0
+var _last_activity_ms: int = 0
 var _outbound_buffer_size: int = DEFAULT_OUTBOUND_BUFFER_MB * 1024 * 1024
 var _low_level_api: LowLevelApi = null
 var _input_sim_api: InputSimulationApi = null
@@ -23,7 +25,12 @@ var _methods: Dictionary = {}
 
 func _ready() -> void:
 	if not _should_activate():
-		print("[Godot CLI Control] inactive — pass --cli-control, set GODOT_CLI_CONTROL=1, or enable %s in Project Settings (debug build only)" % SETTING_AUTO_ENABLE)
+		print(
+			(
+				"[Godot CLI Control] inactive — pass --cli-control, set GODOT_CLI_CONTROL=1, or enable %s in Project Settings (debug build only)"
+				% SETTING_AUTO_ENABLE
+			)
+		)
 		queue_free()
 		return
 	# 即使 SceneTree 暂停也要继续运行
@@ -39,7 +46,9 @@ func _ready() -> void:
 	# 构建统一方法注册表
 	_register_methods()
 	# 缓存 outbound buffer 大小（ProjectSettings 可覆盖默认 10MB，至少 1MB）
-	var mb: int = int(ProjectSettings.get_setting(SETTING_OUTBOUND_BUFFER_MB, DEFAULT_OUTBOUND_BUFFER_MB))
+	var mb: int = int(
+		ProjectSettings.get_setting(SETTING_OUTBOUND_BUFFER_MB, DEFAULT_OUTBOUND_BUFFER_MB)
+	)
 	_outbound_buffer_size = max(1, mb) * 1024 * 1024
 	# 启动 TCP 服务器
 	_port = _parse_port_from_args()
@@ -54,6 +63,16 @@ func _ready() -> void:
 		printerr(msg)
 		return
 	print("GameBridge: Listening on ws://127.0.0.1:%d" % _port)
+	_idle_timeout_secs = _parse_idle_timeout_from_args()
+	_last_activity_ms = Time.get_ticks_msec()
+	if _idle_timeout_secs > 0:
+		var t: Timer = Timer.new()
+		t.wait_time = 1.0
+		t.autostart = true
+		t.process_mode = Node.PROCESS_MODE_ALWAYS
+		t.timeout.connect(_check_idle)
+		add_child(t)
+		print("GameBridge: idle-timeout %ds enabled" % _idle_timeout_secs)
 
 
 func _process(_delta: float) -> void:
@@ -118,14 +137,22 @@ func _register_methods() -> void:
 	_methods["wait_game_time"] = {"callable": _low_level_api.wait_game_time_async, "kind": "async"}
 	_methods["screenshot"] = {"callable": _wrap_screenshot, "kind": "async"}
 	# 输入模拟（同步）
-	_methods["input_action_press"] = {"callable": _input_sim_api.handle_action_press, "kind": "sync"}
-	_methods["input_action_release"] = {"callable": _input_sim_api.handle_action_release, "kind": "sync"}
+	_methods["input_action_press"] = {
+		"callable": _input_sim_api.handle_action_press, "kind": "sync"
+	}
+	_methods["input_action_release"] = {
+		"callable": _input_sim_api.handle_action_release, "kind": "sync"
+	}
 	_methods["input_action_tap"] = {"callable": _input_sim_api.handle_action_tap, "kind": "sync"}
 	_methods["input_get_pressed"] = {"callable": _input_sim_api.handle_get_pressed, "kind": "sync"}
-	_methods["list_input_actions"] = {"callable": _input_sim_api.handle_list_input_actions, "kind": "sync"}
+	_methods["list_input_actions"] = {
+		"callable": _input_sim_api.handle_list_input_actions, "kind": "sync"
+	}
 	_methods["input_hold"] = {"callable": _input_sim_api.handle_hold, "kind": "sync"}
 	_methods["input_release_all"] = {"callable": _input_sim_api.handle_release_all, "kind": "sync"}
-	_methods["input_combo_cancel"] = {"callable": _input_sim_api.handle_combo_cancel, "kind": "sync"}
+	_methods["input_combo_cancel"] = {
+		"callable": _input_sim_api.handle_combo_cancel, "kind": "sync"
+	}
 	# 输入模拟（async_with_id：handler 自行通过 _on_async_response 回响）
 	_methods["input_combo"] = {"callable": _input_sim_api.handle_combo, "kind": "async_with_id"}
 
@@ -136,6 +163,7 @@ func _wrap_screenshot(_params: Dictionary) -> Dictionary:
 
 
 func _handle_message(raw: String) -> void:
+	_last_activity_ms = Time.get_ticks_msec()
 	var parsed: Variant = JSON.parse_string(raw)
 	if parsed == null or not parsed is Dictionary:
 		_send_error("", -32600, "Invalid JSON")
@@ -253,9 +281,30 @@ func _parse_port_from_args() -> int:
 			var port: int = parts[1].to_int()
 			if port < 1 or port > 65535:
 				push_warning(
-					"GameBridge: Port %d out of range [1, 65535], falling back to %d"
-					% [port, DEFAULT_PORT]
+					(
+						"GameBridge: Port %d out of range [1, 65535], falling back to %d"
+						% [port, DEFAULT_PORT]
+					)
 				)
 				return DEFAULT_PORT
 			return port
 	return DEFAULT_PORT
+
+
+func _parse_idle_timeout_from_args() -> int:
+	for arg: String in OS.get_cmdline_args():
+		if arg.begins_with("--game-bridge-idle-timeout="):
+			var parts: PackedStringArray = arg.split("=", false, 1)
+			if parts.size() != 2 or not parts[1].is_valid_int():
+				push_warning("GameBridge: Invalid idle-timeout %s, disabling" % arg)
+				return 0
+			var secs: int = parts[1].to_int()
+			return secs if secs > 0 else 0
+	return 0
+
+
+func _check_idle() -> void:
+	var idle_ms: int = Time.get_ticks_msec() - _last_activity_ms
+	if idle_ms / 1000 >= _idle_timeout_secs:
+		print("GameBridge: idle for %ds, shutting down" % (idle_ms / 1000))
+		get_tree().quit()

--- a/addons/godot_cli_control/tests/gut/test_game_bridge.gd
+++ b/addons/godot_cli_control/tests/gut/test_game_bridge.gd
@@ -344,3 +344,64 @@ func test_sync_input_action_press_routes_to_input_sim_api() -> void:
 	assert_does_not_have(f, "error")
 	assert_eq(_input.press_calls.size(), 1)
 	assert_eq(str(_input.press_calls[0].action), "jump")
+
+
+# ── idle-timeout / in-flight 计数 ─────────────────────────────────
+# 防止回归：长操作（>idle_timeout 的 wait_game_time / combo）期间 _check_idle
+# 不能 quit，否则客户端拿不到响应。
+
+func test_in_flight_starts_at_zero() -> void:
+	assert_eq(_bridge._in_flight, 0)
+
+
+func test_sync_dispatch_returns_in_flight_to_zero() -> void:
+	_send('{"id": "s1", "method": "click", "params": {}}')
+	assert_eq(_bridge._in_flight, 0, "sync 派发完成后 _in_flight 必须归零")
+
+
+func test_async_dispatch_returns_in_flight_to_zero() -> void:
+	_send('{"id": "a1", "method": "wait_for_node", "params": {"path": "/X", "timeout": 1.0}}')
+	# stub 在 await get_tree().process_frame 期间 _in_flight 应保持 1
+	assert_eq(_bridge._in_flight, 1, "async 等待期间 _in_flight 应为 1")
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_eq(_bridge._in_flight, 0, "async 派发完成后 _in_flight 必须归零")
+
+
+func test_async_with_id_keeps_in_flight_until_callback() -> void:
+	# 关键场景：input_combo 长动作（实际可能 5s+）期间，daemon 不能因 idle quit
+	_send('{"id": "c1", "method": "input_combo", "params": {"steps": []}}')
+	assert_eq(_bridge._in_flight, 1, "async_with_id handler 未回响前 _in_flight 应为 1")
+	_input.finish_combo(0, {"success": true})
+	assert_eq(_bridge._in_flight, 0, "回调后 _in_flight 必须归零")
+
+
+func test_async_handler_returning_non_dict_decrements_in_flight() -> void:
+	# type-guard 路径也必须减计数，否则 handler bug 会让 daemon 永远不 idle
+	_bridge._methods["wait_for_node"] = {
+		"callable": _async_returning_null,
+		"kind": "async",
+	}
+	_send('{"id": "wn", "method": "wait_for_node", "params": {}}')
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_eq(_bridge._in_flight, 0, "非 dict 错误路径也必须把 _in_flight 减回 0")
+
+
+func test_validation_failure_does_not_increment_in_flight() -> void:
+	# Invalid JSON / 协议错没进过 handler，不应碰计数
+	_send("not json")
+	_send('{"id": 42, "method": "click"}')  # id 非串
+	_send('{"id": "x", "method": "no_such"}')  # 未知方法
+	assert_eq(_bridge._in_flight, 0, "校验失败路径不应增 _in_flight")
+
+
+func test_check_idle_resets_activity_when_busy() -> void:
+	# _check_idle 在 _in_flight > 0 时必须把活动戳推到现在 —— 否则一个跨越
+	# 整个 idle_timeout 的长操作会被 quit。
+	_bridge._idle_timeout_secs = 1
+	_bridge._in_flight = 1
+	_bridge._last_activity_ms = Time.get_ticks_msec() - 60_000  # 装作 60s 前
+	_bridge._check_idle()
+	var now: int = Time.get_ticks_msec()
+	assert_almost_eq(_bridge._last_activity_ms, now, 200, "busy 时 _check_idle 必须把活动戳推到 ~now")

--- a/docs/superpowers/plans/2026-05-01-daemon-port-and-lifecycle.md
+++ b/docs/superpowers/plans/2026-05-01-daemon-port-and-lifecycle.md
@@ -1,0 +1,1054 @@
+# Daemon Port & Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 消除 daemon 的端口选号烦恼与孤儿守护进程 — 默认端口由 OS 自动分配；新增全局注册表与 `daemon ls` / `daemon stop --all` / `daemon stop --project`；可选 `--idle-timeout` 让 Godot 端空闲自动 shutdown。
+
+**Architecture:** 三组互相独立的小改动。A 改 daemon 内部端口分配函数与 CLI 默认值；B 新增 `registry.py` 模块 + 跨项目子命令；C 在 GDScript 端加 Timer + Python 端加 duration 解析。各组都可独立 commit + 上线，互不阻塞。
+
+**Tech Stack:** Python 3.10+ 标准库（`socket` / `pathlib` / `json` / `hashlib`）+ pytest；GDScript（Godot 4 Timer）。无新增第三方依赖。
+
+**Spec:** `docs/superpowers/specs/2026-05-01-daemon-port-and-lifecycle-design.md`
+
+**File Structure（新增 / 修改）：**
+
+| 文件 | 责任 |
+|---|---|
+| `python/godot_cli_control/daemon.py` | 新增 `_allocate_port`；`start` 接受 `port=0` / `idle_timeout`；`start` / `stop` 调注册表 |
+| `python/godot_cli_control/registry.py` | **新文件** — 全局守护进程注册表读写 + 死记录探活清理 |
+| `python/godot_cli_control/cli.py` | `--port` 默认 0；新增 `daemon ls` / `daemon stop --all/--project` / `--idle-timeout` |
+| `python/godot_cli_control/_duration.py` | **新文件** — `parse_duration("30m") -> 1800`；纯函数 + 单测 |
+| `addons/godot_cli_control/bridge/game_bridge.gd` | 解析 `--game-bridge-idle-timeout`，加 Timer + `_last_activity_ms` 更新点 |
+| `python/tests/test_daemon.py` | 追加 `_allocate_port` 测试 |
+| `python/tests/test_registry.py` | **新文件** — registry 单测 |
+| `python/tests/test_duration.py` | **新文件** — duration parser 单测 |
+| `python/tests/test_cli.py` | 追加 `daemon ls` / `--all` / `--project` / `--idle-timeout` 测试 |
+| `python/README.md` 与 `addons/godot_cli_control/SKILL.md` 与 init 落盘 SKILL 模板 | 文档同步默认端口变更 |
+
+---
+
+## Task 1: `_allocate_port` 函数（替代 `_check_port_available`）
+
+**Files:**
+- Modify: `python/godot_cli_control/daemon.py:399-416`
+- Test: `python/tests/test_daemon.py`
+
+- [ ] **Step 1.1: 写失败测试 — port=0 应返回 OS 分配的高位端口**
+
+追加到 `python/tests/test_daemon.py`：
+
+```python
+from godot_cli_control.daemon import _allocate_port
+
+def test_allocate_port_zero_returns_os_assigned() -> None:
+    port = _allocate_port(0)
+    assert 1024 < port < 65536
+
+def test_allocate_port_specific_returns_same() -> None:
+    # 用 OS 分配一个端口然后立即放掉，再要这个端口应该能拿到
+    free = _allocate_port(0)
+    assert _allocate_port(free) == free
+
+def test_allocate_port_raises_when_occupied() -> None:
+    import socket as _s
+    sock = _s.socket(_s.AF_INET, _s.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    occupied = sock.getsockname()[1]
+    try:
+        with pytest.raises(DaemonError, match="already in use"):
+            _allocate_port(occupied)
+    finally:
+        sock.close()
+```
+
+- [ ] **Step 1.2: 跑测试，确认 `_allocate_port` 不存在导致 ImportError**
+
+```bash
+cd /Users/kesar/Projects/godot-cli-control && uv run pytest python/tests/test_daemon.py::test_allocate_port_zero_returns_os_assigned -v
+```
+Expected: `ImportError: cannot import name '_allocate_port'`
+
+- [ ] **Step 1.3: 实现 `_allocate_port`，删除 `_check_port_available`**
+
+替换 `python/godot_cli_control/daemon.py:399-416`：
+
+```python
+def _allocate_port(requested: int) -> int:
+    """返回可用端口。requested=0 → OS 分配；requested>0 → 校验未被占用后返回原值。
+
+    bind 后立刻关闭与 Godot 子进程实际 listen 之间存在极小 race window，但内核
+    短期内不会立即重用同一端口；真撞上时 Godot listen 失败仍会通过日志被发现。
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        try:
+            sock.bind(("127.0.0.1", requested))
+        except OSError as e:
+            raise DaemonError(
+                f"port {requested} already in use ({e}). 另一个进程正在占用该端口，"
+                f"Godot 起不来。请 stop 旧 daemon 或换 --port。"
+            ) from e
+        return sock.getsockname()[1]
+    finally:
+        sock.close()
+```
+
+- [ ] **Step 1.4: 跑测试确认通过**
+
+```bash
+uv run pytest python/tests/test_daemon.py -v -k allocate_port
+```
+Expected: 3 passed
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add python/godot_cli_control/daemon.py python/tests/test_daemon.py
+git commit -m "feat(daemon): _allocate_port 支持 port=0 自动分配"
+```
+
+---
+
+## Task 2: 串接 `_allocate_port` 到 `Daemon.start`
+
+**Files:**
+- Modify: `python/godot_cli_control/daemon.py:78,112,132,139` (start 方法)
+
+- [ ] **Step 2.1: 写失败测试 — start 用 port=0 时 port_file 写入实际分配的端口**
+
+追加到 `test_daemon.py`，照 `test_start_rejects_*` 类似的 mock 写法：
+
+```python
+def test_start_with_port_zero_writes_actual_port(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """port=0 时 .cli_control/port 落盘的应是 OS 分配的实际端口，不是 0。"""
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "godot"
+    fake_bin.write_text("#!/bin/sh\nsleep 60\n")
+    fake_bin.chmod(0o755)
+
+    monkeypatch.setattr("godot_cli_control.daemon._ensure_imported", lambda *a, **k: None)
+    monkeypatch.setattr("godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True)
+
+    daemon = Daemon(tmp_path)
+    daemon.start(godot_bin=str(fake_bin), port=0)
+    try:
+        written = int(daemon.port_file.read_text().strip())
+        assert written != 0
+        assert 1024 < written < 65536
+    finally:
+        daemon.stop()
+```
+
+- [ ] **Step 2.2: 跑测试确认失败（默认 0 还没改，仍写 0 进去）**
+
+```bash
+uv run pytest python/tests/test_daemon.py::test_start_with_port_zero_writes_actual_port -v
+```
+Expected: FAIL（assert 0 != 0）
+
+- [ ] **Step 2.3: 改 `Daemon.start` 串接 `_allocate_port`**
+
+修改 `python/godot_cli_control/daemon.py:78` 默认值：
+
+```python
+        port: int = 0,  # 0 = OS 自动分配；显式 --port 9877 仍可固定
+```
+
+修改 `daemon.py:112` 调用：
+
+```python
+        actual_port = _allocate_port(port)
+```
+
+修改 `daemon.py:132` 写文件：
+
+```python
+        self.port_file.write_text(str(actual_port))
+```
+
+修改 `daemon.py:139` 传给 Godot：
+
+```python
+            f"--game-bridge-port={actual_port}",
+```
+
+并把后续 `_wait_port_ready(port, ...)` 与日志 `f"...port {port}..."` 全部改用 `actual_port`。
+
+- [ ] **Step 2.4: 跑测试**
+
+```bash
+uv run pytest python/tests/test_daemon.py -v
+```
+Expected: 全部 pass（含旧测试，因为 `port=0` 是新默认）
+
+- [ ] **Step 2.5: 改 CLI 默认端口**
+
+修改 `python/godot_cli_control/cli.py:952-957`：
+
+```python
+    p.add_argument(
+        "--port",
+        type=int,
+        default=0,
+        help="GameBridge 监听端口（默认 0 = OS 自动分配；写入 .cli_control/port）",
+    )
+```
+
+- [ ] **Step 2.6: 跑全套测试**
+
+```bash
+uv run pytest python/tests/ -v
+```
+Expected: 全部 pass
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add python/godot_cli_control/daemon.py python/godot_cli_control/cli.py python/tests/test_daemon.py
+git commit -m "feat(daemon): 默认 port=0 由 OS 分配，避免多项目并发冲突
+
+破坏性变更：daemon start 不再默认 9877。.cli_control/port 是
+source of truth；CLI 子命令自动适配。如需固定旧端口，显式 --port 9877。"
+```
+
+---
+
+## Task 3: `_duration.py` — duration 字符串解析
+
+**Files:**
+- Create: `python/godot_cli_control/_duration.py`
+- Test: `python/tests/test_duration.py`
+
+- [ ] **Step 3.1: 写失败测试**
+
+新建 `python/tests/test_duration.py`：
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from godot_cli_control._duration import parse_duration
+
+
+def test_parse_seconds() -> None:
+    assert parse_duration("30s") == 30
+
+def test_parse_minutes() -> None:
+    assert parse_duration("30m") == 1800
+
+def test_parse_hours() -> None:
+    assert parse_duration("2h") == 7200
+
+def test_parse_zero_is_zero() -> None:
+    assert parse_duration("0") == 0
+
+def test_parse_bare_int_means_seconds() -> None:
+    assert parse_duration("90") == 90
+
+def test_parse_invalid_raises() -> None:
+    with pytest.raises(ValueError, match="invalid duration"):
+        parse_duration("two minutes")
+```
+
+- [ ] **Step 3.2: 跑测试确认失败**
+
+```bash
+uv run pytest python/tests/test_duration.py -v
+```
+Expected: ImportError
+
+- [ ] **Step 3.3: 实现 parse_duration**
+
+新建 `python/godot_cli_control/_duration.py`：
+
+```python
+"""Parse human-friendly duration strings (e.g. "30m", "2h", "90s") to seconds."""
+from __future__ import annotations
+
+import re
+
+_PATTERN = re.compile(r"^\s*(\d+)\s*([smh]?)\s*$")
+_UNITS = {"": 1, "s": 1, "m": 60, "h": 3600}
+
+
+def parse_duration(text: str) -> int:
+    """Return total seconds. Bare integer = seconds. 0 means disabled."""
+    m = _PATTERN.match(text)
+    if not m:
+        raise ValueError(f"invalid duration {text!r} (use 30s / 30m / 2h / 0)")
+    return int(m.group(1)) * _UNITS[m.group(2)]
+```
+
+- [ ] **Step 3.4: 跑测试**
+
+```bash
+uv run pytest python/tests/test_duration.py -v
+```
+Expected: 6 passed
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add python/godot_cli_control/_duration.py python/tests/test_duration.py
+git commit -m "feat: parse_duration 解析 30s/30m/2h 字符串"
+```
+
+---
+
+## Task 4: `registry.py` — 全局守护进程注册表
+
+**Files:**
+- Create: `python/godot_cli_control/registry.py`
+- Test: `python/tests/test_registry.py`
+
+- [ ] **Step 4.1: 写失败测试 — register / list_all / unregister 基本路径**
+
+新建 `python/tests/test_registry.py`：
+
+```python
+"""Global daemon registry tests — 不实际起 Godot，只验状态文件 + 探活逻辑。"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from godot_cli_control import registry
+
+
+@pytest.fixture
+def reg_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "registry")
+    return tmp_path / "registry"
+
+
+def test_register_creates_record(reg_dir: Path, tmp_path: Path) -> None:
+    proj = tmp_path / "p1"
+    proj.mkdir()
+    registry.register(proj, pid=os.getpid(), port=12345, godot_bin="/x/godot",
+                      log_path=str(proj / ".cli_control/godot.log"))
+    records = registry.list_all()
+    assert len(records) == 1
+    r = records[0]
+    assert r.pid == os.getpid()
+    assert r.port == 12345
+    assert Path(r.project_root) == proj.resolve()
+
+
+def test_unregister_removes_record(reg_dir: Path, tmp_path: Path) -> None:
+    proj = tmp_path / "p1"; proj.mkdir()
+    registry.register(proj, pid=os.getpid(), port=1, godot_bin="x", log_path="x")
+    registry.unregister(proj)
+    assert registry.list_all() == []
+
+
+def test_list_all_prunes_dead_pids(reg_dir: Path, tmp_path: Path) -> None:
+    proj = tmp_path / "p1"; proj.mkdir()
+    # PID 1 几乎不会是当前用户的 Godot；用一个肯定死的高位 PID
+    registry.register(proj, pid=2_000_000, port=1, godot_bin="x", log_path="x")
+    assert registry.list_all() == []  # 探活后死记录被清掉
+    # 注册表文件也应被删
+    assert not list(reg_dir.glob("*.json"))
+
+
+def test_list_all_also_cleans_project_state_for_dead(
+    reg_dir: Path, tmp_path: Path
+) -> None:
+    proj = tmp_path / "p1"; proj.mkdir()
+    ctrl = proj / ".cli_control"
+    ctrl.mkdir()
+    (ctrl / "godot.pid").write_text("2000000")
+    (ctrl / "port").write_text("12345")
+    registry.register(proj, pid=2_000_000, port=12345, godot_bin="x",
+                      log_path=str(ctrl / "godot.log"))
+    registry.list_all()
+    assert not (ctrl / "godot.pid").exists()
+    assert not (ctrl / "port").exists()
+
+
+def test_project_hash_stable(tmp_path: Path) -> None:
+    p = tmp_path / "p"; p.mkdir()
+    h1 = registry.project_hash(p)
+    h2 = registry.project_hash(p)
+    assert h1 == h2 and len(h1) == 12
+```
+
+- [ ] **Step 4.2: 跑测试确认 ImportError**
+
+```bash
+uv run pytest python/tests/test_registry.py -v
+```
+Expected: ImportError
+
+- [ ] **Step 4.3: 实现 `registry.py`**
+
+新建 `python/godot_cli_control/registry.py`：
+
+```python
+"""Global cross-project daemon registry under ~/.local/state/godot-cli-control/daemons/.
+
+每个守护进程一份 ``<project_hash>.json``，记录 PID / 端口 / 项目路径 / 启动时刻。
+``list_all()`` 顺手探活并清理死记录。无文件锁 —— 每条记录文件名以 project_hash
+区分，写入幂等。
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import os
+import signal
+from dataclasses import dataclass
+from pathlib import Path
+
+_REGISTRY_DIR = Path.home() / ".local" / "state" / "godot-cli-control" / "daemons"
+
+
+@dataclass(frozen=True)
+class DaemonRecord:
+    project_root: str
+    pid: int
+    port: int
+    started_at: str
+    godot_bin: str
+    log_path: str
+
+    @property
+    def record_file(self) -> Path:
+        return _REGISTRY_DIR / f"{project_hash(Path(self.project_root))}.json"
+
+
+def project_hash(project_root: Path) -> str:
+    return hashlib.sha1(str(Path(project_root).resolve()).encode()).hexdigest()[:12]
+
+
+def register(
+    project_root: Path,
+    *,
+    pid: int,
+    port: int,
+    godot_bin: str,
+    log_path: str,
+) -> None:
+    _REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "project_root": str(Path(project_root).resolve()),
+        "pid": pid,
+        "port": port,
+        "started_at": _dt.datetime.now(_dt.timezone.utc).astimezone().isoformat(timespec="seconds"),
+        "godot_bin": godot_bin,
+        "log_path": log_path,
+    }
+    target = _REGISTRY_DIR / f"{project_hash(project_root)}.json"
+    target.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def unregister(project_root: Path) -> None:
+    target = _REGISTRY_DIR / f"{project_hash(project_root)}.json"
+    target.unlink(missing_ok=True)
+
+
+def list_all() -> list[DaemonRecord]:
+    """List live records. Dead PIDs are pruned (registry + project state files)."""
+    if not _REGISTRY_DIR.exists():
+        return []
+    live: list[DaemonRecord] = []
+    for f in sorted(_REGISTRY_DIR.glob("*.json")):
+        try:
+            data = json.loads(f.read_text())
+            r = DaemonRecord(**{k: data[k] for k in DaemonRecord.__dataclass_fields__})
+        except (OSError, json.JSONDecodeError, KeyError, TypeError):
+            f.unlink(missing_ok=True)
+            continue
+        if _process_alive(r.pid):
+            live.append(r)
+        else:
+            _prune(r, f)
+    return live
+
+
+def _prune(record: DaemonRecord, registry_file: Path) -> None:
+    registry_file.unlink(missing_ok=True)
+    ctrl = Path(record.project_root) / ".cli_control"
+    (ctrl / "godot.pid").unlink(missing_ok=True)
+    (ctrl / "port").unlink(missing_ok=True)
+
+
+def _process_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but owned by another user; treat as alive
+    except OSError:
+        return False
+    return True
+```
+
+- [ ] **Step 4.4: 跑测试确认全 pass**
+
+```bash
+uv run pytest python/tests/test_registry.py -v
+```
+Expected: 5 passed
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add python/godot_cli_control/registry.py python/tests/test_registry.py
+git commit -m "feat(registry): 全局守护进程注册表 + 死记录自动清理"
+```
+
+---
+
+## Task 5: 把 registry 串到 `Daemon.start` / `Daemon.stop`
+
+**Files:**
+- Modify: `python/godot_cli_control/daemon.py` (start 末尾、stop 末尾)
+
+- [ ] **Step 5.1: 写测试 — start 后注册表有一条**
+
+追加到 `test_daemon.py`：
+
+```python
+def test_start_registers_in_global_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from godot_cli_control import registry
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "godot"
+    fake_bin.write_text("#!/bin/sh\nsleep 60\n"); fake_bin.chmod(0o755)
+    monkeypatch.setattr("godot_cli_control.daemon._ensure_imported", lambda *a, **k: None)
+    monkeypatch.setattr("godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True)
+
+    daemon = Daemon(tmp_path)
+    daemon.start(godot_bin=str(fake_bin), port=0)
+    try:
+        records = registry.list_all()
+        assert len(records) == 1
+        assert records[0].pid > 0
+    finally:
+        daemon.stop()
+        assert registry.list_all() == []
+```
+
+- [ ] **Step 5.2: 跑确认失败**
+
+```bash
+uv run pytest python/tests/test_daemon.py::test_start_registers_in_global_registry -v
+```
+Expected: `assert 0 == 1` 或类似
+
+- [ ] **Step 5.3: 接入 register / unregister**
+
+`daemon.py` 顶部 import：
+
+```python
+from . import registry as _registry
+```
+
+`Daemon.start` 末尾、`return proc.pid` 之前追加：
+
+```python
+        _registry.register(
+            self.project_root,
+            pid=proc.pid,
+            port=actual_port,
+            godot_bin=bin_path,
+            log_path=str(self.log_file),
+        )
+```
+
+`Daemon.stop`：把 `_cleanup_state_files()` 后追加 `_registry.unregister(self.project_root)`（在两个 cleanup 路径都加；包括死 PID 自愈路径）。
+
+- [ ] **Step 5.4: 跑全套**
+
+```bash
+uv run pytest python/tests/ -v
+```
+Expected: 全 pass
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add python/godot_cli_control/daemon.py python/tests/test_daemon.py
+git commit -m "feat(daemon): start/stop 同步全局注册表"
+```
+
+---
+
+## Task 6: `daemon ls` 子命令
+
+**Files:**
+- Modify: `python/godot_cli_control/cli.py` (新 cmd_daemon_ls + 子解析器)
+- Test: `python/tests/test_cli.py`
+
+- [ ] **Step 6.1: 写测试 — 调 ls 在空注册表上输出 JSON 信封 stopped/empty**
+
+追加到 `test_cli.py`：
+
+```python
+def test_daemon_ls_empty(monkeypatch, tmp_path, capsys):
+    from godot_cli_control import registry
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+    from godot_cli_control.cli import main
+    rc = main(["daemon", "ls", "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert '"daemons": []' in out
+
+def test_daemon_ls_lists_active(monkeypatch, tmp_path, capsys):
+    from godot_cli_control import registry
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+    proj = tmp_path / "p"; proj.mkdir()
+    registry.register(proj, pid=os.getpid(), port=12345,
+                      godot_bin="x", log_path="y")
+    from godot_cli_control.cli import main
+    rc = main(["daemon", "ls", "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "12345" in out
+    assert str(proj.resolve()) in out
+```
+
+- [ ] **Step 6.2: 跑确认失败**
+
+```bash
+uv run pytest python/tests/test_cli.py -v -k daemon_ls
+```
+Expected: argparse "invalid choice: 'ls'"
+
+- [ ] **Step 6.3: 实现 `cmd_daemon_ls` + parser**
+
+在 `cli.py` 加函数（参考 `cmd_daemon_status` 风格）：
+
+```python
+def cmd_daemon_ls(ns: argparse.Namespace) -> int:
+    from . import registry
+    records = registry.list_all()
+    payload = {
+        "daemons": [
+            {
+                "project_root": r.project_root,
+                "pid": r.pid,
+                "port": r.port,
+                "started_at": r.started_at,
+                "godot_bin": r.godot_bin,
+                "log_path": r.log_path,
+            }
+            for r in records
+        ]
+    }
+    if ns.output_format == OUTPUT_JSON:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        if not records:
+            print("(no running daemons)")
+        else:
+            for r in records:
+                print(f"{r.pid}\t{r.port}\t{r.project_root}\t{r.started_at}")
+    return 0
+```
+
+在 `build_parser` 中 daemon_subs 处追加：
+
+```python
+    ls_p = daemon_subs.add_parser(
+        "ls",
+        help="列出所有正在运行的 daemon（跨项目）",
+        description=(
+            "扫描全局注册表 ~/.local/state/godot-cli-control/daemons/，"
+            "列出所有探活通过的 daemon。死记录会被自动清理。"
+        ),
+    )
+    _add_output_format_flags(ls_p)
+```
+
+并在 dispatch 表中加 `("daemon", "ls"): cmd_daemon_ls`（或与现有 dispatch 风格一致）。
+
+- [ ] **Step 6.4: 跑测试**
+
+```bash
+uv run pytest python/tests/test_cli.py -v -k daemon_ls
+```
+Expected: 2 passed
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add python/godot_cli_control/cli.py python/tests/test_cli.py
+git commit -m "feat(cli): daemon ls 跨项目列出运行中的 daemon"
+```
+
+---
+
+## Task 7: `daemon stop --all` / `--project <path>`
+
+**Files:**
+- Modify: `python/godot_cli_control/cli.py` (cmd_daemon_stop + parser)
+- Test: `python/tests/test_cli.py`
+
+- [ ] **Step 7.1: 写测试**
+
+追加到 `test_cli.py`：
+
+```python
+def test_daemon_stop_all_invokes_terminate(monkeypatch, tmp_path):
+    from godot_cli_control import registry
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+    proj1 = tmp_path / "a"; proj1.mkdir()
+    proj2 = tmp_path / "b"; proj2.mkdir()
+    registry.register(proj1, pid=111, port=1, godot_bin="x", log_path="y")
+    registry.register(proj2, pid=222, port=2, godot_bin="x", log_path="y")
+
+    stopped: list[Path] = []
+    def fake_stop(self):
+        stopped.append(self.project_root)
+        return 0
+    monkeypatch.setattr("godot_cli_control.daemon.Daemon.stop", fake_stop)
+    monkeypatch.setattr("godot_cli_control.daemon.Daemon.is_running", lambda self: True)
+
+    from godot_cli_control.cli import main
+    rc = main(["daemon", "stop", "--all"])
+    assert rc == 0
+    assert {p.resolve() for p in stopped} == {proj1.resolve(), proj2.resolve()}
+
+def test_daemon_stop_project_path(monkeypatch, tmp_path):
+    from godot_cli_control import registry
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+    target = tmp_path / "p"; target.mkdir()
+    seen: list[Path] = []
+    monkeypatch.setattr("godot_cli_control.daemon.Daemon.stop",
+                        lambda self: seen.append(self.project_root) or 0)
+    monkeypatch.setattr("godot_cli_control.daemon.Daemon.is_running", lambda self: True)
+    from godot_cli_control.cli import main
+    rc = main(["daemon", "stop", "--project", str(target)])
+    assert rc == 0
+    assert seen == [target.resolve()]
+```
+
+- [ ] **Step 7.2: 跑确认失败**
+
+```bash
+uv run pytest python/tests/test_cli.py -v -k "daemon_stop_all or daemon_stop_project"
+```
+Expected: argparse 错（unrecognized --all）
+
+- [ ] **Step 7.3: 改 `cmd_daemon_stop` + parser**
+
+`stop_p` 加两个互斥 flag：
+
+```python
+    stop_p = daemon_subs.add_parser("stop", help="停止 daemon", ...)
+    grp = stop_p.add_mutually_exclusive_group()
+    grp.add_argument("--all", action="store_true",
+                     help="停止注册表中所有运行中的 daemon")
+    grp.add_argument("--project", type=Path, default=None,
+                     help="停止指定项目根的 daemon（绝对/相对路径均可）")
+```
+
+改 `cmd_daemon_stop`：
+
+```python
+def cmd_daemon_stop(ns: argparse.Namespace) -> int:
+    from .daemon import Daemon, DaemonError
+    from . import registry
+
+    if ns.all:
+        worst = 0
+        for r in registry.list_all():
+            try:
+                rc = Daemon(Path(r.project_root)).stop()
+                worst = max(worst, rc)
+            except DaemonError as e:
+                print(f"[{r.project_root}] {e}", file=sys.stderr)
+                worst = max(worst, 1)
+        return worst
+
+    target = ns.project.resolve() if ns.project else Path.cwd()
+    daemon = Daemon(target)
+    try:
+        return daemon.stop()
+    except DaemonError as e:
+        # 沿用既有错误信封
+        ...
+```
+
+- [ ] **Step 7.4: 跑测试**
+
+```bash
+uv run pytest python/tests/test_cli.py -v -k "daemon_stop"
+```
+Expected: 全 pass（包含旧的 `daemon stop` 测试）
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add python/godot_cli_control/cli.py python/tests/test_cli.py
+git commit -m "feat(cli): daemon stop --all / --project <path>"
+```
+
+---
+
+## Task 8: GDScript 端 idle timeout
+
+**Files:**
+- Modify: `addons/godot_cli_control/bridge/game_bridge.gd`
+
+- [ ] **Step 8.1: 加 `--game-bridge-idle-timeout=` 解析**
+
+参考 `_parse_port_from_args`，在 `game_bridge.gd:262` 之后追加：
+
+```gdscript
+func _parse_idle_timeout_from_args() -> int:
+	for arg: String in OS.get_cmdline_args():
+		if arg.begins_with("--game-bridge-idle-timeout="):
+			var parts: PackedStringArray = arg.split("=", false, 1)
+			if parts.size() != 2 or not parts[1].is_valid_int():
+				push_warning("GameBridge: Invalid idle-timeout %s, disabling" % arg)
+				return 0
+			var secs: int = parts[1].to_int()
+			return secs if secs > 0 else 0
+	return 0
+```
+
+- [ ] **Step 8.2: 加 `_last_activity_ms` 与看门狗 Timer**
+
+在变量区追加：
+
+```gdscript
+var _idle_timeout_secs: int = 0
+var _last_activity_ms: int = 0
+```
+
+在 `_ready()` 末尾（listen 成功后）追加：
+
+```gdscript
+	_idle_timeout_secs = _parse_idle_timeout_from_args()
+	_last_activity_ms = Time.get_ticks_msec()
+	if _idle_timeout_secs > 0:
+		var t: Timer = Timer.new()
+		t.wait_time = 1.0
+		t.autostart = true
+		t.process_mode = Node.PROCESS_MODE_ALWAYS
+		t.timeout.connect(_check_idle)
+		add_child(t)
+		print("GameBridge: idle-timeout %ds enabled" % _idle_timeout_secs)
+```
+
+加新方法：
+
+```gdscript
+func _check_idle() -> void:
+	var idle_ms: int = Time.get_ticks_msec() - _last_activity_ms
+	if idle_ms / 1000 >= _idle_timeout_secs:
+		print("GameBridge: idle for %ds, shutting down" % (idle_ms / 1000))
+		get_tree().quit()
+```
+
+在 `_handle_message` 函数体首行加：
+
+```gdscript
+	_last_activity_ms = Time.get_ticks_msec()
+```
+
+- [ ] **Step 8.3: 手动验证（无 Godot 单测，做端到端冒烟）**
+
+```bash
+# 在测试 Godot 项目里
+godot-cli-control daemon start --idle-timeout 5s
+sleep 8
+godot-cli-control daemon ls --json   # 应该看到死记录被清，输出 daemons: []
+```
+
+记录冒烟结果，复制 godot.log 末尾到 commit message。
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add addons/godot_cli_control/bridge/game_bridge.gd
+git commit -m "feat(bridge): --game-bridge-idle-timeout 空闲自动 shutdown
+
+GDScript 端实现：1s Timer 检查 (now - last_activity) > timeout 则
+get_tree().quit()。每次 _handle_message 入口刷新 last_activity。
+默认 0 = 关闭，行为与今天一致。"
+```
+
+---
+
+## Task 9: Python 端 `--idle-timeout` flag
+
+**Files:**
+- Modify: `python/godot_cli_control/cli.py` (`_add_daemon_flags`)
+- Modify: `python/godot_cli_control/daemon.py` (`Daemon.start` + Popen args)
+- Test: `python/tests/test_daemon.py`
+
+- [ ] **Step 9.1: 写测试 — `start(idle_timeout=10)` 应让 Popen 收到 `--game-bridge-idle-timeout=10`**
+
+追加到 `test_daemon.py`：
+
+```python
+def test_start_passes_idle_timeout_to_popen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+    class FakeProc:
+        pid = 99999
+        def poll(self): return None
+        def wait(self, timeout=None): return 0
+    def fake_popen(args, **kwargs):
+        captured["args"] = args
+        return FakeProc()
+
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "godot"; fake_bin.write_text("x"); fake_bin.chmod(0o755)
+    monkeypatch.setattr("godot_cli_control.daemon._ensure_imported", lambda *a, **k: None)
+    monkeypatch.setattr("godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True)
+    monkeypatch.setattr("godot_cli_control.daemon.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("godot_cli_control.daemon._process_alive", lambda pid: False)
+
+    daemon = Daemon(tmp_path)
+    daemon.start(godot_bin=str(fake_bin), port=0, idle_timeout=10)
+    assert any(a == "--game-bridge-idle-timeout=10" for a in captured["args"])
+
+def test_start_omits_idle_timeout_when_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # 同上但 idle_timeout=0 时 args 里不该出现该 flag
+    ...
+```
+
+- [ ] **Step 9.2: 跑确认失败**
+
+```bash
+uv run pytest python/tests/test_daemon.py -v -k idle_timeout
+```
+Expected: TypeError unexpected keyword
+
+- [ ] **Step 9.3: `Daemon.start` 接受 `idle_timeout`**
+
+`daemon.py` 签名加：
+
+```python
+        idle_timeout: int = 0,
+```
+
+构造 args 后追加：
+
+```python
+        if idle_timeout > 0:
+            args.append(f"--game-bridge-idle-timeout={idle_timeout}")
+```
+
+- [ ] **Step 9.4: CLI flag**
+
+`_add_daemon_flags` 末尾追加：
+
+```python
+    p.add_argument(
+        "--idle-timeout",
+        type=str,
+        default="0",
+        help="空闲超时（如 30m / 2h / 90s / 0=关闭）。开启后 Godot 端 Timer 自动 quit。",
+    )
+```
+
+`cmd_daemon_start` / `cmd_run` 中：
+
+```python
+    from ._duration import parse_duration
+    try:
+        idle = parse_duration(ns.idle_timeout)
+    except ValueError as e:
+        print(f"错误：{e}", file=sys.stderr); return EXIT_USAGE
+    daemon.start(..., idle_timeout=idle)
+```
+
+- [ ] **Step 9.5: 跑全套**
+
+```bash
+uv run pytest python/tests/ -v
+```
+Expected: 全 pass
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+git add python/godot_cli_control/daemon.py python/godot_cli_control/cli.py python/tests/test_daemon.py
+git commit -m "feat(cli): daemon start --idle-timeout 30m 透传 GDScript 端"
+```
+
+---
+
+## Task 10: 文档同步
+
+**Files:**
+- Modify: `python/README.md`
+- Modify: `addons/godot_cli_control/SKILL.md`
+- Modify: 各 init 落盘的 SKILL 模板（在 `python/godot_cli_control/templates/` 或 `init_cmd.py` 引用处）
+
+- [ ] **Step 10.1: 找 SKILL 模板源头**
+
+```bash
+ls /Users/kesar/Projects/godot-cli-control/python/godot_cli_control/templates/ 2>&1
+grep -rn "9877\|DEFAULT_PORT" /Users/kesar/Projects/godot-cli-control/python/godot_cli_control/templates/ \
+  /Users/kesar/Projects/godot-cli-control/addons/godot_cli_control/SKILL.md \
+  /Users/kesar/Projects/godot-cli-control/python/README.md \
+  /Users/kesar/Projects/godot-cli-control/README.md 2>/dev/null
+```
+
+- [ ] **Step 10.2: 改文档要点**
+- 默认端口 9877 → "由 OS 自动分配，写入 .cli_control/port"
+- 提示外部脚本连接 daemon 时**优先读 .cli_control/port**，而非 hardcode 9877
+- README 加 changelog 条目，破坏性变更单独标注
+- README 加 `daemon ls` / `daemon stop --all` / `--idle-timeout` 简短示例
+
+- [ ] **Step 10.3: Commit**
+
+```bash
+git add python/README.md addons/godot_cli_control/SKILL.md python/godot_cli_control/templates/
+git commit -m "docs: 同步默认端口变更与新子命令 ls / stop --all / --idle-timeout"
+```
+
+---
+
+## Task 11: 端到端验证
+
+无单测覆盖、需要真 Godot 的最后一关。
+
+- [ ] **Step 11.1: 端口自动分配冒烟**
+  - 在两个 Godot 测试项目分别 `godot-cli-control daemon start` 不带 --port
+  - `cat .cli_control/port` 两个端口不同且都不是 9877
+  - 各跑一次 `godot-cli-control screenshot /tmp/a.png`，确认 RPC 通
+
+- [ ] **Step 11.2: 全局注册表冒烟**
+  - 任意 cwd 下 `godot-cli-control daemon ls --json` 看到两条
+  - `kill -9 <pid>` 一个，再 `daemon ls`，死记录 + 对应 .cli_control/godot.pid 都被清
+  - `godot-cli-control daemon stop --all` 全停
+
+- [ ] **Step 11.3: idle timeout 冒烟**
+  - `godot-cli-control daemon start --idle-timeout 5s`
+  - `sleep 8 && pgrep -f 'godot.*--cli-control'` 应找不到该 PID
+  - `daemon ls` 自动清理后输出空
+
+- [ ] **Step 11.4: 收尾 issue**
+  - 遵循全局 CLAUDE.md「实施收尾必开 issue」：盘点 review 标记、未覆盖手测场景、spec/实现差异
+  - 候选项：Windows 注册表路径合规性 / 项目级 idle 默认值 config / `daemon ls` 多用户区分
+
+---
+
+## Notes for Implementer
+
+- **TDD 严格度**：Task 1–7、9 全部 TDD（先写测试、先看失败、再实现）。Task 8（GDScript）、Task 10（文档）、Task 11（端到端）无单测，靠手动冒烟。
+- **commit 频率**：每个 Task 一次 commit；Task 内部可以多次 commit 但每个 commit 必须独立编译通过。
+- **不要扩大范围**：本 plan **只**做 spec 里这三件事。途中发现的其他问题（命名不一致、文件过大、潜在 bug）记到 Task 11 的收尾 issue 列表里，**不要顺手改**。
+- **执行顺序**：Task 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10 → 11。Task 3（duration parser）在 Task 9 才用到，但提前实现以解耦。

--- a/docs/superpowers/specs/2026-05-01-daemon-port-and-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-05-01-daemon-port-and-lifecycle-design.md
@@ -1,0 +1,235 @@
+# 端口与守护进程生命周期改进设计
+
+- 日期：2026-05-01
+- 作者：kesar（与 Claude 协作头脑风暴）
+- 状态：草稿，待评审
+
+## 目标
+
+消除 `godot-cli-control daemon` 在多项目并发与异常退出场景下的两个核心痛点：
+
+1. **端口冲突 / 选号麻烦**：默认端口 `9877` 硬编码，多项目并发或被外部进程占用时需要手动 `--port` 错开。
+2. **孤儿守护进程**：Python CLI 崩溃 / 终端关闭 / 用户忘记 `daemon stop` 时，Godot 子进程会以孤儿形态长期驻留，且跨项目时缺乏统一观察手段。
+
+## 非目标
+
+- 不替换 TCP 为 Unix Domain Socket（架构改动过大，addon、Windows 兼容均需重做）
+- 不实现父进程死亡级联（`PR_SET_PDEATHSIG` 在 macOS 缺失，`kqueue` 方案复杂；以注册表 + idle timeout 兜底已足够）
+- 不引入新的第三方依赖（注册表用标准库 `pathlib` + `json` + `hashlib`）
+- 不破坏现有 `.cli_control/` 项目级状态文件契约（仍是 source of truth）
+- 不改 RPC 协议本身
+
+## 背景
+
+当前实现状况（来自代码探查）：
+
+- 默认端口 `9877` 硬编码于 `python/godot_cli_control/client.py:15`
+- `daemon start --port <N>` 由 `python/godot_cli_control/cli.py:952-957` 解析
+- 启动前 `_check_port_available(port)` 在 `python/godot_cli_control/daemon.py:399-416` 做 bind 预检（最近的 commit 368d9aa）
+- 端口落盘到 `<project>/.cli_control/port`，RPC 命令按 `--port → port file → DEFAULT_PORT` 顺序读取（`cli.py:1304-1308`）
+- Godot 端通过 `--game-bridge-port=<N>` CLI flag 接收端口（`addons/godot_cli_control/bridge/game_bridge.gd:244-261`）
+- daemon 状态文件全部在 `<project>/.cli_control/` 下（`godot.pid` / `port` / `godot.log` / `last_exit_code` / `movie_path` / `godot_bin`）
+- 没有任何全局视角：跨项目 daemon 无法一次性查看或停止
+- 没有任何空闲检测：Godot 子进程会一直跑到被外部终止
+
+## 用户决策汇总
+
+头脑风暴中已落锤的三点：
+
+1. **方案 A 改默认端口为 0（自动分配）**：`9877` 仅在用户显式 `--port 9877` 时使用，不再作为默认值兜底
+2. **方案 B 加全局注册表 + 跨项目 daemon 子命令**：`daemon ls` 扫描时**自动清理死记录**，不引入额外 `prune` 子命令
+3. **方案 C 加 idle-timeout 自动 shutdown**：**默认关闭**，opt-in via `--idle-timeout 30m` 等显式 flag
+
+## 设计
+
+### A. 端口自动分配
+
+**接口契约**
+
+- `daemon start` 的 `--port` argparse 默认值由 `9877` 改为 `0`
+- `port=0` 时由 OS 分配空闲端口；`port>0` 时走原有 `_check_port_available` 预检
+- 实际使用的端口写入 `<project>/.cli_control/port`，并以 `--game-bridge-port=<actual>` 传给 Godot 子进程
+- `client.py` 的 `DEFAULT_PORT = 9877` 保留，仅作 RPC 命令在"既无 `--port` 又无 port file"时的最后兜底（极少触发）
+
+**实现要点**
+
+新函数 `_allocate_port(requested: int) -> int` 替代当前 `_check_port_available`：
+
+```python
+def _allocate_port(requested: int) -> int:
+    """Return a usable port. requested=0 means OS-allocate."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("127.0.0.1", requested))
+        except OSError as e:
+            raise DaemonError(
+                f"port {requested} already in use ({e}). "
+                "请 stop 旧 daemon 或换 --port"
+            )
+        return s.getsockname()[1]
+```
+
+- 关闭 socket 后到 Godot listen 之间存在极小 race window，但内核短期内不会立即重用同一端口；如果真的撞上，原 Godot 启动失败检测路径仍能兜住
+- `daemon.start` 在拿到 `actual_port` 后写 `port_file`，再传给 Popen
+- 替换 `daemon.py:138` 的硬编码 `--game-bridge-port={port}` 为 `--game-bridge-port={actual_port}`
+
+**用户感知**
+
+- 默认行为变化：`daemon start` 不再固定占 9877。用户日常通过 CLI 调命令完全无感（CLI 自动读 port file）
+- 外部脚本如果硬编码 `connect("127.0.0.1", 9877)`，现在必须改为读 `.cli_control/port`，或显式 `daemon start --port 9877`
+- README / SKILL 模板需要更新示例
+
+### B. 全局守护进程注册表
+
+**注册表位置**
+
+`~/.local/state/godot-cli-control/daemons/`（XDG state 风格，跨平台用 `Path.home() / ".local/state/..."` 即可，无需 platformdirs）
+
+**记录格式**
+
+每个守护进程一份 `<project_hash>.json`，其中 `project_hash = hashlib.sha1(str(project_root.resolve()).encode()).hexdigest()[:12]`：
+
+```json
+{
+  "project_root": "/Users/kesar/Projects/foo-game",
+  "pid": 12345,
+  "port": 54321,
+  "started_at": "2026-05-01T10:30:00+08:00",
+  "godot_bin": "/Applications/Godot.app/Contents/MacOS/Godot",
+  "log_path": "/Users/kesar/Projects/foo-game/.cli_control/godot.log"
+}
+```
+
+**生命周期**
+
+- `daemon.start()` 在 Popen 成功并通过端口探测后写入注册表
+- `daemon.stop()` 成功后删除对应记录
+- `daemon ls` 扫描所有 json，对每条记录用 `os.kill(pid, 0)` 探活：
+  - 活：列入输出
+  - 死：**直接删除**注册表文件 + 对应项目的 `.cli_control/godot.pid` 与 `.cli_control/port`（与现有 `_cleanup_state` 行为一致）
+- 不需要文件锁，注册表路径以 project_hash 区分，写入是幂等的
+
+**新 CLI 子命令**
+
+- `godot-cli-control daemon ls`
+  - 默认输出 table：项目路径 / PID / 端口 / 启动时长
+  - `--json` 输出机器可读
+  - 自动清理死记录（清完才输出）
+- `godot-cli-control daemon stop --all`
+  - 对注册表里所有活记录依次 `_terminate(pid)`，逐条报告结果
+  - exit code 取所有结果中最差的一个（任一失败 → 非 0）
+- `godot-cli-control daemon stop --project <path>`
+  - 等价于 `cd <path> && daemon stop`，但不要求 cwd 切换；对该项目的注册表项 + .cli_control 状态做完整清理
+
+**新模块**
+
+`python/godot_cli_control/registry.py`，纯函数 + 标准库实现，约 80 行：
+
+- `registry_dir() -> Path`
+- `project_hash(project_root: Path) -> str`
+- `register(project_root, pid, port, godot_bin, log_path) -> None`
+- `unregister(project_root) -> None`
+- `list_all() -> list[DaemonRecord]`（探活 + 自动清理死记录）
+- `stop_record(record) -> tuple[ok, msg]`
+
+### C. 空闲自动 shutdown（opt-in）
+
+**接口契约**
+
+- `daemon start` 新增 `--idle-timeout <duration>` flag
+- duration 解析支持 `30m` / `1h` / `90s` / `0`（0 = 永不超时，等价于不传 flag）
+- 默认不传 → Godot 端不启用看门狗，行为与今天完全一致
+
+**实现位置**
+
+看门狗在 **Godot 端** 实现，不在 Python 侧。原因：daemon 启动后 Python CLI 即退出，常驻进程是 Godot 本身。
+
+**Godot 端改动（`addons/godot_cli_control/bridge/game_bridge.gd`）**
+
+- `_parse_args()` 增加 `--game-bridge-idle-timeout=<secs>` 解析（解析失败或缺省 → 0 = 关闭）
+- bridge 内维护 `_last_activity_ms: int`，初始为启动时刻
+- 每次 `_handle_command` 入口处更新 `_last_activity_ms = Time.get_ticks_msec()`
+- `_ready` 时若 `_idle_timeout_secs > 0`，启动一个 1 秒 Timer：
+  - `_check_idle()`: 如果 `(now - _last_activity_ms) / 1000 > _idle_timeout_secs`，调用 `get_tree().quit()`
+- Godot 退出后，Python 端无主动通知；下次 `daemon ls` 探活会清理孤儿注册表项 + 项目状态文件
+
+**Python 端改动（`python/godot_cli_control/daemon.py`）**
+
+- `daemon.start` 接受 `idle_timeout: int | None = None`
+- CLI 解析 `--idle-timeout` flag → 调用 `_parse_duration("30m") -> 1800` 转秒
+- 传给 Popen：`--game-bridge-idle-timeout={secs}`（仅当 > 0 时附加）
+- 注册表记录中可选记 `idle_timeout` 字段（便于 `daemon ls` 输出列）
+
+## 实施步骤（建议顺序）
+
+1. **方案 A**：改默认端口
+   - `cli.py` 中 `--port` argparse default → 0
+   - `daemon.py` 引入 `_allocate_port`，替换 `_check_port_available` 调用点
+   - 改 Popen 传参用 `actual_port`
+   - 单测：`port=0` 时 returned port 落盘正确；`port=9877` 占用时仍立即失败
+2. **方案 B**：全局注册表
+   - 新建 `registry.py` + 单测
+   - `daemon.start` 末尾 `register(...)`、`daemon.stop` 末尾 `unregister(...)`
+   - CLI 加 `daemon ls`、`daemon stop --all`、`daemon stop --project`
+   - 集成测：双项目 start → ls 显示两条 → kill -9 一个 → ls 自动清理
+3. **方案 C**：idle timeout
+   - GDScript 端先加：解析 flag、记录 last_activity、Timer 检查、quit
+   - Python 端 `--idle-timeout` flag + duration parser + 传 Popen 参
+   - 集成测：`--idle-timeout 5s` 启动后空闲 8s，进程自然退出，`daemon ls` 自动清理
+4. **文档同步**
+   - 更新 `README.md` 中 `daemon start` 示例与 port file 说明
+   - 更新 `addons/godot_cli_control/SKILL.md` 与 init 落盘的 SKILL 模板，强调"默认 port=auto，请通过 .cli_control/port 读取"
+   - 在 `docs/` 加一段 daemon ls 的使用说明
+
+## 关键文件
+
+| 文件 | 改动概要 |
+|---|---|
+| `python/godot_cli_control/cli.py` | `--port` 默认 0；新增 `daemon ls` / `daemon stop --all` / `daemon stop --project` / `--idle-timeout` |
+| `python/godot_cli_control/daemon.py` | `_allocate_port` 替换 `_check_port_available`；`start`/`stop` 调用 registry；接受 `idle_timeout` |
+| `python/godot_cli_control/registry.py` | 新文件，全局注册表读写 + 探活清理 |
+| `python/godot_cli_control/client.py` | `DEFAULT_PORT` 注释明确：仅作 RPC 兜底 |
+| `addons/godot_cli_control/bridge/game_bridge.gd` | 解析 `--game-bridge-idle-timeout`，加 Timer + `_last_activity_ms` |
+| `README.md` | 更新示例 |
+| `addons/godot_cli_control/SKILL.md` 与 init 落盘模板 | 同步文档 |
+
+## 兼容性与迁移
+
+- **破坏性变更**：默认端口不再是 9877。受影响人群：在外部脚本（非通过本 CLI）中硬编码连 9877 的用户。
+  - 迁移方案 1：脚本改读 `<project>/.cli_control/port`
+  - 迁移方案 2：`daemon start --port 9877` 显式指定，恢复旧行为
+  - README 在变更日志区域显著标注
+- 注册表目录是新增的，不影响旧版本
+- idle timeout 默认关，对现有用户零感知
+
+## 验证
+
+实施完成后端到端验证：
+
+1. **端口自动分配**
+   - `daemon start`（不带 --port），观察 `.cli_control/port` 写入的不是 9877 而是一个高位端口
+   - `cat .cli_control/port` → `screenshot test.png` 能正常工作（CLI 自动读 port file）
+   - 第二个项目并发 `daemon start` 不冲突
+   - `daemon start --port 9877` + 立即再次 `daemon start --port 9877` → 后者立即报"already in use"
+2. **全局注册表**
+   - 在两个不同项目分别 `daemon start`
+   - 任意 cwd 下 `godot-cli-control daemon ls` → 显示两行，含项目路径 + PID + 端口 + 已运行时长
+   - 手动 `kill -9 <pid>` 一个，再 `daemon ls` → 死记录被自动清理，对应项目的 `.cli_control/godot.pid` 也被清
+   - `daemon stop --all` → 全部停止，`daemon ls` 输出空
+   - `daemon stop --project /path/to/foo` → 只停 foo 项目
+3. **idle timeout**
+   - `daemon start --idle-timeout 5s` 启动
+   - 等待 8 秒不发任何命令 → `pgrep godot` 应找不到该进程
+   - `daemon ls` 自动清理，输出无该项
+   - 对照组：`daemon start`（无 idle 参数）等待 8 秒进程仍在
+4. **回归**
+   - 现有所有测试通过
+   - `daemon stop` / `daemon status` 在新注册表下仍正确
+
+## 后续 issue（实施收尾时开）
+
+按用户全局规则（CLAUDE.md 中"实施收尾必开 issue"），实施 PR 合并前盘点：
+
+- 是否要给 `daemon ls` 加 `--all-projects` vs `--mine` 区分（如果将来扩到多用户场景）
+- Windows 上的注册表路径合规性（当前 `~/.local/state/...` 在 Windows 不是惯例，但项目目前似乎不主打 Windows）
+- 是否给 idle timeout 加一个项目级 config 默认值（避免每次手敲 flag）

--- a/python/README.md
+++ b/python/README.md
@@ -36,7 +36,8 @@ import asyncio
 from godot_cli_control import GameClient
 
 async def main():
-    async with GameClient(port=9877) as client:
+    # Omitting port lets GameClient auto-discover from .cli_control/port (written by daemon start)
+    async with GameClient() as client:
         tree = await client.get_scene_tree(depth=3)
         await client.click("/root/MyScene/Button")
         await client.action_press("jump")
@@ -84,7 +85,7 @@ def test_jump(godot_daemon, bridge):
 CLI options:
 
 ```
---godot-cli-port=N           # GameBridge port (default 9877)
+--godot-cli-port=N           # GameBridge port (default: read from .cli_control/port)
 --godot-cli-no-headless      # open a real Godot window
 --godot-cli-project-root=DIR # default: pytest rootdir
 ```
@@ -96,9 +97,10 @@ The CLI is the canonical surface — every `GameClient` method has a one-line eq
 ```bash
 # Lifecycle
 godot-cli-control init [--path DIR] [--force]
-godot-cli-control daemon start [--headless --record --movie-path X --fps N --port N]
-godot-cli-control daemon stop
+godot-cli-control daemon start [--headless --record --movie-path X --fps N --port N --idle-timeout 30m]
+godot-cli-control daemon stop [--all | --project PATH]
 godot-cli-control daemon status
+godot-cli-control daemon ls                  # list running daemons across all projects
 godot-cli-control run <script.py> [--headless ...]
 
 # Read

--- a/python/godot_cli_control/_duration.py
+++ b/python/godot_cli_control/_duration.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import re
 
-_PATTERN = re.compile(r"^\s*(\d+)\s*([smh]?)\s*$")
+# 不允许数字与单位之间留空格 —— 与帮助文本「30m / 2h / 90s」保持一致，避免
+# 既文档教 30m 又静默接受 "30 m" 这种半通不通的输入。两端 \s* 仍保留，方便
+# 用户从 shell 复制带尾换行的字串。
+_PATTERN = re.compile(r"^\s*(\d+)([smh]?)\s*$")
 _UNITS = {"": 1, "s": 1, "m": 60, "h": 3600}
 
 

--- a/python/godot_cli_control/_duration.py
+++ b/python/godot_cli_control/_duration.py
@@ -1,0 +1,15 @@
+"""Parse human-friendly duration strings (e.g. "30m", "2h", "90s") to seconds."""
+from __future__ import annotations
+
+import re
+
+_PATTERN = re.compile(r"^\s*(\d+)\s*([smh]?)\s*$")
+_UNITS = {"": 1, "s": 1, "m": 60, "h": 3600}
+
+
+def parse_duration(text: str) -> int:
+    """Return total seconds. Bare integer = seconds. 0 means disabled."""
+    m = _PATTERN.match(text)
+    if not m:
+        raise ValueError(f"invalid duration {text!r} (use 30s / 30m / 2h / 0)")
+    return int(m.group(1)) * _UNITS[m.group(2)]

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -712,16 +712,25 @@ def cmd_daemon_status(ns: argparse.Namespace) -> int:
                 f"running pid={pid} port={port if port is not None else '?'}"
             )
         return EXIT_OK
-    # Stopped：若上一轮启动留下了 godot.log，把路径透出来。issue #38 要求
-    # 在 daemon 已退出时让用户能直接看到日志位置而不是手摸 .cli_control/。
+    # Stopped：若上一轮启动留下了 godot.log / last_exit_code，把诊断信息透出来。
+    # issue #38 要求 daemon 已退出时直接告诉用户「last exit: <code>, see ...log」，
+    # 不让用户再手摸 .cli_control/ 翻文件。
     stopped_payload: dict[str, Any] = {"state": "stopped"}
     if daemon.log_file.exists():
         stopped_payload["last_log"] = str(daemon.log_file)
+    last_rc = daemon.read_last_exit_code()
+    if last_rc is not None:
+        stopped_payload["last_exit_code"] = last_rc
     if fmt == OUTPUT_JSON:
         _emit_success_payload(stopped_payload)
     else:
+        hints: list[str] = []
+        if "last_exit_code" in stopped_payload:
+            hints.append(f"last exit: {stopped_payload['last_exit_code']}")
         if "last_log" in stopped_payload:
-            print(f"stopped (last log: {stopped_payload['last_log']})")
+            hints.append(f"see {stopped_payload['last_log']}")
+        if hints:
+            print(f"stopped ({', '.join(hints)})")
         else:
             print("stopped")
     return EXIT_RPC_ERROR

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -641,6 +641,13 @@ RPC_BY_NAME: dict[str, RpcSpec] = {s.name: s for s in RPC_SPECS}
 
 def cmd_daemon_start(ns: argparse.Namespace) -> int:
     from .daemon import Daemon, DaemonError
+    from ._duration import parse_duration
+
+    try:
+        idle_seconds = parse_duration(getattr(ns, "idle_timeout", "0"))
+    except ValueError as e:
+        _emit_top_error(ns, code=CLIENT_CODE_USAGE, message=str(e))
+        return EXIT_USAGE
 
     daemon = Daemon(Path.cwd())
     try:
@@ -650,6 +657,7 @@ def cmd_daemon_start(ns: argparse.Namespace) -> int:
             headless=ns.headless,
             fps=ns.fps,
             port=ns.port,
+            idle_timeout=idle_seconds,
         )
     except DaemonError as e:
         _emit_top_error(ns, code=CLIENT_CODE_USAGE, message=str(e))
@@ -810,11 +818,18 @@ def cmd_daemon_ls(ns: argparse.Namespace) -> int:
 def cmd_run(ns: argparse.Namespace) -> int:
     """加载用户脚本（要求定义 ``run(bridge)``），自动启停 daemon。"""
     from .daemon import Daemon, DaemonError
+    from ._duration import parse_duration
 
     script_path = Path(ns.script)
     if not script_path.exists():
         print(f"错误：找不到脚本: {script_path}", file=sys.stderr)
         return 1
+
+    try:
+        idle_seconds = parse_duration(getattr(ns, "idle_timeout", "0"))
+    except ValueError as e:
+        print(f"错误：{e}", file=sys.stderr)
+        return EXIT_USAGE
 
     daemon = Daemon(Path.cwd())
     auto_started = False
@@ -826,6 +841,7 @@ def cmd_run(ns: argparse.Namespace) -> int:
                 headless=ns.headless,
                 fps=ns.fps,
                 port=ns.port,
+                idle_timeout=idle_seconds,
             )
         except DaemonError as e:
             print(f"错误：{e}", file=sys.stderr)
@@ -1025,6 +1041,12 @@ def _add_daemon_flags(p: argparse.ArgumentParser) -> None:
         type=int,
         default=0,
         help="GameBridge 监听端口（默认 0 = OS 自动分配；写入 .cli_control/port）",
+    )
+    p.add_argument(
+        "--idle-timeout",
+        type=str,
+        default="0",
+        help="空闲超时（如 30m / 2h / 90s / 0=关闭，默认关）。开启后 Godot 端 Timer 自动 quit。",
     )
 
 

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -42,6 +42,10 @@ OUTPUT_TEXT = "text"
 EXIT_OK = 0
 EXIT_RPC_ERROR = 1
 EXIT_INFRA_ERROR = 2  # 连接 / 超时 / 用户输入解析失败
+# `daemon stop --all` 专用：至少一条 stop 失败。不复用 EXIT_INFRA_ERROR(=2) —— 单个项目
+# stop rc=2 是「daemon 已停但 ffmpeg 转码失败」的合法成功旁路；--all 聚合若也用 2，
+# 调用方分不清「全停成功只是某个 transcode 失败」与「真有 daemon 没停掉」。
+EXIT_PARTIAL = 3
 EXIT_USAGE = 64  # 命令组合无效（如 combo 既无文件又无 --steps-json）
 
 # RPC 错误统一信封（无论 --json 还是 --text）的连接/超时占位 code。GD 端
@@ -691,7 +695,7 @@ def cmd_daemon_stop(ns: argparse.Namespace) -> int:
                 print("(no running daemons)")
             return EXIT_OK
         results: list[dict[str, Any]] = []
-        worst = 0
+        had_failure = False
         for r in records:
             entry: dict[str, Any] = {
                 "project_root": r.project_root,
@@ -701,17 +705,29 @@ def cmd_daemon_stop(ns: argparse.Namespace) -> int:
             try:
                 rc = Daemon(Path(r.project_root)).stop()
                 entry["rc"] = rc
-                worst = max(worst, rc)
+                if fmt != OUTPUT_JSON:
+                    suffix = f" (rc={rc})" if rc != 0 else ""
+                    print(f"stopped pid={r.pid} port={r.port} {r.project_root}{suffix}")
             except DaemonError as e:
                 entry["rc"] = EXIT_INFRA_ERROR
                 entry["error"] = str(e)
-                worst = max(worst, EXIT_INFRA_ERROR)
+                had_failure = True
                 # 单条失败不能阻止其余 daemon 收尾
                 print(f"[{r.project_root}] {e}", file=sys.stderr)
             results.append(entry)
+        # rc 含义：0 = 全部成功；EXIT_PARTIAL = 至少一条 DaemonError。注意单条 stop
+        # 返回 2（ffmpeg 转码失败但 daemon 已停）不算"失败"，按成功汇总；调用方
+        # 想要逐条状态请看 JSON 输出 / 文本里的每行 rc=N 标记。
+        rc_total = EXIT_PARTIAL if had_failure else EXIT_OK
         if fmt == OUTPUT_JSON:
-            _emit_success_payload({"stopped": results, "rc": worst})
-        return worst
+            _emit_success_payload({"stopped": results, "rc": rc_total})
+        else:
+            failed = sum(1 for x in results if "error" in x)
+            print(
+                f"summary: {len(results) - failed}/{len(results)} stopped"
+                + (f", {failed} failed" if failed else "")
+            )
+        return rc_total
 
     target = (ns.project.resolve() if getattr(ns, "project", None) else Path.cwd())
     daemon = Daemon(target)

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -670,17 +670,52 @@ def cmd_daemon_start(ns: argparse.Namespace) -> int:
 
 def cmd_daemon_stop(ns: argparse.Namespace) -> int:
     from .daemon import Daemon, DaemonError
+    from . import registry
 
-    daemon = Daemon(Path.cwd())
+    fmt = _output_format(ns)
+
+    if getattr(ns, "all", False):
+        records = registry.list_all()
+        if not records:
+            if fmt == OUTPUT_JSON:
+                _emit_success_payload({"stopped": [], "rc": 0})
+            else:
+                print("(no running daemons)")
+            return EXIT_OK
+        results: list[dict[str, Any]] = []
+        worst = 0
+        for r in records:
+            entry: dict[str, Any] = {
+                "project_root": r.project_root,
+                "pid": r.pid,
+                "port": r.port,
+            }
+            try:
+                rc = Daemon(Path(r.project_root)).stop()
+                entry["rc"] = rc
+                worst = max(worst, rc)
+            except DaemonError as e:
+                entry["rc"] = EXIT_INFRA_ERROR
+                entry["error"] = str(e)
+                worst = max(worst, EXIT_INFRA_ERROR)
+                # 单条失败不能阻止其余 daemon 收尾
+                print(f"[{r.project_root}] {e}", file=sys.stderr)
+            results.append(entry)
+        if fmt == OUTPUT_JSON:
+            _emit_success_payload({"stopped": results, "rc": worst})
+        return worst
+
+    target = (ns.project.resolve() if getattr(ns, "project", None) else Path.cwd())
+    daemon = Daemon(target)
     try:
         rc = daemon.stop()
     except DaemonError as e:
         _emit_top_error(ns, code=CLIENT_CODE_USAGE, message=str(e))
         return EXIT_INFRA_ERROR
-    if _output_format(ns) == OUTPUT_JSON:
+    if fmt == OUTPUT_JSON:
         # rc 0=正常停 / 2=ffmpeg 转码失败但 daemon 已停。两种都算"stopped"，
         # 把 rc 透出让 agent 决定要不要 retry transcode。
-        _emit_success_payload({"stopped": True, "rc": rc})
+        _emit_success_payload({"stopped": True, "rc": rc, "project_root": str(target)})
     return rc
 
 
@@ -1068,10 +1103,22 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_daemon_flags(start_p)
 
-    daemon_subs.add_parser(
+    stop_p = daemon_subs.add_parser(
         "stop",
         help="停止 daemon",
-        description="停止 .cli_control/godot.pid 记录的 daemon。",
+        description=(
+            "停止 daemon。无 flag 时停 cwd 项目；--all 停所有注册的 daemon；"
+            "--project <path> 停指定项目。"
+        ),
+    )
+    stop_grp = stop_p.add_mutually_exclusive_group()
+    stop_grp.add_argument(
+        "--all", action="store_true",
+        help="停止注册表中所有运行中的 daemon"
+    )
+    stop_grp.add_argument(
+        "--project", type=Path, default=None,
+        help="停止指定项目根的 daemon（绝对/相对路径均可）"
     )
 
     daemon_subs.add_parser(

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -952,8 +952,8 @@ def _add_daemon_flags(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--port",
         type=int,
-        default=DEFAULT_PORT,
-        help=f"GameBridge 监听端口（默认 {DEFAULT_PORT}）",
+        default=0,
+        help="GameBridge 监听端口（默认 0 = OS 自动分配；写入 .cli_control/port）",
     )
 
 

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -736,6 +736,42 @@ def cmd_daemon_status(ns: argparse.Namespace) -> int:
     return EXIT_RPC_ERROR
 
 
+def cmd_daemon_ls(ns: argparse.Namespace) -> int:
+    """跨项目列出运行中的 daemon。
+
+    扫全局注册表 ~/.local/state/godot-cli-control/daemons/，对每条记录探活。
+    死记录会被 list_all 自动清理（连同对应项目的 .cli_control/godot.pid 与 port）。
+    JSON 模式：{"ok": true, "result": {"daemons": [...]}}（信封一致）。
+    Text 模式：每条一行 `<pid>\t<port>\t<project_root>\t<started_at>`；空时 (no running daemons)。
+    """
+    from . import registry
+
+    fmt = _output_format(ns)
+    records = registry.list_all()
+    payload = {
+        "daemons": [
+            {
+                "project_root": r.project_root,
+                "pid": r.pid,
+                "port": r.port,
+                "started_at": r.started_at,
+                "godot_bin": r.godot_bin,
+                "log_path": r.log_path,
+            }
+            for r in records
+        ]
+    }
+    if fmt == OUTPUT_JSON:
+        _emit_success_payload(payload)
+    else:
+        if not records:
+            print("(no running daemons)")
+        else:
+            for r in records:
+                print(f"{r.pid}\t{r.port}\t{r.project_root}\t{r.started_at}")
+    return EXIT_OK
+
+
 def cmd_run(ns: argparse.Namespace) -> int:
     """加载用户脚本（要求定义 ``run(bridge)``），自动启停 daemon。"""
     from .daemon import Daemon, DaemonError
@@ -1049,6 +1085,16 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    ls_p = daemon_subs.add_parser(
+        "ls",
+        help="列出所有正在运行的 daemon（跨项目）",
+        description=(
+            "扫描全局注册表 ~/.local/state/godot-cli-control/daemons/，"
+            "列出所有探活通过的 daemon。死记录会被自动清理。"
+        ),
+    )
+    _add_output_format_flags(ls_p)
+
     # run：自动启停 + 跑用户脚本
     run_p = subs.add_parser(
         "run",
@@ -1278,6 +1324,8 @@ def main() -> None:
             sys.exit(cmd_daemon_stop(ns))
         if ns.action == "status":
             sys.exit(cmd_daemon_status(ns))
+        if ns.action == "ls":
+            sys.exit(cmd_daemon_ls(ns))
         parser.error(f"unknown daemon action: {ns.action}")
     if ns.cmd == "run":
         sys.exit(cmd_run(ns))

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -712,10 +712,18 @@ def cmd_daemon_status(ns: argparse.Namespace) -> int:
                 f"running pid={pid} port={port if port is not None else '?'}"
             )
         return EXIT_OK
+    # Stopped：若上一轮启动留下了 godot.log，把路径透出来。issue #38 要求
+    # 在 daemon 已退出时让用户能直接看到日志位置而不是手摸 .cli_control/。
+    stopped_payload: dict[str, Any] = {"state": "stopped"}
+    if daemon.log_file.exists():
+        stopped_payload["last_log"] = str(daemon.log_file)
     if fmt == OUTPUT_JSON:
-        _emit_success_payload({"state": "stopped"})
+        _emit_success_payload(stopped_payload)
     else:
-        print("stopped")
+        if "last_log" in stopped_payload:
+            print(f"stopped (last log: {stopped_payload['last_log']})")
+        else:
+            print("stopped")
     return EXIT_RPC_ERROR
 
 

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -386,6 +386,33 @@ def find_godot_binary() -> str | None:
 def _process_alive(pid: int) -> bool:
     if pid <= 0:
         return False
+    if sys.platform == "win32":
+        # Windows 上 os.kill(pid, 0) 把 0 当 signal.CTRL_C_EVENT（值就是 0），
+        # 会向当前 console 发 Ctrl+C —— 自己把自己/pytest 中断了。所以走
+        # OpenProcess + GetExitCodeProcess。
+        import ctypes
+        from ctypes import wintypes
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        STILL_ACTIVE = 259
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+        kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        kernel32.CloseHandle.restype = wintypes.BOOL
+
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return False
+        try:
+            exit_code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return False
+            return exit_code.value == STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
     try:
         os.kill(pid, 0)
     except ProcessLookupError:

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -15,8 +15,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-from .client import DEFAULT_PORT
-
 
 class DaemonError(RuntimeError):
     """Daemon 启停过程中可恢复的错误（用户应看到 message，不必看 traceback）。"""

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -38,6 +38,10 @@ class Daemon:
         # Godot 进程的 stdout+stderr。每次 start 时 truncate 重写，stop 后保留
         # 让用户回溯最近一次启动失败的根因（issue #38）。
         self.log_file = self.control_dir / "godot.log"
+        # 启动失败时把 returncode 落盘，让 daemon status 能在 stopped 状态下
+        # 直接报「last exit: <code>」，省下一轮回溯。stop / 新一轮 start 会
+        # 清掉。issue #38。
+        self.exit_code_file = self.control_dir / "last_exit_code"
 
     # ── 状态查询 ──
 
@@ -116,6 +120,9 @@ class Daemon:
         # 没走 stop，旧路径会留在文件里，本次 stop 流程触发针对错误文件的
         # ffmpeg 转码（多半失败但也可能转个旧 .avi 误导用户）。
         self.movie_path_file.unlink(missing_ok=True)
+        # 上一轮 last_exit_code 在新一轮 start 时也作废 —— 否则 start 成功后
+        # status 还会拿出陈旧的退出码骗用户。
+        self.exit_code_file.unlink(missing_ok=True)
 
         self.port_file.write_text(str(port))
 
@@ -160,6 +167,7 @@ class Daemon:
         # 启动后 1s 仍存活才认为 launch 成功（捕获 --cli-control 拒识/参数错误）
         time.sleep(1)
         if proc.poll() is not None:
+            self._record_exit_code(proc.returncode)
             self._cleanup_state_files()
             raise DaemonError(
                 f"Godot exited immediately after launch (returncode={proc.returncode}).\n"
@@ -169,6 +177,8 @@ class Daemon:
         print(f"等待 GameBridge 就绪 (port {port})...", file=sys.stderr)
         if not _wait_port_ready(port, wait_seconds, proc=proc):
             crashed_rc = proc.poll()
+            if crashed_rc is not None:
+                self._record_exit_code(crashed_rc)
             self._terminate(proc.pid)
             self._cleanup_state_files()
             if crashed_rc is not None:
@@ -240,6 +250,25 @@ class Daemon:
         if value and Path(value).is_file() and os.access(value, os.X_OK):
             return value
         return None
+
+    def read_last_exit_code(self) -> int | None:
+        """读上一次启动失败的 Godot returncode；没有 / 解析失败返回 None。"""
+        if not self.exit_code_file.exists():
+            return None
+        try:
+            return int(self.exit_code_file.read_text().strip())
+        except (ValueError, OSError):
+            return None
+
+    def _record_exit_code(self, rc: int | None) -> None:
+        """落盘 last exit code。返回 None 时（理论上不该发生 —— poll 已确认死了）
+        跳过写入，避免给 status 一个误导的 ``last_exit_code: None``。"""
+        if rc is None:
+            return
+        try:
+            self.exit_code_file.write_text(str(rc))
+        except OSError:
+            pass
 
     def _format_log_tail(self, n: int = 30) -> str:
         """渲染 godot.log 末尾若干行，给启动失败的 DaemonError 拼可读上下文。

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -109,7 +109,7 @@ class Daemon:
         # spawn 前快速判定端口空闲。GameBridge 那头 listen 失败只 printerr 不
         # 退进程；daemon 这头探活又走 create_connection，会握手到占端口的进程上
         # 误报启动成功，后续 RPC 全打错。先 bind 一次让占用立刻可见。
-        _check_port_available(port)
+        _allocate_port(port)
 
         # 先确保 import 缓存就位（避免首次启动 GameBridge 来不及绑端口）
         _ensure_imported(self.project_root, bin_path)
@@ -396,22 +396,22 @@ def _force_kill_signal() -> int:
     return getattr(signal, "SIGKILL", signal.SIGTERM)
 
 
-def _check_port_available(port: int) -> None:
-    """spawn Godot 之前 bind 一次 ``127.0.0.1:port``，被占就抛 DaemonError。
+def _allocate_port(requested: int) -> int:
+    """返回可用端口。requested=0 → OS 分配；requested>0 → 校验未被占用后返回原值。
 
-    Linux/macOS/Windows 上无 ``SO_REUSEADDR`` / ``SO_REUSEPORT`` 时，bind 占用
-    端口会失败 —— 用这一点判定端口是否被别的进程持有。bind 与 Godot 子进程实际
-    bind 之间存在 race window，但常见的「被占」场景里占用方持续占着，race 不
-    影响主线诊断价值。
+    bind 后立刻关闭与 Godot 子进程实际 listen 之间存在极小 race window，但内核
+    短期内不会立即重用同一端口；真撞上时 Godot listen 失败仍会通过日志被发现。
     """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
-        sock.bind(("127.0.0.1", port))
-    except OSError as e:
-        raise DaemonError(
-            f"port {port} already in use ({e}). 另一个进程正在占用该端口，"
-            f"Godot 起不来。请 stop 旧 daemon 或换 --port。"
-        ) from e
+        try:
+            sock.bind(("127.0.0.1", requested))
+        except OSError as e:
+            raise DaemonError(
+                f"port {requested} already in use ({e}). 另一个进程正在占用该端口，"
+                f"Godot 起不来。请 stop 旧 daemon 或换 --port。"
+            ) from e
+        return sock.getsockname()[1]
     finally:
         sock.close()
 

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -35,6 +35,9 @@ class Daemon:
         self.pid_file = self.control_dir / "godot.pid"
         self.port_file = self.control_dir / "port"
         self.movie_path_file = self.control_dir / "movie_path"
+        # Godot 进程的 stdout+stderr。每次 start 时 truncate 重写，stop 后保留
+        # 让用户回溯最近一次启动失败的根因（issue #38）。
+        self.log_file = self.control_dir / "godot.log"
 
     # ── 状态查询 ──
 
@@ -141,7 +144,17 @@ class Daemon:
             popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
         else:
             popen_kwargs["start_new_session"] = True
-        proc = subprocess.Popen(args, **popen_kwargs)
+
+        # 把 Godot 的 stdout+stderr 落到 .cli_control/godot.log。truncate 重写
+        # 让 log 始终对应最近一次启动；子进程 dup 之后这边的 fh 可以立即关闭，
+        # daemon 不必长期持有 fd。issue #38。
+        log_fh = open(self.log_file, "wb")
+        try:
+            popen_kwargs["stdout"] = log_fh
+            popen_kwargs["stderr"] = subprocess.STDOUT
+            proc = subprocess.Popen(args, **popen_kwargs)
+        finally:
+            log_fh.close()
         self.pid_file.write_text(str(proc.pid))
 
         # 启动后 1s 仍存活才认为 launch 成功（捕获 --cli-control 拒识/参数错误）
@@ -149,15 +162,25 @@ class Daemon:
         if proc.poll() is not None:
             self._cleanup_state_files()
             raise DaemonError(
-                f"Godot exited immediately after launch (returncode={proc.returncode})"
+                f"Godot exited immediately after launch (returncode={proc.returncode}).\n"
+                f"{self._format_log_tail()}"
             )
 
         print(f"等待 GameBridge 就绪 (port {port})...", file=sys.stderr)
-        if not _wait_port_ready(port, wait_seconds):
+        if not _wait_port_ready(port, wait_seconds, proc=proc):
+            crashed_rc = proc.poll()
             self._terminate(proc.pid)
             self._cleanup_state_files()
+            if crashed_rc is not None:
+                # 端口探活期间 Godot 自己挂了（autoload 报错 / scene load 失败 等）。
+                # 这是 issue #38 报告的"daemon start 报成功后 RPC 全失败"主线场景。
+                raise DaemonError(
+                    f"Godot exited during launch (returncode={crashed_rc}).\n"
+                    f"{self._format_log_tail()}"
+                )
             raise DaemonError(
-                f"GameBridge not ready on port {port} within {wait_seconds}s"
+                f"GameBridge not ready on port {port} within {wait_seconds}s.\n"
+                f"{self._format_log_tail()}"
             )
 
         print(f"Godot 已启动 (PID {proc.pid})", file=sys.stderr)
@@ -217,6 +240,26 @@ class Daemon:
         if value and Path(value).is_file() and os.access(value, os.X_OK):
             return value
         return None
+
+    def _format_log_tail(self, n: int = 30) -> str:
+        """渲染 godot.log 末尾若干行，给启动失败的 DaemonError 拼可读上下文。
+
+        失败兜底成 ``(log unavailable)`` 而不是抛异常 —— 启动错误本身比 log
+        读取错误更重要，不能让 IO 失败盖掉真正的根因。
+        """
+        try:
+            text = self.log_file.read_text(errors="replace")
+        except OSError:
+            return f"(log unavailable: {self.log_file})"
+        lines = text.splitlines()
+        header = f"Godot 日志（{self.log_file}）末尾 {n} 行："
+        if not lines:
+            return f"{header}\n  (空 — Godot 进程未输出任何内容)"
+        if len(lines) <= n:
+            body = text.rstrip()
+        else:
+            body = "...\n" + "\n".join(lines[-n:])
+        return f"{header}\n{body}"
 
     def _terminate(self, pid: int, timeout: float = 10.0) -> None:
         """SIGTERM → wait → SIGKILL。"""
@@ -319,9 +362,21 @@ def _force_kill_signal() -> int:
     return getattr(signal, "SIGKILL", signal.SIGTERM)
 
 
-def _wait_port_ready(port: int, max_seconds: int) -> bool:
+def _wait_port_ready(
+    port: int,
+    max_seconds: int,
+    proc: subprocess.Popen[Any] | None = None,
+) -> bool:
+    """轮询直到端口可连接或超时。
+
+    若传入 ``proc``，每轮先检查它是否已退出 —— Godot 在 GameBridge 起来前自己
+    挂了（autoload 报错、--cli-control 接错……）就立刻返回 False，不让用户干等
+    剩下的 wait_seconds。issue #38。
+    """
     deadline = time.time() + max_seconds
     while time.time() < deadline:
+        if proc is not None and proc.poll() is not None:
+            return False
         try:
             with socket.create_connection(("127.0.0.1", port), timeout=0.5):
                 return True

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -276,7 +276,14 @@ class Daemon:
             return None
         try:
             return int(self.exit_code_file.read_text().strip())
-        except (ValueError, OSError):
+        except (ValueError, OSError) as e:
+            # 静默吞掉会让 status 显示「stopped」而不带 last_exit，用户以为没崩过；
+            # 起码 stderr 提示一句让人有线索。不抛 —— 上层 status 路径不该被
+            # 一个诊断辅助文件读失败击穿。
+            print(
+                f"warning: failed to read {self.exit_code_file}: {e}",
+                file=sys.stderr,
+            )
             return None
 
     def _record_exit_code(self, rc: int | None) -> None:
@@ -286,23 +293,34 @@ class Daemon:
             return
         try:
             self.exit_code_file.write_text(str(rc))
-        except OSError:
-            pass
+        except OSError as e:
+            # 写不进去（磁盘满 / .cli_control 只读）会让后续 daemon status 报
+            # 「stopped」而不带 last_exit_code，用户找不到 Godot 真正的退出码。
+            # 至少 print 一句到 stderr，留下根因线索。
+            print(
+                f"warning: failed to record last exit code to {self.exit_code_file}: {e}",
+                file=sys.stderr,
+            )
 
     def _format_log_tail(self, n: int = 30) -> str:
         """渲染 godot.log 末尾若干行，给启动失败的 DaemonError 拼可读上下文。
 
+        从文件末尾倒着 8KB 一块读，避免一次性 read_text() 把潜在的大日志整盘吞内存
+        —— 启动失败路径目前日志都很小，但若将来 status 也调本函数，遇到长跑后崩溃
+        的几百 MB 日志会爆。
+
         失败兜底成 ``(log unavailable)`` 而不是抛异常 —— 启动错误本身比 log
         读取错误更重要，不能让 IO 失败盖掉真正的根因。
         """
+        header = f"Godot 日志（{self.log_file}）末尾 {n} 行："
         try:
-            text = self.log_file.read_text(errors="replace")
+            tail_bytes, total_size = _read_tail_bytes(self.log_file, n)
         except OSError:
             return f"(log unavailable: {self.log_file})"
-        lines = text.splitlines()
-        header = f"Godot 日志（{self.log_file}）末尾 {n} 行："
-        if not lines:
+        if total_size == 0:
             return f"{header}\n  (空 — Godot 进程未输出任何内容)"
+        text = tail_bytes.decode("utf-8", errors="replace")
+        lines = text.splitlines()
         if len(lines) <= n:
             body = text.rstrip()
         else:
@@ -410,20 +428,54 @@ def _force_kill_signal() -> int:
     return getattr(signal, "SIGKILL", signal.SIGTERM)
 
 
+def _read_tail_bytes(path: Path, target_lines: int, chunk: int = 8192) -> tuple[bytes, int]:
+    """读取 path 末尾若干行（>= target_lines），返回 (字节串, 文件总大小)。
+
+    倒着 8KB 一块往前读，遇到超过 target_lines 个 ``\\n`` 即停。空文件返回 (b'', 0)。
+    """
+    with open(path, "rb") as f:
+        f.seek(0, os.SEEK_END)
+        total_size = f.tell()
+        if total_size == 0:
+            return b"", 0
+        end = total_size
+        chunks: list[bytes] = []
+        newlines = 0
+        # target_lines 是"行数"；至少多读一段 newline 用于切分
+        needed = target_lines + 1
+        while end > 0 and newlines <= needed:
+            start = max(0, end - chunk)
+            f.seek(start)
+            buf = f.read(end - start)
+            chunks.append(buf)
+            newlines += buf.count(b"\n")
+            end = start
+        chunks.reverse()
+        return b"".join(chunks), total_size
+
+
 def _allocate_port(requested: int) -> int:
     """返回可用端口。requested=0 → OS 分配；requested>0 → 校验未被占用后返回原值。
 
-    bind 后立刻关闭与 Godot 子进程实际 listen 之间存在极小 race window，但内核
-    短期内不会立即重用同一端口；真撞上时 Godot listen 失败仍会通过日志被发现。
+    Race window：bind→close→spawn→Godot listen 之间窗口达数秒（Godot 要 import
+    项目+autoload+_ready 才 listen）。这段时间里其它进程仍可能抢走端口；当下
+    Godot 端 listen 失败只 push_error+printerr，daemon 这边在日志 tail 里能看到，
+    但不会被自动重试。**推荐用默认 --port 0** 让 OS 每次分配新端口，从根上回避。
+
+    SO_REUSEADDR：避免上一轮 daemon 刚 stop、内核仍在 TIME_WAIT 时显式
+    --port N 立刻起新 daemon 报 EADDRINUSE。Godot TCPServer 内部也开了
+    SO_REUSEADDR，这里探测必须对齐，否则会出现"探测说占用、Godot 实际能 bind"
+    的假阳性。
     """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             sock.bind(("127.0.0.1", requested))
         except OSError as e:
             raise DaemonError(
                 f"port {requested} already in use ({e}). 另一个进程正在占用该端口，"
-                f"Godot 起不来。请 stop 旧 daemon 或换 --port。"
+                f"Godot 起不来。请 stop 旧 daemon 或换 --port（默认 --port 0 由 OS 分配最稳）。"
             ) from e
         return sock.getsockname()[1]
     finally:

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -219,7 +219,6 @@ class Daemon:
         if not _process_alive(pid):
             print(f"Godot (PID {pid}) 已不在运行，清理 PID 文件", file=sys.stderr)
             self._cleanup_state_files()
-            _registry.unregister(self.project_root)
             return 0
         if not _process_is_godot(pid):
             raise DaemonError(
@@ -230,7 +229,6 @@ class Daemon:
         print(f"关闭 Godot (PID {pid})...", file=sys.stderr)
         self._terminate(pid)
         self._cleanup_state_files()
-        _registry.unregister(self.project_root)
         print("Godot 已停止", file=sys.stderr)
 
         # 录制转码（即使失败也认为 stop 成功；返回非 0 让 CI 感知）
@@ -244,13 +242,17 @@ class Daemon:
     # ── 内部 ──
 
     def _cleanup_state_files(self) -> None:
-        """清理 daemon 启停产生的 pid/port 临时文件。
+        """清理本 daemon 的所有持久化状态：本地 pid/port + 全局 registry 记录。
 
-        port_file 跟随 pid_file 一起清，避免后续 ``current_port()`` 读到 stale
-        值把 RPC 请求发到已不存在的端口。``movie_path`` 在 stop 流程中独立处理。
+        三者同生同死 —— ``start()`` 成功后一并写入；任何 stop 路径（包括 start
+        途中失败的回滚清理）必须把它们一并清掉，否则下次 ``daemon ls`` / 启动
+        校验会误以为还有进程在跑。``movie_path`` 在 stop 流程中独立处理。
         """
         self.pid_file.unlink(missing_ok=True)
         self.port_file.unlink(missing_ok=True)
+        # start 失败回滚路径还没 register 时，unregister 是 unlink(missing_ok=True)，
+        # 行为一致；保持一处兜底比让所有 caller 记得手动 unregister 更不易遗漏。
+        _registry.unregister(self.project_root)
 
     def read_godot_bin_pref(self) -> str | None:
         """读取 init 命令写入的 ``.cli_control/godot_bin`` 路径偏好。"""

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -77,6 +77,7 @@ class Daemon:
         fps: int = 30,
         port: int = 0,  # 0 = OS 自动分配；显式 --port 9877 仍可固定
         wait_seconds: int = 30,
+        idle_timeout: int = 0,
     ) -> int:
         """启动 Godot daemon，等端口就绪后返回 PID。"""
         # 项目根校验：拒绝在非 Godot 项目目录跑，避免 Godot 用 --path .
@@ -140,6 +141,8 @@ class Daemon:
         ]
         if headless:
             args.append("--headless")
+        if idle_timeout > 0:
+            args.append(f"--game-bridge-idle-timeout={idle_timeout}")
 
         env = os.environ.copy()
         if record:

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -75,7 +75,7 @@ class Daemon:
         movie_path: str | None = None,
         headless: bool = False,
         fps: int = 30,
-        port: int = DEFAULT_PORT,
+        port: int = 0,  # 0 = OS 自动分配；显式 --port 9877 仍可固定
         wait_seconds: int = 30,
     ) -> int:
         """启动 Godot daemon，等端口就绪后返回 PID。"""
@@ -109,7 +109,7 @@ class Daemon:
         # spawn 前快速判定端口空闲。GameBridge 那头 listen 失败只 printerr 不
         # 退进程；daemon 这头探活又走 create_connection，会握手到占端口的进程上
         # 误报启动成功，后续 RPC 全打错。先 bind 一次让占用立刻可见。
-        _allocate_port(port)
+        actual_port = _allocate_port(port)
 
         # 先确保 import 缓存就位（避免首次启动 GameBridge 来不及绑端口）
         _ensure_imported(self.project_root, bin_path)
@@ -129,14 +129,14 @@ class Daemon:
         # status 还会拿出陈旧的退出码骗用户。
         self.exit_code_file.unlink(missing_ok=True)
 
-        self.port_file.write_text(str(port))
+        self.port_file.write_text(str(actual_port))
 
         args: list[str] = [
             bin_path,
             "--path",
             str(self.project_root),
             "--cli-control",
-            f"--game-bridge-port={port}",
+            f"--game-bridge-port={actual_port}",
         ]
         if headless:
             args.append("--headless")
@@ -179,8 +179,8 @@ class Daemon:
                 f"{self._format_log_tail()}"
             )
 
-        print(f"等待 GameBridge 就绪 (port {port})...", file=sys.stderr)
-        if not _wait_port_ready(port, wait_seconds, proc=proc):
+        print(f"等待 GameBridge 就绪 (port {actual_port})...", file=sys.stderr)
+        if not _wait_port_ready(actual_port, wait_seconds, proc=proc):
             crashed_rc = proc.poll()
             if crashed_rc is not None:
                 self._record_exit_code(crashed_rc)
@@ -194,7 +194,7 @@ class Daemon:
                     f"{self._format_log_tail()}"
                 )
             raise DaemonError(
-                f"GameBridge not ready on port {port} within {wait_seconds}s.\n"
+                f"GameBridge not ready on port {actual_port} within {wait_seconds}s.\n"
                 f"{self._format_log_tail()}"
             )
 

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -386,10 +386,11 @@ def find_godot_binary() -> str | None:
 def _process_alive(pid: int) -> bool:
     if pid <= 0:
         return False
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: no cover
         # Windows 上 os.kill(pid, 0) 把 0 当 signal.CTRL_C_EVENT（值就是 0），
         # 会向当前 console 发 Ctrl+C —— 自己把自己/pytest 中断了。所以走
         # OpenProcess + GetExitCodeProcess。
+        # POSIX CI 进不到这里；Windows CI 上 fail-under 不跑，故整块跳过覆盖率统计。
         import ctypes
         from ctypes import wintypes
 

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -106,6 +106,11 @@ class Daemon:
         if not os.access(bin_path, os.X_OK):
             raise DaemonError(f"Godot binary not executable: {bin_path}")
 
+        # spawn 前快速判定端口空闲。GameBridge 那头 listen 失败只 printerr 不
+        # 退进程；daemon 这头探活又走 create_connection，会握手到占端口的进程上
+        # 误报启动成功，后续 RPC 全打错。先 bind 一次让占用立刻可见。
+        _check_port_available(port)
+
         # 先确保 import 缓存就位（避免首次启动 GameBridge 来不及绑端口）
         _ensure_imported(self.project_root, bin_path)
 
@@ -389,6 +394,26 @@ def _process_is_godot(pid: int) -> bool:
 
 def _force_kill_signal() -> int:
     return getattr(signal, "SIGKILL", signal.SIGTERM)
+
+
+def _check_port_available(port: int) -> None:
+    """spawn Godot 之前 bind 一次 ``127.0.0.1:port``，被占就抛 DaemonError。
+
+    Linux/macOS/Windows 上无 ``SO_REUSEADDR`` / ``SO_REUSEPORT`` 时，bind 占用
+    端口会失败 —— 用这一点判定端口是否被别的进程持有。bind 与 Godot 子进程实际
+    bind 之间存在 race window，但常见的「被占」场景里占用方持续占着，race 不
+    影响主线诊断价值。
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", port))
+    except OSError as e:
+        raise DaemonError(
+            f"port {port} already in use ({e}). 另一个进程正在占用该端口，"
+            f"Godot 起不来。请 stop 旧 daemon 或换 --port。"
+        ) from e
+    finally:
+        sock.close()
 
 
 def _wait_port_ready(

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -15,6 +15,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from . import registry as _registry
+
 
 class DaemonError(RuntimeError):
     """Daemon 启停过程中可恢复的错误（用户应看到 message，不必看 traceback）。"""
@@ -197,6 +199,13 @@ class Daemon:
             )
 
         print(f"Godot 已启动 (PID {proc.pid})", file=sys.stderr)
+        _registry.register(
+            self.project_root,
+            pid=proc.pid,
+            port=actual_port,
+            godot_bin=bin_path,
+            log_path=str(self.log_file),
+        )
         return proc.pid
 
     # ── 停止 ──
@@ -210,6 +219,7 @@ class Daemon:
         if not _process_alive(pid):
             print(f"Godot (PID {pid}) 已不在运行，清理 PID 文件", file=sys.stderr)
             self._cleanup_state_files()
+            _registry.unregister(self.project_root)
             return 0
         if not _process_is_godot(pid):
             raise DaemonError(
@@ -220,6 +230,7 @@ class Daemon:
         print(f"关闭 Godot (PID {pid})...", file=sys.stderr)
         self._terminate(pid)
         self._cleanup_state_files()
+        _registry.unregister(self.project_root)
         print("Godot 已停止", file=sys.stderr)
 
         # 录制转码（即使失败也认为 stop 成功；返回非 0 让 CI 感知）

--- a/python/godot_cli_control/registry.py
+++ b/python/godot_cli_control/registry.py
@@ -51,8 +51,12 @@ def register(
         "godot_bin": godot_bin,
         "log_path": log_path,
     }
+    # 原子写：先写 .tmp 再 os.replace，避免被 SIGKILL / OOM 打断后留下 0 字节
+    # 文件让 list_all 误删尚未完成的注册。docstring 的"幂等"才真正成立。
     target = _REGISTRY_DIR / f"{project_hash(project_root)}.json"
-    target.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+    tmp = target.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+    os.replace(tmp, target)
 
 
 def unregister(project_root: Path) -> None:

--- a/python/godot_cli_control/registry.py
+++ b/python/godot_cli_control/registry.py
@@ -97,9 +97,10 @@ def _prune(record: DaemonRecord, registry_file: Path) -> None:
 def _process_alive(pid: int) -> bool:
     if pid <= 0:
         return False
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: no cover
         # 见 daemon._process_alive：os.kill(pid, 0) 在 Windows 等价于
         # signal.CTRL_C_EVENT（值就是 0），会向当前 console 发 Ctrl+C。
+        # POSIX CI 进不到这里；Windows CI 上 fail-under 不跑，故整块跳过覆盖率统计。
         import ctypes
         from ctypes import wintypes
 

--- a/python/godot_cli_control/registry.py
+++ b/python/godot_cli_control/registry.py
@@ -10,6 +10,7 @@ import datetime as _dt
 import hashlib
 import json
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -96,6 +97,32 @@ def _prune(record: DaemonRecord, registry_file: Path) -> None:
 def _process_alive(pid: int) -> bool:
     if pid <= 0:
         return False
+    if sys.platform == "win32":
+        # 见 daemon._process_alive：os.kill(pid, 0) 在 Windows 等价于
+        # signal.CTRL_C_EVENT（值就是 0），会向当前 console 发 Ctrl+C。
+        import ctypes
+        from ctypes import wintypes
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        STILL_ACTIVE = 259
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+        kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        kernel32.CloseHandle.restype = wintypes.BOOL
+
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return False
+        try:
+            exit_code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return False
+            return exit_code.value == STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
     try:
         os.kill(pid, 0)
     except ProcessLookupError:

--- a/python/godot_cli_control/registry.py
+++ b/python/godot_cli_control/registry.py
@@ -1,0 +1,100 @@
+"""Global cross-project daemon registry under ~/.local/state/godot-cli-control/daemons/.
+
+每个守护进程一份 ``<project_hash>.json``，记录 PID / 端口 / 项目路径 / 启动时刻。
+``list_all()`` 顺手探活并清理死记录。无文件锁 —— 每条记录文件名以 project_hash
+区分，写入幂等。
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+_REGISTRY_DIR = Path.home() / ".local" / "state" / "godot-cli-control" / "daemons"
+
+
+@dataclass(frozen=True)
+class DaemonRecord:
+    project_root: str
+    pid: int
+    port: int
+    started_at: str
+    godot_bin: str
+    log_path: str
+
+    @property
+    def record_file(self) -> Path:
+        return _REGISTRY_DIR / f"{project_hash(Path(self.project_root))}.json"
+
+
+def project_hash(project_root: Path) -> str:
+    return hashlib.sha1(str(Path(project_root).resolve()).encode()).hexdigest()[:12]
+
+
+def register(
+    project_root: Path,
+    *,
+    pid: int,
+    port: int,
+    godot_bin: str,
+    log_path: str,
+) -> None:
+    _REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "project_root": str(Path(project_root).resolve()),
+        "pid": pid,
+        "port": port,
+        "started_at": _dt.datetime.now(_dt.timezone.utc).astimezone().isoformat(timespec="seconds"),
+        "godot_bin": godot_bin,
+        "log_path": log_path,
+    }
+    target = _REGISTRY_DIR / f"{project_hash(project_root)}.json"
+    target.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def unregister(project_root: Path) -> None:
+    target = _REGISTRY_DIR / f"{project_hash(project_root)}.json"
+    target.unlink(missing_ok=True)
+
+
+def list_all() -> list[DaemonRecord]:
+    """List live records. Dead PIDs are pruned (registry + project state files)."""
+    if not _REGISTRY_DIR.exists():
+        return []
+    live: list[DaemonRecord] = []
+    for f in sorted(_REGISTRY_DIR.glob("*.json")):
+        try:
+            data = json.loads(f.read_text())
+            r = DaemonRecord(**{k: data[k] for k in DaemonRecord.__dataclass_fields__})
+        except (OSError, json.JSONDecodeError, KeyError, TypeError):
+            f.unlink(missing_ok=True)
+            continue
+        if _process_alive(r.pid):
+            live.append(r)
+        else:
+            _prune(r, f)
+    return live
+
+
+def _prune(record: DaemonRecord, registry_file: Path) -> None:
+    registry_file.unlink(missing_ok=True)
+    ctrl = Path(record.project_root) / ".cli_control"
+    (ctrl / "godot.pid").unlink(missing_ok=True)
+    (ctrl / "port").unlink(missing_ok=True)
+
+
+def _process_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but owned by another user; treat as alive
+    except OSError:
+        return False
+    return True

--- a/python/godot_cli_control/registry.py
+++ b/python/godot_cli_control/registry.py
@@ -18,6 +18,9 @@ _REGISTRY_DIR = Path.home() / ".local" / "state" / "godot-cli-control" / "daemon
 
 @dataclass(frozen=True)
 class DaemonRecord:
+    # ``project_root`` 始终是 resolve() 后的绝对路径（见 ``register()``）。
+    # 同一个项目被 daemon start 软链接路径访问时，``daemon ls`` 输出的会是真实
+    # 路径而非传入的软链接 —— 有意为之，让任何路径表述都对齐到唯一注册项。
     project_root: str
     pid: int
     port: int

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -269,7 +269,7 @@ Pytest CLI options the plugin adds:
 
 | Option | Default | Purpose |
 |---|---|---|
-| `--godot-cli-port` | `9877` | GameBridge port the fixture connects to / starts the daemon on |
+| `--godot-cli-port` | `(auto)` | GameBridge port. Default: read from `.cli_control/port` (which the daemon writes when it starts). |
 | `--godot-cli-no-headless` | off (i.e. headless) | Drop `--headless`, open a real Godot window |
 | `--godot-cli-project-root` | `pytest rootdir` | Override the Godot project root |
 
@@ -292,7 +292,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **Node paths must be absolute** — start with `/root/...`. Relative paths return `node not found`.
 - **`InvalidMessage` / `did not receive a valid HTTP response`** — `all_proxy` / `http_proxy` env var is hijacking localhost. The client sets `proxy=None` to defend, but if you see weird handshake errors, `unset all_proxy` first.
 - **Daemon won't start** — check `.cli_control/godot_bin` exists and points at a real Godot 4 binary, or `export GODOT_BIN=/path/to/godot`. See `godot-cli-control init -h` for the full lookup chain.
-- **Top-level `--port` doesn't change daemon port** — it only routes RPC subcommands. To make `daemon start` / `run` listen on a non-default port, pass `--port` *after* the subcommand: `godot-cli-control daemon start --port 9888`.
+- **Top-level `--port` doesn't change daemon port** — it only routes RPC subcommands. The daemon defaults to OS-assigned (written to `.cli_control/port`); to fix it, pass `--port` *after* the subcommand: `godot-cli-control daemon start --port 9888`.
 - **`combo` rejects everything with `1004`** — a combo is already running. Call `combo-cancel` (or `release-all`) to abort.
 - **`set` with a string that *looks* like JSON** — value parser parses JSON first. To force a literal `"42"` string, pass `'"42"'`; to set a literal hash sign or array text, JSON-encode it.
 

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -461,12 +461,16 @@ def test_daemon_status_json_envelope_running(
 
 
 def test_daemon_status_json_envelope_stopped(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     import json as _json
 
     import godot_cli_control.daemon as daemon_mod
 
+    # chdir tmp_path 避免读到工作目录里残留的 .cli_control/godot.log
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(daemon_mod.Daemon, "is_running", lambda self: False)
 
     from godot_cli_control.cli import OUTPUT_JSON, cmd_daemon_status
@@ -476,6 +480,60 @@ def test_daemon_status_json_envelope_stopped(
     assert rc == 1  # exit code 语义不变
     payload = _json.loads(capsys.readouterr().out)
     assert payload == {"ok": True, "result": {"state": "stopped"}}
+
+
+def test_daemon_status_stopped_includes_last_log(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """issue #38：daemon 已停 + .cli_control/godot.log 存在 → status 必须把
+    日志路径透出来，让用户立刻知道去哪 cat 上次启动失败的原因。"""
+    import json as _json
+
+    import godot_cli_control.daemon as daemon_mod
+
+    monkeypatch.chdir(tmp_path)
+    control_dir = tmp_path / ".cli_control"
+    control_dir.mkdir()
+    log = control_dir / "godot.log"
+    log.write_text("ERROR: autoload failed\n")
+
+    monkeypatch.setattr(daemon_mod.Daemon, "is_running", lambda self: False)
+
+    from godot_cli_control.cli import OUTPUT_JSON, cmd_daemon_status
+
+    ns = __import__("argparse").Namespace(output_format=OUTPUT_JSON)
+    rc = cmd_daemon_status(ns)
+    assert rc == 1
+    payload = _json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["result"]["state"] == "stopped"
+    assert payload["result"]["last_log"] == str(log)
+
+
+def test_daemon_status_stopped_text_mode_includes_last_log(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """text 模式下也要带 last log 提示，否则人类用户读不到。"""
+    import godot_cli_control.daemon as daemon_mod
+
+    monkeypatch.chdir(tmp_path)
+    control_dir = tmp_path / ".cli_control"
+    control_dir.mkdir()
+    (control_dir / "godot.log").write_text("crash\n")
+
+    monkeypatch.setattr(daemon_mod.Daemon, "is_running", lambda self: False)
+
+    from godot_cli_control.cli import OUTPUT_TEXT, cmd_daemon_status
+
+    ns = __import__("argparse").Namespace(output_format=OUTPUT_TEXT)
+    rc = cmd_daemon_status(ns)
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "stopped" in out and "godot.log" in out
 
 
 def test_run_rpc_emits_success_envelope(

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -512,18 +512,47 @@ def test_daemon_status_stopped_includes_last_log(
     assert payload["result"]["last_log"] == str(log)
 
 
+def test_daemon_status_stopped_includes_last_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """issue #38 进阶：last_exit_code 文件存在时，JSON 必须把退出码透出。"""
+    import json as _json
+
+    import godot_cli_control.daemon as daemon_mod
+
+    monkeypatch.chdir(tmp_path)
+    control_dir = tmp_path / ".cli_control"
+    control_dir.mkdir()
+    (control_dir / "godot.log").write_text("FATAL\n")
+    (control_dir / "last_exit_code").write_text("137")
+
+    monkeypatch.setattr(daemon_mod.Daemon, "is_running", lambda self: False)
+
+    from godot_cli_control.cli import OUTPUT_JSON, cmd_daemon_status
+
+    ns = __import__("argparse").Namespace(output_format=OUTPUT_JSON)
+    rc = cmd_daemon_status(ns)
+    assert rc == 1
+    payload = _json.loads(capsys.readouterr().out)
+    assert payload["result"]["last_exit_code"] == 137
+    assert payload["result"]["last_log"].endswith("godot.log")
+
+
 def test_daemon_status_stopped_text_mode_includes_last_log(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """text 模式下也要带 last log 提示，否则人类用户读不到。"""
+    """text 模式下也要带 last exit + log 提示，否则人类用户读不到。"""
     import godot_cli_control.daemon as daemon_mod
 
     monkeypatch.chdir(tmp_path)
     control_dir = tmp_path / ".cli_control"
     control_dir.mkdir()
     (control_dir / "godot.log").write_text("crash\n")
+    (control_dir / "last_exit_code").write_text("11")
 
     monkeypatch.setattr(daemon_mod.Daemon, "is_running", lambda self: False)
 
@@ -533,7 +562,9 @@ def test_daemon_status_stopped_text_mode_includes_last_log(
     rc = cmd_daemon_status(ns)
     assert rc == 1
     out = capsys.readouterr().out
-    assert "stopped" in out and "godot.log" in out
+    assert "stopped" in out
+    assert "last exit: 11" in out
+    assert "godot.log" in out
 
 
 def test_run_rpc_emits_success_envelope(

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -976,10 +976,11 @@ def test_run_rpc_separates_local_io_error_from_connection(
     from unittest.mock import AsyncMock, patch
 
     spec = RPC_BY_NAME["screenshot"]
-    # 指向只读目录的子路径：mkdir / write_bytes 必失败
-    bad_path = tmp_path / "ro_dir" / "out.png"
-    (tmp_path / "ro_dir").mkdir()
-    (tmp_path / "ro_dir").chmod(0o400)  # 只读
+    # 父级是个文件（不是目录），mkdir(parents=True, exist_ok=True) 必抛
+    # FileExistsError —— 跨平台可靠（chmod 0o400 在 Windows 上不让目录只读）。
+    blocker = tmp_path / "blocker"
+    blocker.write_bytes(b"")
+    bad_path = blocker / "out.png"
     ns = __import__("argparse").Namespace(output_path=str(bad_path))
 
     mock_client = AsyncMock()
@@ -987,13 +988,10 @@ def test_run_rpc_separates_local_io_error_from_connection(
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 
-    try:
-        with patch(
-            "godot_cli_control.cli.GameClient", return_value=mock_client
-        ):
-            rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_JSON))
-    finally:
-        (tmp_path / "ro_dir").chmod(0o700)  # 让 tmp_path 清理能跑
+    with patch(
+        "godot_cli_control.cli.GameClient", return_value=mock_client
+    ):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_JSON))
 
     assert rc == 2
     payload = _json.loads(capsys.readouterr().out.strip())
@@ -1081,8 +1079,12 @@ def test_daemon_ls_lists_active_daemon(
     rc = cmd_daemon_ls(argparse.Namespace(output_format=OUTPUT_JSON))
     out = capsys.readouterr().out
     assert rc == 0
-    assert "12345" in out
-    assert str(proj.resolve()) in out
+    # 直接读字段而不是子串匹配 —— Windows 路径含反斜杠，JSON 输出会转义成 \\
+    import json as _json
+    payload = _json.loads(out)
+    daemons = payload["result"]["daemons"]
+    assert any(d["port"] == 12345 for d in daemons)
+    assert any(d["project_root"] == str(proj.resolve()) for d in daemons)
 
 
 def test_daemon_ls_subcommand_parses() -> None:
@@ -1211,7 +1213,9 @@ def test_daemon_stop_subcommand_parses_all_and_project() -> None:
     assert ns.all is True
 
     ns = build_parser().parse_args(["daemon", "stop", "--project", "/tmp/x"])
-    assert str(ns.project) == "/tmp/x"
+    # argparse 用 type=Path，Windows 上 str(WindowsPath("/tmp/x")) == "\\tmp\\x"，
+    # 所以与 Path("/tmp/x") 比较保证跨平台。
+    assert ns.project == Path("/tmp/x")
 
     # mutually exclusive — argparse should refuse both
     import pytest as _pt

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1120,6 +1120,55 @@ def test_daemon_stop_all_invokes_terminate(
     assert {p.resolve() for p in stopped} == {proj1.resolve(), proj2.resolve()}
 
 
+def test_daemon_stop_all_returns_partial_when_one_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--all 中至少一条 stop 抛 DaemonError → rc=EXIT_PARTIAL（与 ffmpeg rc=2 区分）。"""
+    from godot_cli_control import registry
+    from godot_cli_control.daemon import DaemonError
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+
+    proj1 = tmp_path / "ok"; proj1.mkdir()
+    proj2 = tmp_path / "bad"; proj2.mkdir()
+    import os
+    registry.register(proj1, pid=os.getpid(), port=1, godot_bin="x", log_path="y")
+    registry.register(proj2, pid=os.getpid(), port=2, godot_bin="x", log_path="y")
+
+    def fake_stop(self) -> int:
+        if "bad" in str(self.project_root):
+            raise DaemonError("simulated failure")
+        return 0
+    import godot_cli_control.daemon as daemon_mod
+    monkeypatch.setattr(daemon_mod.Daemon, "stop", fake_stop)
+
+    from godot_cli_control.cli import cmd_daemon_stop, OUTPUT_JSON, EXIT_PARTIAL
+    import argparse
+    ns = argparse.Namespace(all=True, project=None, output_format=OUTPUT_JSON)
+    rc = cmd_daemon_stop(ns)
+    assert rc == EXIT_PARTIAL
+    assert EXIT_PARTIAL != 2, "EXIT_PARTIAL 必须与 EXIT_INFRA_ERROR 区分，避免与单项目 ffmpeg rc=2 撞码"
+
+
+def test_daemon_stop_all_ffmpeg_rc2_does_not_promote_to_partial(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """单条 stop 返回 2（ffmpeg 转码失败但 daemon 已停）不算 --all 失败 —— rc 应为 0。"""
+    from godot_cli_control import registry
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+    proj = tmp_path / "p"; proj.mkdir()
+    import os
+    registry.register(proj, pid=os.getpid(), port=1, godot_bin="x", log_path="y")
+
+    import godot_cli_control.daemon as daemon_mod
+    monkeypatch.setattr(daemon_mod.Daemon, "stop", lambda self: 2)
+
+    from godot_cli_control.cli import cmd_daemon_stop, OUTPUT_JSON
+    import argparse
+    ns = argparse.Namespace(all=True, project=None, output_format=OUTPUT_JSON)
+    rc = cmd_daemon_stop(ns)
+    assert rc == 0
+
+
 def test_daemon_stop_project_flag(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1044,3 +1044,46 @@ def test_run_rpc_text_mode_uses_text_formatter(
 
     assert rc == 0
     assert capsys.readouterr().out.strip() == "true"
+
+
+def test_daemon_ls_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from godot_cli_control import registry
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+
+    from godot_cli_control.cli import cmd_daemon_ls, OUTPUT_JSON
+    import argparse
+
+    rc = cmd_daemon_ls(argparse.Namespace(output_format=OUTPUT_JSON))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert '"daemons": []' in out
+
+
+def test_daemon_ls_lists_active_daemon(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import os
+    from godot_cli_control import registry
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+    proj = tmp_path / "p"; proj.mkdir()
+    registry.register(
+        proj, pid=os.getpid(), port=12345, godot_bin="x", log_path="y"
+    )
+
+    from godot_cli_control.cli import cmd_daemon_ls, OUTPUT_JSON
+    import argparse
+
+    rc = cmd_daemon_ls(argparse.Namespace(output_format=OUTPUT_JSON))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "12345" in out
+    assert str(proj.resolve()) in out
+
+
+def test_daemon_ls_subcommand_parses() -> None:
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["daemon", "ls"])
+    assert ns.cmd == "daemon"
+    assert ns.action == "ls"

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -825,7 +825,10 @@ def test_daemon_stop_emits_json_envelope(
     rc = cmd_daemon_stop(ns)
     assert rc == 2  # exit code 直通：agent 既能从 stdout JSON 拿到 rc=2，也能从 $? 看
     payload = _json.loads(capsys.readouterr().out.strip())
-    assert payload == {"ok": True, "result": {"stopped": True, "rc": 2}}
+    assert payload["ok"] is True
+    assert payload["result"]["stopped"] is True
+    assert payload["result"]["rc"] == 2
+    assert "project_root" in payload["result"]
 
 
 def test_cmd_set_passes_json_parsed_value_to_client(
@@ -1087,3 +1090,81 @@ def test_daemon_ls_subcommand_parses() -> None:
     ns = build_parser().parse_args(["daemon", "ls"])
     assert ns.cmd == "daemon"
     assert ns.action == "ls"
+
+
+def test_daemon_stop_all_invokes_terminate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--all 应对注册表里每条记录调 Daemon(...).stop()。"""
+    from godot_cli_control import registry
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+
+    proj1 = tmp_path / "a"; proj1.mkdir()
+    proj2 = tmp_path / "b"; proj2.mkdir()
+    import os
+    registry.register(proj1, pid=os.getpid(), port=1, godot_bin="x", log_path="y")
+    registry.register(proj2, pid=os.getpid(), port=2, godot_bin="x", log_path="y")
+
+    stopped: list[Path] = []
+    def fake_stop(self) -> int:
+        stopped.append(self.project_root)
+        return 0
+    import godot_cli_control.daemon as daemon_mod
+    monkeypatch.setattr(daemon_mod.Daemon, "stop", fake_stop)
+
+    from godot_cli_control.cli import cmd_daemon_stop, OUTPUT_JSON
+    import argparse
+    ns = argparse.Namespace(all=True, project=None, output_format=OUTPUT_JSON)
+    rc = cmd_daemon_stop(ns)
+    assert rc == 0
+    assert {p.resolve() for p in stopped} == {proj1.resolve(), proj2.resolve()}
+
+
+def test_daemon_stop_project_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--project <path> 应对该项目调 Daemon(...).stop()，与 cwd 无关。"""
+    target = tmp_path / "p"; target.mkdir()
+    seen: list[Path] = []
+    import godot_cli_control.daemon as daemon_mod
+    monkeypatch.setattr(daemon_mod.Daemon, "stop",
+                        lambda self: (seen.append(self.project_root), 0)[1])
+
+    from godot_cli_control.cli import cmd_daemon_stop, OUTPUT_JSON
+    import argparse
+    ns = argparse.Namespace(all=False, project=target, output_format=OUTPUT_JSON)
+    rc = cmd_daemon_stop(ns)
+    assert rc == 0
+    assert seen == [target.resolve()]
+
+
+def test_daemon_stop_default_uses_cwd(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """无 --all 也无 --project 时，行为与今天一致：使用 cwd 的 Daemon。"""
+    monkeypatch.chdir(tmp_path)
+    import godot_cli_control.daemon as daemon_mod
+    seen: list[Path] = []
+    monkeypatch.setattr(daemon_mod.Daemon, "stop",
+                        lambda self: (seen.append(self.project_root), 0)[1])
+
+    from godot_cli_control.cli import cmd_daemon_stop, OUTPUT_JSON
+    import argparse
+    ns = argparse.Namespace(all=False, project=None, output_format=OUTPUT_JSON)
+    rc = cmd_daemon_stop(ns)
+    assert rc == 0
+    assert seen == [tmp_path.resolve()]
+
+
+def test_daemon_stop_subcommand_parses_all_and_project() -> None:
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["daemon", "stop", "--all"])
+    assert ns.all is True
+
+    ns = build_parser().parse_args(["daemon", "stop", "--project", "/tmp/x"])
+    assert str(ns.project) == "/tmp/x"
+
+    # mutually exclusive — argparse should refuse both
+    import pytest as _pt
+    with _pt.raises(SystemExit):
+        build_parser().parse_args(["daemon", "stop", "--all", "--project", "/tmp/x"])

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1168,3 +1168,15 @@ def test_daemon_stop_subcommand_parses_all_and_project() -> None:
     import pytest as _pt
     with _pt.raises(SystemExit):
         build_parser().parse_args(["daemon", "stop", "--all", "--project", "/tmp/x"])
+
+
+def test_daemon_start_idle_timeout_flag_parses() -> None:
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["daemon", "start", "--idle-timeout", "30m"])
+    assert ns.idle_timeout == "30m"
+
+
+def test_daemon_start_idle_timeout_default_is_zero() -> None:
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["daemon", "start"])
+    assert ns.idle_timeout == "0"

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -1173,26 +1173,19 @@ def test_start_with_port_zero_writes_actual_port(
 def test_start_registers_in_global_registry(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """start() 成功后必须写全局注册表；stop() 必须清除注册记录。
+    """start() 成功后必须写全局注册表 JSON；stop() 必须删除该 JSON。
 
-    _FakeProc.pid = 999_999_900 是假 PID，不是真实进程，所以 registry.list_all()
-    的存活探测会把它剔除。需要 patch registry._process_alive 让它认为该 PID 活着，
-    才能验证注册表写入；stop 结束时再恢复默认，确认 unregister 被调用。
+    直接断言 registry 目录下的文件存在 / 不存在，比走 list_all() 更严：
+    list_all() 自带死 PID 剪枝，会让"忘记 unregister"的 bug 偷偷过去。
     """
     from godot_cli_control import registry
 
     monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
-    # 让 registry.list_all 认为假 PID 是活进程
-    monkeypatch.setattr(registry, "_process_alive", lambda pid: True)
-
     daemon, _ = _setup_start_env(tmp_path, monkeypatch)
+    record_file = tmp_path / "reg" / f"{registry.project_hash(tmp_path)}.json"
+
     daemon.start(port=0)
+    assert record_file.exists(), "start() 后注册表 JSON 应存在"
 
-    records = registry.list_all()
-    assert len(records) == 1
-    assert records[0].pid > 0  # _FakeProc.pid = 999_999_900
-
-    # 恢复真实 _process_alive，stop 读到死 PID → 走死 PID 自愈分支 → unregister
-    monkeypatch.setattr(registry, "_process_alive", lambda pid: False)
     daemon.stop()
-    assert registry.list_all() == []
+    assert not record_file.exists(), "stop() 后注册表 JSON 应被 unregister 删掉"

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -1170,6 +1170,92 @@ def test_start_with_port_zero_writes_actual_port(
     assert 1024 < written < 65536
 
 
+def test_start_passes_idle_timeout_to_popen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """daemon.start(idle_timeout=10) 必须把 --game-bridge-idle-timeout=10 加到 Popen argv。"""
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "fake_godot"
+    fake_bin.write_text("")
+    fake_bin.chmod(0o755)
+
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        pid = 999_999_010
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+    def _record_popen(args: list[str], **kwargs: Any) -> _FakeProc:
+        captured["args"] = args
+        return _FakeProc()
+
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: str(fake_bin)
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._ensure_imported", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.subprocess.Popen", _record_popen
+    )
+    monkeypatch.setattr("godot_cli_control.daemon.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
+    )
+    from godot_cli_control import registry as _reg
+    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
+
+    daemon = Daemon(tmp_path)
+    daemon.start(port=0, idle_timeout=10)
+    assert any(a == "--game-bridge-idle-timeout=10" for a in captured["args"])
+
+
+def test_start_omits_idle_timeout_when_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """idle_timeout=0 (默认) 时 argv 里不该有该 flag —— 保持旧行为。"""
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "fake_godot"
+    fake_bin.write_text("")
+    fake_bin.chmod(0o755)
+
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        pid = 999_999_020
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+    def _record_popen(args: list[str], **kwargs: Any) -> _FakeProc:
+        captured["args"] = args
+        return _FakeProc()
+
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: str(fake_bin)
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._ensure_imported", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.subprocess.Popen", _record_popen
+    )
+    monkeypatch.setattr("godot_cli_control.daemon.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
+    )
+    from godot_cli_control import registry as _reg
+    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
+
+    daemon = Daemon(tmp_path)
+    daemon.start(port=0)  # 不传 idle_timeout 用默认
+    assert not any(a.startswith("--game-bridge-idle-timeout=") for a in captured["args"])
+
+
 def test_start_registers_in_global_registry(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -734,6 +734,54 @@ def test_process_alive_negative_pid_is_dead() -> None:
 # ── start 校验 godot_bin 可执行 ──
 
 
+def test_start_rejects_when_port_already_in_use(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """端口已被别的进程监听 → daemon.start 立刻报错，不 spawn Godot。
+
+    场景（issue #?）：旧 daemon 没 stop 干净 / 别的服务占了同端口。GameBridge
+    listen 失败时只 printerr 不退进程，daemon 这头 create_connection 又会
+    握手到错的进程上误报启动成功，后续 RPC 全打错。spawn 前先 bind 校验
+    端口空闲，被占就直接报「port N already in use」。
+    """
+    import socket as _socket
+
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "fake_godot"
+    fake_bin.write_text("")
+    fake_bin.chmod(0o755)
+
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: str(fake_bin)
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._ensure_imported", lambda *a, **k: None
+    )
+    popen_called: list = []
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.subprocess.Popen",
+        lambda *a, **k: popen_called.append(a) or (_ for _ in ()).throw(
+            AssertionError("Popen 不该被调用 —— 端口校验应在此之前失败")
+        ),
+    )
+
+    sock = _socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    busy_port = sock.getsockname()[1]
+    try:
+        daemon = Daemon(tmp_path)
+        with pytest.raises(DaemonError, match="in use"):
+            daemon.start(port=busy_port)
+    finally:
+        sock.close()
+
+    assert popen_called == [], "端口被占时不应 spawn Godot"
+    # 失败时不该污染 .cli_control 状态
+    assert not daemon.pid_file.exists()
+    assert not daemon.port_file.exists()
+
+
 def test_start_rejects_non_executable_godot_bin(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -747,3 +748,218 @@ def test_start_rejects_non_executable_godot_bin(
     daemon = Daemon(tmp_path)
     with pytest.raises(DaemonError, match="not executable"):
         daemon.start()
+
+
+# ---------------------------------------------------------------------------
+# issue #38：godot stdout/stderr 捕获 + 启动失败时输出 log tail
+# ---------------------------------------------------------------------------
+
+
+def test_start_redirects_godot_output_to_log_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Popen 必须把 stdout 指向 godot.log、stderr 合并 —— 用户事后能 cat 日志。"""
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "fake_godot"
+    fake_bin.write_text("")
+    fake_bin.chmod(0o755)
+
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        pid = 999_999_500
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+    def _record_popen(args: list[str], **kwargs: Any) -> _FakeProc:
+        captured["kwargs"] = kwargs
+        # 模拟 Godot 写一行到日志再继续 —— 验证 fh 是真的 writable。
+        kwargs["stdout"].write(b"hello from godot\n")
+        return _FakeProc()
+
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: str(fake_bin)
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._ensure_imported", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.subprocess.Popen", _record_popen
+    )
+    monkeypatch.setattr("godot_cli_control.daemon.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
+    )
+
+    daemon = Daemon(tmp_path)
+    daemon.start(port=29900)
+
+    # 1) Popen 拿到的 stdout 是文件、stderr 合并到 stdout
+    assert captured["kwargs"]["stderr"] == subprocess.STDOUT
+    # 2) 文件写在约定位置
+    assert daemon.log_file.exists()
+    assert daemon.log_file.read_bytes() == b"hello from godot\n"
+
+
+def test_start_immediate_crash_includes_log_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """1s poll 抓到立即崩溃 → DaemonError 必须把 godot.log 末尾贴出来。
+
+    issue #38：之前只报 "exited immediately (returncode=N)"，用户还得手动
+    `cat .cli_control/godot.log`。现在直接拼到 message 里。
+    """
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "fake_godot"
+    fake_bin.write_text("")
+    fake_bin.chmod(0o755)
+
+    class _DeadProc:
+        pid = 999_999_400
+        returncode = 1
+
+        def poll(self) -> int:
+            return 1
+
+    def _spew_log(args: list[str], **kwargs: Any) -> _DeadProc:
+        kwargs["stdout"].write(
+            b"GODOT FATAL: autoload script not found at res://main.gd\n"
+        )
+        return _DeadProc()
+
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: str(fake_bin)
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._ensure_imported", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.subprocess.Popen", _spew_log
+    )
+    monkeypatch.setattr("godot_cli_control.daemon.time.sleep", lambda *_: None)
+
+    daemon = Daemon(tmp_path)
+    with pytest.raises(DaemonError, match="autoload script not found") as ei:
+        daemon.start(port=29901)
+    assert "exited immediately" in str(ei.value)
+    # log 文件保留供事后查阅
+    assert daemon.log_file.exists()
+
+
+def test_start_detects_crash_during_port_wait(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """端口探活期间 Godot 自死 → 报「exited during launch」+ log tail，
+    不再误报「GameBridge not ready within 30s」让用户怀疑端口冲突。"""
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "fake_godot"
+    fake_bin.write_text("")
+    fake_bin.chmod(0o755)
+
+    # 首次 poll() 返回 None（1s 存活检查通过），之后变非 None（探活时崩溃）。
+    class _LateCrashProc:
+        pid = 999_999_300
+        returncode = 11
+        _polls = 0
+
+        def poll(self) -> int | None:
+            self._polls += 1
+            return None if self._polls == 1 else 11
+
+    def _make_proc(args: list[str], **kwargs: Any) -> _LateCrashProc:
+        kwargs["stdout"].write(b"ERROR: scene main.tscn referenced missing res\n")
+        return _LateCrashProc()
+
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: str(fake_bin)
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._ensure_imported", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.subprocess.Popen", _make_proc
+    )
+    monkeypatch.setattr("godot_cli_control.daemon.time.sleep", lambda *_: None)
+    monkeypatch.setattr(Daemon, "_terminate", lambda self, pid, **kw: None)
+
+    daemon = Daemon(tmp_path)
+    with pytest.raises(DaemonError, match="exited during launch") as ei:
+        daemon.start(port=29902, wait_seconds=2)
+    assert "scene main.tscn" in str(ei.value)
+
+
+def test_start_port_timeout_includes_log_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Godot 仍在跑但 GameBridge 超时未就绪 → message 也带 log tail，便于诊断
+    （比如 GameBridge autoload 没启用、端口被占等情况）。"""
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "fake_godot"
+    fake_bin.write_text("")
+    fake_bin.chmod(0o755)
+
+    class _LiveProc:
+        pid = 999_999_200
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+    def _make_proc(args: list[str], **kwargs: Any) -> _LiveProc:
+        # 通过子进程的 stdout fh 写日志：这样可以躲过 start() 自己的 truncate。
+        kwargs["stdout"].write(b"WARN: no GameBridge autoload registered\n")
+        return _LiveProc()
+
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: str(fake_bin)
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._ensure_imported", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.subprocess.Popen", _make_proc
+    )
+    monkeypatch.setattr("godot_cli_control.daemon.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: False
+    )
+    monkeypatch.setattr(Daemon, "_terminate", lambda self, pid, **kw: None)
+
+    daemon = Daemon(tmp_path)
+    with pytest.raises(DaemonError, match="not ready") as ei:
+        daemon.start(port=29903, wait_seconds=1)
+    assert "no GameBridge autoload registered" in str(ei.value)
+
+
+def test_format_log_tail_truncates_long_logs(tmp_path: Path) -> None:
+    daemon = Daemon(tmp_path)
+    daemon.control_dir.mkdir(parents=True, exist_ok=True)
+    daemon.log_file.write_text("\n".join(f"line{i}" for i in range(100)))
+    out = daemon._format_log_tail(n=5)
+    assert "line99" in out
+    assert "line95" in out
+    assert "line0" not in out, "末尾 5 行不应该包含开头"
+    assert out.startswith("Godot 日志（")
+
+
+def test_format_log_tail_handles_missing_log(tmp_path: Path) -> None:
+    daemon = Daemon(tmp_path)
+    out = daemon._format_log_tail()
+    assert "log unavailable" in out
+
+
+def test_wait_port_ready_returns_false_when_proc_died(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """端口未开 + proc.poll() 已返回非 None → 立刻 False，不再等到 deadline。"""
+    class _DeadProc:
+        def poll(self) -> int:
+            return 137
+
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.time.sleep", lambda *_: None
+    )
+    # 必须秒返：max_seconds=10 但因 proc 死了第一轮就跳出
+    assert _wait_port_ready(port=1, max_seconds=10, proc=_DeadProc()) is False

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -1141,3 +1141,14 @@ def test_read_last_exit_code_handles_garbage(tmp_path: Path) -> None:
 def test_read_last_exit_code_none_when_missing(tmp_path: Path) -> None:
     daemon = Daemon(tmp_path)
     assert daemon.read_last_exit_code() is None
+
+
+def test_start_with_port_zero_writes_actual_port(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """port=0 时 .cli_control/port 落盘的应是 OS 分配的实际端口，不是 0。"""
+    daemon, _ = _setup_start_env(tmp_path, monkeypatch)
+    daemon.start(port=0)
+    written = int(daemon.port_file.read_text().strip())
+    assert written != 0
+    assert 1024 < written < 65536

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -12,6 +12,7 @@ import pytest
 from godot_cli_control.daemon import (
     Daemon,
     DaemonError,
+    _allocate_port,
     _process_alive,
     _wait_port_ready,
 )
@@ -663,6 +664,33 @@ def test_ensure_imported_rebuilds_when_cache_missing(
     )
     _ensure_imported(tmp_path, "/fake/godot")
     assert called == [(tmp_path, "/fake/godot")]
+
+
+# ── _allocate_port ──
+
+
+def test_allocate_port_zero_returns_os_assigned() -> None:
+    port = _allocate_port(0)
+    assert 1024 < port < 65536
+
+
+def test_allocate_port_specific_returns_same() -> None:
+    # Get a free port from the OS, release it, then ask for that exact port
+    free = _allocate_port(0)
+    assert _allocate_port(free) == free
+
+
+def test_allocate_port_raises_when_occupied() -> None:
+    import socket as _s
+    sock = _s.socket(_s.AF_INET, _s.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    occupied = sock.getsockname()[1]
+    try:
+        with pytest.raises(DaemonError, match="already in use"):
+            _allocate_port(occupied)
+    finally:
+        sock.close()
 
 
 # ── stop 后录制转码失败 → 返回 2 ──

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -823,6 +824,11 @@ def test_start_rejects_when_port_already_in_use(
     assert not daemon.port_file.exists()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows 没有 X 权限位，os.access(X_OK) 对任意存在的文件都返回 True；"
+    "可执行性需靠扩展名 / Win32 PE 头判定，是单独的功能点（见 issue），与本用例无关。",
+)
 def test_start_rejects_non_executable_godot_bin(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -963,3 +963,105 @@ def test_wait_port_ready_returns_false_when_proc_died(
     )
     # 必须秒返：max_seconds=10 但因 proc 死了第一轮就跳出
     assert _wait_port_ready(port=1, max_seconds=10, proc=_DeadProc()) is False
+
+
+# ── last_exit_code 持久化 ──
+
+
+def test_start_records_exit_code_on_immediate_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """1s poll 抓到崩溃 → returncode 必须落盘到 last_exit_code 文件。"""
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "fake_godot"
+    fake_bin.write_text("")
+    fake_bin.chmod(0o755)
+
+    class _DeadProc:
+        pid = 999_999_100
+        returncode = 137
+
+        def poll(self) -> int:
+            return 137
+
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: str(fake_bin)
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._ensure_imported", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.subprocess.Popen",
+        lambda *a, **k: _DeadProc(),
+    )
+    monkeypatch.setattr("godot_cli_control.daemon.time.sleep", lambda *_: None)
+
+    daemon = Daemon(tmp_path)
+    with pytest.raises(DaemonError, match="exited immediately"):
+        daemon.start(port=29904)
+    assert daemon.read_last_exit_code() == 137
+
+
+def test_start_records_exit_code_on_port_wait_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """探活期间 Godot 自死 → returncode 也必须落盘。"""
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "fake_godot"
+    fake_bin.write_text("")
+    fake_bin.chmod(0o755)
+
+    class _LateCrashProc:
+        pid = 999_999_050
+        _polls = 0
+
+        def poll(self) -> int | None:
+            self._polls += 1
+            return None if self._polls == 1 else 11
+
+        @property
+        def returncode(self) -> int | None:
+            return None if self._polls == 0 else 11
+
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: str(fake_bin)
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._ensure_imported", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.subprocess.Popen",
+        lambda *a, **k: _LateCrashProc(),
+    )
+    monkeypatch.setattr("godot_cli_control.daemon.time.sleep", lambda *_: None)
+    monkeypatch.setattr(Daemon, "_terminate", lambda self, pid, **kw: None)
+
+    daemon = Daemon(tmp_path)
+    with pytest.raises(DaemonError, match="exited during launch"):
+        daemon.start(port=29905, wait_seconds=2)
+    assert daemon.read_last_exit_code() == 11
+
+
+def test_start_clears_stale_exit_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """新一轮 start 必须清掉上次的 last_exit_code，否则 status 永远显示陈旧值。"""
+    daemon, _ = _setup_start_env(tmp_path, monkeypatch)
+    daemon.control_dir.mkdir(parents=True, exist_ok=True)
+    daemon.exit_code_file.write_text("99")  # 上一轮残留
+
+    daemon.start(port=29906)
+    assert daemon.read_last_exit_code() is None, \
+        "新一轮 start 必须 invalidate 旧 exit code"
+
+
+def test_read_last_exit_code_handles_garbage(tmp_path: Path) -> None:
+    daemon = Daemon(tmp_path)
+    daemon.control_dir.mkdir()
+    daemon.exit_code_file.write_text("not a number")
+    assert daemon.read_last_exit_code() is None
+
+
+def test_read_last_exit_code_none_when_missing(tmp_path: Path) -> None:
+    daemon = Daemon(tmp_path)
+    assert daemon.read_last_exit_code() is None

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -224,6 +224,9 @@ def test_start_detaches_subprocess_signal_group(
     monkeypatch.setattr(
         "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
     )
+    # 隔离全局注册表
+    from godot_cli_control import registry as _reg
+    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
 
     daemon.start(port=29998)
 
@@ -310,7 +313,11 @@ def test_wait_port_ready_returns_true_when_listening() -> None:
 def _setup_start_env(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, port_ready: bool = True
 ) -> tuple[Daemon, Path]:
-    """返回 (daemon, fake_bin)。已 patch find_godot_binary、_ensure_imported、Popen、sleep、_wait_port_ready。"""
+    """返回 (daemon, fake_bin)。已 patch find_godot_binary、_ensure_imported、Popen、sleep、_wait_port_ready。
+
+    同时把 registry._REGISTRY_DIR 重定向到 tmp_path/reg，避免成功 start()
+    的测试污染真实 ~/.local/state/godot-cli-control/daemons/。
+    """
     _touch_godot_project(tmp_path)
     fake_bin = tmp_path / "fake_godot"
     fake_bin.write_text("")
@@ -337,6 +344,9 @@ def _setup_start_env(
         "godot_cli_control.daemon._wait_port_ready",
         lambda *a, **k: port_ready,
     )
+    # 隔离全局注册表：把写入重定向到临时目录，避免污染 ~/.local/state/…
+    from godot_cli_control import registry as _reg
+    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
     return Daemon(tmp_path), fake_bin
 
 
@@ -595,6 +605,9 @@ def test_start_record_writes_movie_path_file_and_args(
     monkeypatch.setattr(
         "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
     )
+    # 隔离全局注册表
+    from godot_cli_control import registry as _reg
+    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
 
     daemon = Daemon(tmp_path)
     movie = tmp_path / "rec.avi"
@@ -868,6 +881,9 @@ def test_start_redirects_godot_output_to_log_file(
     monkeypatch.setattr(
         "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
     )
+    # 隔离全局注册表
+    from godot_cli_control import registry as _reg
+    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
 
     daemon = Daemon(tmp_path)
     daemon.start(port=29900)
@@ -1152,3 +1168,31 @@ def test_start_with_port_zero_writes_actual_port(
     written = int(daemon.port_file.read_text().strip())
     assert written != 0
     assert 1024 < written < 65536
+
+
+def test_start_registers_in_global_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """start() 成功后必须写全局注册表；stop() 必须清除注册记录。
+
+    _FakeProc.pid = 999_999_900 是假 PID，不是真实进程，所以 registry.list_all()
+    的存活探测会把它剔除。需要 patch registry._process_alive 让它认为该 PID 活着，
+    才能验证注册表写入；stop 结束时再恢复默认，确认 unregister 被调用。
+    """
+    from godot_cli_control import registry
+
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+    # 让 registry.list_all 认为假 PID 是活进程
+    monkeypatch.setattr(registry, "_process_alive", lambda pid: True)
+
+    daemon, _ = _setup_start_env(tmp_path, monkeypatch)
+    daemon.start(port=0)
+
+    records = registry.list_all()
+    assert len(records) == 1
+    assert records[0].pid > 0  # _FakeProc.pid = 999_999_900
+
+    # 恢复真实 _process_alive，stop 读到死 PID → 走死 PID 自愈分支 → unregister
+    monkeypatch.setattr(registry, "_process_alive", lambda pid: False)
+    daemon.stop()
+    assert registry.list_all() == []

--- a/python/tests/test_duration.py
+++ b/python/tests/test_duration.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from godot_cli_control._duration import parse_duration
+
+
+def test_parse_seconds() -> None:
+    assert parse_duration("30s") == 30
+
+def test_parse_minutes() -> None:
+    assert parse_duration("30m") == 1800
+
+def test_parse_hours() -> None:
+    assert parse_duration("2h") == 7200
+
+def test_parse_zero_is_zero() -> None:
+    assert parse_duration("0") == 0
+
+def test_parse_bare_int_means_seconds() -> None:
+    assert parse_duration("90") == 90
+
+def test_parse_invalid_raises() -> None:
+    with pytest.raises(ValueError, match="invalid duration"):
+        parse_duration("two minutes")

--- a/python/tests/test_duration.py
+++ b/python/tests/test_duration.py
@@ -23,3 +23,14 @@ def test_parse_bare_int_means_seconds() -> None:
 def test_parse_invalid_raises() -> None:
     with pytest.raises(ValueError, match="invalid duration"):
         parse_duration("two minutes")
+
+
+def test_parse_rejects_internal_whitespace() -> None:
+    # 与帮助文本保持一致：30m 合法、"30 m" 不合法
+    with pytest.raises(ValueError, match="invalid duration"):
+        parse_duration("30 m")
+
+
+def test_parse_allows_outer_whitespace() -> None:
+    # shell 复制粘贴带尾换行/前导空格仍要 work
+    assert parse_duration("  30m\n") == 1800

--- a/python/tests/test_pytest_plugin.py
+++ b/python/tests/test_pytest_plugin.py
@@ -301,7 +301,11 @@ def test_project_root_option_is_respected(pytester: pytest.Pytester) -> None:
         plugin.GameBridge = FakeBridge
 
         def pytest_terminal_summary(terminalreporter, exitstatus, config):
-            terminalreporter.write_line(f"SEEN_ROOTS={SEEN_ROOTS}")
+            # 用 str() 逐条打印 —— 列表的 repr 在 Windows 上是
+            # repr(WindowsPath(...)) 用正斜杠，str(WindowsPath) 用反斜杠，
+            # 测试若直接 in 整个列表 repr 会 mismatch。
+            for p in SEEN_ROOTS:
+                terminalreporter.write_line(f"SEEN_ROOT={p}")
         """
     )
     pytester.makepyfile("def test_x(bridge): pass")

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -64,3 +64,11 @@ def test_project_hash_stable(tmp_path: Path) -> None:
     h1 = registry.project_hash(p)
     h2 = registry.project_hash(p)
     assert h1 == h2 and len(h1) == 12
+
+
+def test_process_alive_branches() -> None:
+    """直接覆盖 _process_alive 四个分支，避免未来 'simplify' 误改 PermissionError 含义。"""
+    assert registry._process_alive(0) is False
+    assert registry._process_alive(-1) is False
+    assert registry._process_alive(os.getpid()) is True
+    assert registry._process_alive(2_000_000) is False

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -1,0 +1,66 @@
+"""Global daemon registry tests — 不实际起 Godot，只验状态文件 + 探活逻辑。"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from godot_cli_control import registry
+
+
+@pytest.fixture
+def reg_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "registry")
+    return tmp_path / "registry"
+
+
+def test_register_creates_record(reg_dir: Path, tmp_path: Path) -> None:
+    proj = tmp_path / "p1"
+    proj.mkdir()
+    registry.register(proj, pid=os.getpid(), port=12345, godot_bin="/x/godot",
+                      log_path=str(proj / ".cli_control/godot.log"))
+    records = registry.list_all()
+    assert len(records) == 1
+    r = records[0]
+    assert r.pid == os.getpid()
+    assert r.port == 12345
+    assert Path(r.project_root) == proj.resolve()
+
+
+def test_unregister_removes_record(reg_dir: Path, tmp_path: Path) -> None:
+    proj = tmp_path / "p1"; proj.mkdir()
+    registry.register(proj, pid=os.getpid(), port=1, godot_bin="x", log_path="x")
+    registry.unregister(proj)
+    assert registry.list_all() == []
+
+
+def test_list_all_prunes_dead_pids(reg_dir: Path, tmp_path: Path) -> None:
+    proj = tmp_path / "p1"; proj.mkdir()
+    # PID 1 几乎不会是当前用户的 Godot；用一个肯定死的高位 PID
+    registry.register(proj, pid=2_000_000, port=1, godot_bin="x", log_path="x")
+    assert registry.list_all() == []  # 探活后死记录被清掉
+    # 注册表文件也应被删
+    assert not list(reg_dir.glob("*.json"))
+
+
+def test_list_all_also_cleans_project_state_for_dead(
+    reg_dir: Path, tmp_path: Path
+) -> None:
+    proj = tmp_path / "p1"; proj.mkdir()
+    ctrl = proj / ".cli_control"
+    ctrl.mkdir()
+    (ctrl / "godot.pid").write_text("2000000")
+    (ctrl / "port").write_text("12345")
+    registry.register(proj, pid=2_000_000, port=12345, godot_bin="x",
+                      log_path=str(ctrl / "godot.log"))
+    registry.list_all()
+    assert not (ctrl / "godot.pid").exists()
+    assert not (ctrl / "port").exists()
+
+
+def test_project_hash_stable(tmp_path: Path) -> None:
+    p = tmp_path / "p"; p.mkdir()
+    h1 = registry.project_hash(p)
+    h2 = registry.project_hash(p)
+    assert h1 == h2 and len(h1) == 12


### PR DESCRIPTION
## Summary

修复 issue #38：`daemon start` 报「已启动」但 Godot 几秒内静默退出时，没有任何日志可查的体感问题。

- **stdout/stderr 落盘**：daemon 启动 Godot 时把 `stdout` / `stderr` 重定向到 `.cli_control/godot.log`（每次 start 时 truncate，对应「最近一次启动」）
- **启动失败立刻带 log tail**：1s immediate-crash 与 GameBridge port-wait 两条失败路径都在 `DaemonError.message` 拼上日志末 30 行；`_wait_port_ready()` 新增 `proc` 参数，期间 Godot 自死立刻 break，不让用户干等剩下的 30s
- **状态文件落盘退出码**：start 检测到崩溃时把 `returncode` 写到 `.cli_control/last_exit_code`；新一轮 start 在清掉日志的同时 invalidate
- **`daemon status` stopped 时报诊断信息**：JSON 加 `last_log` + `last_exit_code` 字段；text 输出「`stopped (last exit: 137, see .cli_control/godot.log)`」

## Test plan

- [x] `uv run pytest`（241 passed）
- [x] `uv run coverage run -m pytest && uv run coverage report --fail-under=80`（81% TOTAL，门禁通过）
- [x] 新增 12 例单测覆盖：log 重定向 / 立即崩溃 tail / 探活期崩溃 / 探活超时 tail / `_format_log_tail` 截断与缺失 / `_wait_port_ready` proc 早退 / `last_exit_code` 写入 + 清理 + 解析容错 / `daemon status` JSON 与 text 模式的 last_log + last_exit_code 字段

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)