### PR TITLE
fix: AI 友好性 review 7 项修复 (1004 撞码 / argparse / headless 等)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# godot-cli-control —— Claude / AI agent 工作指引
+
+## 核心原则：这是一个「AI 友好型 CLI」
+
+本项目的设计目标是**让 AI agent 能仅通过 shell 子命令驱动一个运行中的 Godot 4 项目**——
+点节点、读写属性、模拟输入、截图、录像、查场景树、跑断言。
+
+「AI 友好」不是 README 用语，而是贯穿源码的契约。**任何新增 / 修改 / 重构必须先回到这条主线**：
+
+> *如果一个 LLM 只能 shell 出去执行一条命令、并且只能解析单行 JSON，它能否搞清楚下一步该做什么？*
+
+### 必须保住的契约（破了它就破了 AI 友好性）
+
+1. **JSON 信封默认开**
+   - 成功 ：`{"ok": true, "result": <data>}` 单行 stdout，exit 由命令语义决定
+   - 失败 ：`{"ok": false, "error": {"code": <int>, "message": "..."}}` 单行 stdout
+   - 任何异常都必须落进信封，不允许 traceback 漏到 stdout（traceback 走 stderr 给人看）。
+   - `--text` / `--no-json` 是 legacy 旁路，不能反过来变默认。
+   - 实现锚点：`python/godot_cli_control/cli.py` 的 `_emit_*_payload` / `_run_rpc`。
+
+2. **错误码三段制，不允许撞码**
+   - 服务端（GDScript LowLevelApi）：正整数 `1xxx`（业务）+ `-32xxx`（JSON-RPC 标准）
+   - 客户端（Python CLI）：`-1xxx`
+   - 三段互不重叠，单 `code` 字段无歧义。新增码前先查 `SKILL.md` 错误码表 + `low_level_api.gd` 常量。
+   - **现在已知 1004 在「combo 进行中」与「scene tree too large」两处冲突**——见下方"已知遗留 issue"。新加业务码请避开这个坑。
+
+3. **退出码语义化**
+   - 0 = 成功 / 布尔 true / 节点存在 / wait 命中
+   - 1 = RPC 错（含 `exists`/`visible`=false、`wait-node` timeout、`daemon status` stopped）
+   - 2 = 连接 / IO / 用法错（agent 应该 retry 或修参数，而不是把它当 RPC 失败）
+   - 64 = argparse 用法错
+   - 3 = `daemon stop --all` 部分失败（专用，避免与 2 撞）
+   - shell `if godot-cli-control exists /root/Foo; then …` 必须能用。
+
+4. **shell 是 canonical surface**
+   - 每个 RPC 都必须有对应 CLI 子命令，参数是位置形式 + JSON 字面量（避免引号嵌套地狱）。
+   - `def run(bridge):` 脚本是次选，仅用于"必须保持单连接跨多步"的场景。
+   - 新加 RPC 的标准流程：
+     1. `client.py` 加 async 方法
+     2. `bridge.py` 加同步包装
+     3. `cli.py` 加 `RpcSpec` + handler + 文本格式化（`text_formatter`）+ 必要时 `preflight` / `exit_code_from`
+     4. `addons/.../low_level_api.gd` 或 `input_simulation_api.gd` 加 RPC handler
+     5. 更新 `SKILL.md`（模板在 `python/godot_cli_control/templates/skill/SKILL.md`）+ addon `README.md` 错误码 / 命令表
+
+5. **preflight 优先于网络往返**
+   - 用户 / agent 用法错（如 `combo` 没传 steps）必须在连 daemon **之前**报错，
+     不能让 agent 干等 30s connection retry 才知道自己参数写错了。
+   - 实现锚点：`RpcSpec.preflight` + `cli.py:_preflight_combo`。
+
+6. **不让大 payload 撑爆 agent 上下文**
+   - `screenshot` 强制写文件路径，禁止 base64 灌 stdout。
+   - `tree` / `children` 默认深度有上限；超大场景要有 truncate 信号。
+   - 新加返回大数据的 RPC 要先想清楚 trim 策略。
+
+7. **SKILL.md 是 AI agent 的入口，必须随 CLI 同步**
+   - `init` 命令会把 `python/godot_cli_control/templates/skill/SKILL.md` 渲染（注入 `{{cli_help}}` + `{{version}}`）后写到目标 Godot 项目的 `.claude/skills/godot-cli-control/SKILL.md` 与 `.codex/skills/.../SKILL.md`。
+   - **改 CLI 子命令、改错误码、改默认行为时，SKILL.md 必须一起改**。错误码表、退出码表、JSON 信封示例、common pitfalls 是 agent 唯一能看到的 ground truth。
+   - 改完跑一次 `python -c "from godot_cli_control import cli; print(cli.format_full_help())"` 检查渲染没崩。
+
+8. **localhost-only / blacklist 安全网不能为了"方便"放掉**
+   - GameBridge 永远 listen `127.0.0.1`；release build 必须自动 disable。
+   - method/property blacklist 是防 RCE 的最后一道，不能让单条新功能的 PR 把它松开。第三方项目要扩需求请走 `godot_cli_control/method_blacklist_extra` ProjectSettings 走"增量"路径。
+
+## Repo layout 速查
+
+```
+addons/godot_cli_control/   # Godot 4 GDScript 插件 + GUT 测试
+python/godot_cli_control/   # Python CLI / GameClient (async) / GameBridge (sync) / pytest plugin / SKILL.md 模板
+python/tests/               # pytest 套件（pytest-asyncio）
+docs/                       # 设计文档
+release.sh                  # 发版脚本
+```
+
+依赖：`websockets>=14,<16`，Python ≥ 3.10。覆盖率门槛 80%（`pyproject.toml [tool.coverage.report] fail_under=80`）。
+
+## 测试 & 覆盖率
+
+- 测试不能用 `pytest --cov` 跑，必须 `coverage run -m pytest`。原因写在 `pyproject.toml` 的注释里：pytest11 entry-point 在 pytest 启动时 import 包，pytest-cov 上得太晚会 miss 掉 import-time 语句。
+- 跑测试遵循全局规则：**用 subagent 委托执行（指定 `model: "sonnet"`），主会话只接收精简结论**，避免大量 pytest 输出污染上下文。
+- GDScript 那侧的单测走 `./addons/godot_cli_control/tests/run_gut.sh`，需要 `GODOT_BIN`。
+
+## 发版 / CI
+
+- 版本由 `hatch-vcs` 从 git tag 派生，写到 `python/godot_cli_control/_version.py`。
+- 改 SKILL.md 模板后想验证 `init` 注入正确：跑 `pytest python/tests/test_skills_install.py`。
+
+## 已知遗留 issue（PR 路过时顺手修）
+
+*（截至 2026-05-11，AI 友好性 review 列出的 7 项已全部 land。下次 review 发现新坑请补到这里。）*

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -44,6 +44,21 @@
 #### Out of scope (intentional)
 - `run <script.py>` 子命令保留旧的人类可读 stderr 输出。它是交互式脚本宿主，不是 RPC，新的 JSON 信封契约只覆盖 RPC 子命令 + daemon 三命令。
 
+### AI-friendliness review fixes (2026-05-11)
+
+#### Fixed
+- **CLI flag position**: `--json` / `--text` / `--no-json` 现在在 RPC 子命令尾部也接受（之前只能写最前面）。argparse 子 parser 用 `default=argparse.SUPPRESS` + 顶层 `set_defaults` 兜底，避免子 parser 默认值覆盖父 parser 解析结果。
+- **Error code 1004 collision**: `low_level_api.gd` 的 scene tree 超限改用新业务码 `1005 "scene tree too large"`，与 input_simulation `1004 "combo in progress"` 解耦。新增 `error_codes.gd` 集中常量。
+- **pytest fixture default port**: `--godot-cli-port` 默认从 9877 改为 0（OS-assigned），与 `daemon start` 默认对齐；多项目并行测试不再撞端口。
+- **Addon README error-code table**: 之前只列到 1003，补全 1004 / 1005 / 客户端 -1xxx 段。
+
+#### Added
+- `tree --max-nodes <N>`（默认 200）：节点数软上限；超出时响应含 `truncated: true` + `total_nodes`，agent 据此决定分子树。硬墙仍是 5000 节点 → `1005`。
+- `set` / `call --text-value`：禁用 JSON 解析、把 value/args 强制按字符串处理，避开 `null` / `true` / `42` 这类字面量被解析成 Variant 类型的 footgun。
+
+#### Changed
+- **BREAKING (轻微)**：`daemon start` / `run` 默认 headless 行为改为基于 `sys.stdout.isatty()` 自动判定 —— pipe / CI / agent shell 默认 headless；交互终端默认开窗。新增 `--gui` 强制开窗 flag。`--headless` 仍可显式传，覆盖自动判。脚本里依赖 "默认会开窗" 的需要加 `--gui`。
+
 ## [0.1.6] - Unreleased
 
 ### Added

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -51,6 +51,8 @@
 - **Error code 1004 collision**: `low_level_api.gd` 的 scene tree 超限改用新业务码 `1005 "scene tree too large"`，与 input_simulation `1004 "combo in progress"` 解耦。新增 `error_codes.gd` 集中常量。
 - **pytest fixture default port**: `--godot-cli-port` 默认从 9877 改为 0（OS-assigned），与 `daemon start` 默认对齐；多项目并行测试不再撞端口。
 - **Addon README error-code table**: 之前只列到 1003，补全 1004 / 1005 / 客户端 -1xxx 段。
+- **Scene tree hard limit bypass (DoS fix)**: `handle_get_scene_tree` 入口现在把 `max_nodes` clamp 到硬墙 `_BUILD_TREE_NODE_LIMIT` (5000)。修复前客户端传 `max_nodes=999999` 会让服务端先把整棵超大树构造成 Dictionary 再被 1005 错误丢弃（内存浪费 / OOM 路径）。
+- **Error code 1003 semantic split**: screenshot 在 viewport texture 为 null 时不再借用 `1003 METHOD_NOT_FOUND`，改用新业务码 `1006 RESOURCE_UNAVAILABLE`。1003 现在是纯 schema 错（不应 retry），1006 是 transient 错（短重试可能成功），agent 据此分别处置。
 
 #### Added
 - `tree --max-nodes <N>`（默认 200）：节点数软上限；超出时响应含 `truncated: true` + `total_nodes`，agent 据此决定分子树。硬墙仍是 5000 节点 → `1005`。

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -107,9 +107,10 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 |---|---|---|
 | `1001` | server | Node not found at the given path |
 | `1002` | server | Property not found / shape mismatch |
-| `1003` | server | Method not found / render unavailable |
+| `1003` | server | Method not found on the node (schema error, don't retry) |
 | `1004` | server | Combo already in progress (call `combo-cancel` to retry) |
 | `1005` | server | Scene tree too large (lower `depth` or pass `--max-nodes`) |
+| `1006` | server | Resource transiently unavailable (e.g. screenshot before viewport ready) — safe to retry |
 | `-32600` | server | Malformed JSON-RPC request |
 | `-32601` | server | Unknown method name |
 | `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist) |

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -99,7 +99,27 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 | `combo_cancel()` | `await client.combo_cancel()` |
 | `release_all()` | `await client.release_all()` |
 
-Error codes: `-32600` invalid request, `-32601` unknown method, `-32602` invalid params, `1001` node not found, `1002` property not found, `1003` method not found.
+### Error codes
+
+Three numeric ranges share `error.code`; they never overlap, so a single field is unambiguous.
+
+| Code | Source | Meaning |
+|---|---|---|
+| `1001` | server | Node not found at the given path |
+| `1002` | server | Property not found / shape mismatch |
+| `1003` | server | Method not found / render unavailable |
+| `1004` | server | Combo already in progress (call `combo-cancel` to retry) |
+| `1005` | server | Scene tree too large (lower `depth` or pass `--max-nodes`) |
+| `-32600` | server | Malformed JSON-RPC request |
+| `-32601` | server | Unknown method name |
+| `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist) |
+| `-1001` | client | Connection failure (daemon not running, port wrong, proxy hijacking localhost) |
+| `-1002` | client | Timeout waiting for response |
+| `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, …) |
+| `-1004` | client | Local file IO error (e.g. screenshot can't write the destination) |
+| `-1099` | client | Internal CLI bug — please file an issue |
+
+For full retry guidance see the SKILL.md shipped by `godot-cli-control init` (`.claude/skills/godot-cli-control/SKILL.md` in the target project).
 
 ## Activation Modes
 

--- a/addons/godot_cli_control/bridge/error_codes.gd
+++ b/addons/godot_cli_control/bridge/error_codes.gd
@@ -11,9 +11,12 @@ extends RefCounted
 
 const NODE_NOT_FOUND: int = 1001
 const PROPERTY_NOT_FOUND: int = 1002       # 也用于 "node has no 'text' property"
-const METHOD_NOT_FOUND: int = 1003         # 也用于 "screenshot unavailable"
+const METHOD_NOT_FOUND: int = 1003
 const COMBO_IN_PROGRESS: int = 1004
 const SCENE_TREE_TOO_LARGE: int = 1005
+# 资源 transient 不可用（screenshot viewport texture null 等）。
+# 与 1003 拆开：1003 是 schema 错（永久），1006 是时机错（短重试可能成功）。
+const RESOURCE_UNAVAILABLE: int = 1006
 
 const INVALID_PARAMS: int = -32602
 const INVALID_REQUEST: int = -32600

--- a/addons/godot_cli_control/bridge/error_codes.gd
+++ b/addons/godot_cli_control/bridge/error_codes.gd
@@ -1,0 +1,20 @@
+class_name CliControlErrorCodes
+extends RefCounted
+## 集中错误码常量。新加业务码必须在这里登记，
+## 避免 1004 那种隐式撞码（input_sim 用 "combo in progress"，
+## low_level 又用 "scene tree too large"）。
+##
+## 三段制（详见 SKILL.md 错误码表）：
+##   1xxx        服务端业务码
+##   -32xxx      JSON-RPC 标准
+##   -1xxx       客户端（Python）侧；GDScript 这边不会产出
+
+const NODE_NOT_FOUND: int = 1001
+const PROPERTY_NOT_FOUND: int = 1002       # 也用于 "node has no 'text' property"
+const METHOD_NOT_FOUND: int = 1003         # 也用于 "screenshot unavailable"
+const COMBO_IN_PROGRESS: int = 1004
+const SCENE_TREE_TOO_LARGE: int = 1005
+
+const INVALID_PARAMS: int = -32602
+const INVALID_REQUEST: int = -32600
+const METHOD_UNKNOWN: int = -32601

--- a/addons/godot_cli_control/bridge/input_simulation_api.gd
+++ b/addons/godot_cli_control/bridge/input_simulation_api.gd
@@ -46,10 +46,10 @@ func is_combo_active() -> bool:
 
 func handle_action_press(params: Dictionary) -> Dictionary:
 	if _combo_active:
-		return _err(1004, "combo in progress")
+		return _err(CliControlErrorCodes.COMBO_IN_PROGRESS, "combo in progress")
 	var action: String = params.get("action", "") as String
 	if not InputMap.has_action(action):
-		return _err(1003, "Unknown action: %s" % action)
+		return _err(CliControlErrorCodes.METHOD_NOT_FOUND, "Unknown action: %s" % action)
 	_do_press(action)
 	_pressed_actions[action] = true
 	return {"success": true}
@@ -57,10 +57,10 @@ func handle_action_press(params: Dictionary) -> Dictionary:
 
 func handle_action_release(params: Dictionary) -> Dictionary:
 	if _combo_active:
-		return _err(1004, "combo in progress")
+		return _err(CliControlErrorCodes.COMBO_IN_PROGRESS, "combo in progress")
 	var action: String = params.get("action", "") as String
 	if not InputMap.has_action(action):
-		return _err(1003, "Unknown action: %s" % action)
+		return _err(CliControlErrorCodes.METHOD_NOT_FOUND, "Unknown action: %s" % action)
 	_do_release(action)
 	_pressed_actions.erase(action)
 	_held_actions.erase(action)
@@ -71,10 +71,10 @@ func handle_action_release(params: Dictionary) -> Dictionary:
 ## 定时器到期后自动释放
 func handle_action_tap(params: Dictionary) -> Dictionary:
 	if _combo_active:
-		return _err(1004, "combo in progress")
+		return _err(CliControlErrorCodes.COMBO_IN_PROGRESS, "combo in progress")
 	var action: String = params.get("action", "") as String
 	if not InputMap.has_action(action):
-		return _err(1003, "Unknown action: %s" % action)
+		return _err(CliControlErrorCodes.METHOD_NOT_FOUND, "Unknown action: %s" % action)
 	var duration: float = params.get("duration", 0.1) as float
 	_do_press(action)
 	_held_actions[action] = duration
@@ -104,10 +104,10 @@ func handle_list_input_actions(params: Dictionary) -> Dictionary:
 
 func handle_hold(params: Dictionary) -> Dictionary:
 	if _combo_active:
-		return _err(1004, "combo in progress")
+		return _err(CliControlErrorCodes.COMBO_IN_PROGRESS, "combo in progress")
 	var action: String = params.get("action", "") as String
 	if not InputMap.has_action(action):
-		return _err(1003, "Unknown action: %s" % action)
+		return _err(CliControlErrorCodes.METHOD_NOT_FOUND, "Unknown action: %s" % action)
 	var duration: float = params.get("duration", 0.0) as float
 	_do_press(action)
 	_held_actions[action] = duration
@@ -137,7 +137,7 @@ func release_all() -> void:
 func handle_combo(params: Dictionary, request_id: String) -> void:
 	if _combo_active:
 		if _send_response_callback.is_valid():
-			_send_response_callback.call(request_id, _err(1004, "combo in progress"))
+			_send_response_callback.call(request_id, _err(CliControlErrorCodes.COMBO_IN_PROGRESS, "combo in progress"))
 		return
 	var steps: Array = params.get("steps", []) as Array
 	_combo_request_id = request_id
@@ -188,7 +188,7 @@ func _begin_combo_step() -> void:
 	var raw: Variant = _combo_steps[_combo_index]
 	if not raw is Dictionary:
 		_abort_combo_with_error(
-			-32602, "combo step must be object at index %d" % _combo_index
+			CliControlErrorCodes.INVALID_PARAMS, "combo step must be object at index %d" % _combo_index
 		)
 		return
 	var step: Dictionary = raw as Dictionary
@@ -198,7 +198,7 @@ func _begin_combo_step() -> void:
 		var action: String = step["action"] as String
 		if not InputMap.has_action(action):
 			_abort_combo_with_error(
-				1003, "Unknown action at combo step %d: %s" % [_combo_index, action]
+				CliControlErrorCodes.METHOD_NOT_FOUND, "Unknown action at combo step %d: %s" % [_combo_index, action]
 			)
 			return
 		var duration: float = step.get("duration", 0.1) as float
@@ -207,7 +207,7 @@ func _begin_combo_step() -> void:
 		_combo_timer = duration
 	else:
 		_abort_combo_with_error(
-			-32602, "combo step missing 'wait' or 'action' at index %d" % _combo_index
+			CliControlErrorCodes.INVALID_PARAMS, "combo step missing 'wait' or 'action' at index %d" % _combo_index
 		)
 
 

--- a/addons/godot_cli_control/bridge/input_simulation_api.gd
+++ b/addons/godot_cli_control/bridge/input_simulation_api.gd
@@ -1,6 +1,10 @@
 class_name InputSimulationApi
 extends Node
 ## 输入模拟 API：动作级按键、持续控制、组合序列
+##
+## 错误码常量来自 res://addons/godot_cli_control/bridge/error_codes.gd
+## （class_name CliControlErrorCodes）。靠 Godot 全局 class 注册解析；若 GUT
+## 测试跑前遇到 "Class 'CliControlErrorCodes' not found"，先 import 一次。
 
 # 手动按下的动作（无定时器）
 var _pressed_actions: Dictionary = {}

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -1,6 +1,11 @@
 class_name LowLevelApi
 extends Node
 ## 低层 API：通用节点操作（click、属性、场景树等）
+##
+## 错误码常量来自 res://addons/godot_cli_control/bridge/error_codes.gd
+## （class_name CliControlErrorCodes）。靠 Godot 全局 class 注册解析，无需 preload；
+## 若冷启动或 GUT 跑前遇到 "Class 'CliControlErrorCodes' not found"，先跑一次
+## 完整 import（`godot --editor --quit --path .`）让 .godot/global_script_class_cache.cfg 建立。
 
 const _BUILD_TREE_HARD_LIMIT: int = 50
 # 总节点数上限：宽场景（1000+ 子项的 Grid/Container）会构造极大 JSON，
@@ -187,17 +192,18 @@ func handle_get_scene_tree(params: Dictionary) -> Dictionary:
 	# Array 是引用类型，递归子调用对 counter[0] 的写入对调用方可见。
 	var counter: Array[int] = [0]
 	var tree: Dictionary = _build_tree(root, max_depth, 0, counter, max_nodes)
-	var truncated: bool = counter[0] > max_nodes
-	var response: Dictionary = {"tree": tree}
-	if truncated:
-		response["truncated"] = true
-		response["total_nodes"] = counter[0]
-	# 仍然保留硬墙：超 5000 走 1005，避免恶意大场景吃完 outbound buffer。
+	# 硬墙优先：超 5000 走 1005，避免恶意大场景吃完 outbound buffer。
+	# 排在软上限前面，使「先组装 partial response 再被 1005 短路」的代码异味消失。
 	if counter[0] > _BUILD_TREE_NODE_LIMIT:
 		return _err(
 			CliControlErrorCodes.SCENE_TREE_TOO_LARGE,
 			"scene tree too large (>%d nodes); lower 'depth' or query a subtree" % _BUILD_TREE_NODE_LIMIT,
 		)
+	# 软上限：硬墙内但超过 max_nodes 时附加 truncated 信号让 agent 决定分子树。
+	var response: Dictionary = {"tree": tree}
+	if counter[0] > max_nodes:
+		response["truncated"] = true
+		response["total_nodes"] = counter[0]
 	return response
 
 

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -81,7 +81,7 @@ func handle_click(params: Dictionary) -> Dictionary:
 		click_event.pressed = true
 		area.input_event.emit(get_viewport(), click_event, 0)
 		return {"success": true}
-	return _err(-32602, "Node is not clickable: %s" % node.get_class())
+	return _err(CliControlErrorCodes.INVALID_PARAMS, "Node is not clickable: %s" % node.get_class())
 
 
 func handle_get_property(params: Dictionary) -> Dictionary:
@@ -90,9 +90,9 @@ func handle_get_property(params: Dictionary) -> Dictionary:
 		return _node_not_found(params.get("path", "") as String)
 	var property: String = params.get("property", "") as String
 	if property.is_empty():
-		return _err(-32602, "Missing 'property' parameter")
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'property' parameter")
 	if not _has_property(node, property):
-		return _err(1002, "Property not found: %s" % property)
+		return _err(CliControlErrorCodes.PROPERTY_NOT_FOUND, "Property not found: %s" % property)
 	return {"value": node.get(property)}
 
 
@@ -102,14 +102,14 @@ func handle_set_property(params: Dictionary) -> Dictionary:
 		return _node_not_found(params.get("path", "") as String)
 	var property: String = params.get("property", "") as String
 	if property.is_empty():
-		return _err(-32602, "Missing 'property' parameter")
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'property' parameter")
 	# Godot Object.set() 接受 NodePath 形式的子属性（如 "position:x"）。
 	# 精确字符串黑名单会漏掉 "script:source_code" / "texture:resource_path" 这类
 	# 嵌套写入向量 —— 拿 ":" 前的 top-level 名重新过一次黑名单。
 	# 同时整串也走一次（防御深度，万一未来加非冒号语法的反射子路径）。
 	var top_level: String = property.split(":", true, 1)[0]
 	if property in _property_blacklist or top_level in _property_blacklist:
-		return _err(-32602, "Blocked property: %s" % property)
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "Blocked property: %s" % property)
 	var value: Variant = params.get("value", null)
 	node.set(property, value)
 	return {"success": true}
@@ -121,9 +121,9 @@ func handle_call_method(params: Dictionary) -> Dictionary:
 		return _node_not_found(params.get("path", "") as String)
 	var method: String = params.get("method", "") as String
 	if method in _method_blacklist:
-		return _err(-32602, "Blocked method: %s" % method)
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "Blocked method: %s" % method)
 	if not node.has_method(method):
-		return _err(1003, "Method not found: %s" % method)
+		return _err(CliControlErrorCodes.METHOD_NOT_FOUND, "Method not found: %s" % method)
 	var args: Array = params.get("args", []) as Array
 	# 注意：GDScript 没有 try-catch，callv 参数不匹配会产生引擎错误而非可捕获异常
 	var result: Variant = node.callv(method, args)
@@ -135,7 +135,7 @@ func handle_get_text(params: Dictionary) -> Dictionary:
 	if node == null:
 		return _node_not_found(params.get("path", "") as String)
 	if not "text" in node:
-		return _err(1002, "Node does not have a 'text' property")
+		return _err(CliControlErrorCodes.PROPERTY_NOT_FOUND, "Node does not have a 'text' property")
 	return {"text": str(node.get("text"))}
 
 
@@ -184,7 +184,7 @@ func handle_get_scene_tree(params: Dictionary) -> Dictionary:
 	var tree: Dictionary = _build_tree(root, max_depth, 0, counter)
 	if counter[0] > _BUILD_TREE_NODE_LIMIT:
 		return _err(
-			1004,
+			CliControlErrorCodes.SCENE_TREE_TOO_LARGE,
 			"scene tree too large (>%d nodes); lower 'depth' or query a subtree" % _BUILD_TREE_NODE_LIMIT,
 		)
 	return {"tree": tree}
@@ -216,7 +216,7 @@ func take_screenshot_async() -> Dictionary:
 		await RenderingServer.frame_post_draw
 	var image: Image = get_viewport().get_texture().get_image()
 	if image == null:
-		return _err(1003, "Screenshot unavailable (viewport texture is null)")
+		return _err(CliControlErrorCodes.METHOD_NOT_FOUND, "Screenshot unavailable (viewport texture is null)")
 	var png_buffer: PackedByteArray = image.save_png_to_buffer()
 	var base64_str: String = Marshalls.raw_to_base64(png_buffer)
 	return {"image": base64_str}
@@ -225,9 +225,9 @@ func take_screenshot_async() -> Dictionary:
 func wait_game_time_async(params: Dictionary) -> Dictionary:
 	var seconds: float = params.get("seconds", 0.0) as float
 	if seconds < 0.0:
-		return _err(-32602, "seconds must be >= 0")
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "seconds must be >= 0")
 	if seconds > _MAX_WAIT_SECONDS:
-		return _err(-32602, "seconds must be <= %s" % _MAX_WAIT_SECONDS)
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "seconds must be <= %s" % _MAX_WAIT_SECONDS)
 	if seconds == 0.0:
 		return {"success": true}
 	await get_tree().create_timer(seconds).timeout
@@ -240,7 +240,7 @@ func _get_node_or_error(params: Dictionary) -> Node:
 
 
 func _node_not_found(path: String) -> Dictionary:
-	return _err(1001, "Node not found: %s" % path)
+	return _err(CliControlErrorCodes.NODE_NOT_FOUND, "Node not found: %s" % path)
 
 
 func _err(code: int, message: String) -> Dictionary:
@@ -256,7 +256,7 @@ func _has_property(node: Node, property: String) -> bool:
 
 ## depth=0 表示"无限深度"，使用硬限制 _BUILD_TREE_HARD_LIMIT (50) 防止无限递归。
 ## counter 是 by-ref 计数器：超过 _BUILD_TREE_NODE_LIMIT 时短路（不再递归子节点），
-## 调用方读 counter[0] > LIMIT 决定是否走 1004 错误路径。
+## 调用方读 counter[0] > LIMIT 决定是否走 1005 (SCENE_TREE_TOO_LARGE) 错误路径。
 func _build_tree(node: Node, max_depth: int, current_depth: int, counter: Array[int]) -> Dictionary:
 	counter[0] += 1
 	var entry: Dictionary = {

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -180,10 +180,14 @@ func handle_get_children(params: Dictionary) -> Dictionary:
 
 func handle_get_scene_tree(params: Dictionary) -> Dictionary:
 	var max_depth: int = params.get("depth", 5) as int
-	# max_nodes 是软上限：超出立刻停止 _build_tree 递归并把信号透出。
-	# 不传时用硬墙 5000 兼容旧客户端。
+	# max_nodes 是客户端控制的软上限。**入口处 clamp 到硬墙
+	# _BUILD_TREE_NODE_LIMIT (5000)**：防止恶意 / 失误调用传 max_nodes=999999
+	# 时让 _build_tree 真把整棵超大树构造成 Dictionary 后才被外层错误返回丢弃
+	# （DoS / OOM 路径）。clamp 后 _build_tree 内部的短路单一来源，
+	# 同时承担软上限（agent truncated 信号）与硬墙（防爆 outbound buffer）。
+	# 不传时也用硬墙做默认，兼容旧客户端。
 	var max_nodes: int = params.get("max_nodes", _BUILD_TREE_NODE_LIMIT) as int
-	if max_nodes <= 0:
+	if max_nodes <= 0 or max_nodes > _BUILD_TREE_NODE_LIMIT:
 		max_nodes = _BUILD_TREE_NODE_LIMIT
 	var root: Node = get_tree().current_scene
 	if root == null:
@@ -192,8 +196,10 @@ func handle_get_scene_tree(params: Dictionary) -> Dictionary:
 	# Array 是引用类型，递归子调用对 counter[0] 的写入对调用方可见。
 	var counter: Array[int] = [0]
 	var tree: Dictionary = _build_tree(root, max_depth, 0, counter, max_nodes)
-	# 硬墙优先：超 5000 走 1005，避免恶意大场景吃完 outbound buffer。
-	# 排在软上限前面，使「先组装 partial response 再被 1005 短路」的代码异味消失。
+	# 触发 1005 的语义：counter 越过硬墙 = 场景大到不该序列化。
+	# 因为 max_nodes 已 clamp 到 ≤ LIMIT，counter 最多比 LIMIT 多 ~1，
+	# 所以这条分支只在 max_nodes==LIMIT（客户端没传或传了 ≥LIMIT）时被触发。
+	# max_nodes < LIMIT 的客户端永远走 truncated 软信号路径，不会撞 1005。
 	if counter[0] > _BUILD_TREE_NODE_LIMIT:
 		return _err(
 			CliControlErrorCodes.SCENE_TREE_TOO_LARGE,
@@ -233,7 +239,8 @@ func take_screenshot_async() -> Dictionary:
 		await RenderingServer.frame_post_draw
 	var image: Image = get_viewport().get_texture().get_image()
 	if image == null:
-		return _err(CliControlErrorCodes.METHOD_NOT_FOUND, "Screenshot unavailable (viewport texture is null)")
+		# 1006 (transient) ≠ 1003 (schema)：agent 可短重试，等下一帧 viewport 就绪。
+		return _err(CliControlErrorCodes.RESOURCE_UNAVAILABLE, "Screenshot unavailable (viewport texture is null)")
 	var png_buffer: PackedByteArray = image.save_png_to_buffer()
 	var base64_str: String = Marshalls.raw_to_base64(png_buffer)
 	return {"image": base64_str}

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -175,19 +175,30 @@ func handle_get_children(params: Dictionary) -> Dictionary:
 
 func handle_get_scene_tree(params: Dictionary) -> Dictionary:
 	var max_depth: int = params.get("depth", 5) as int
+	# max_nodes 是软上限：超出立刻停止 _build_tree 递归并把信号透出。
+	# 不传时用硬墙 5000 兼容旧客户端。
+	var max_nodes: int = params.get("max_nodes", _BUILD_TREE_NODE_LIMIT) as int
+	if max_nodes <= 0:
+		max_nodes = _BUILD_TREE_NODE_LIMIT
 	var root: Node = get_tree().current_scene
 	if root == null:
 		root = get_tree().root
 	# counter 用 Array[int] 当 by-ref 计数器：GDScript 没指针/inout，
 	# Array 是引用类型，递归子调用对 counter[0] 的写入对调用方可见。
 	var counter: Array[int] = [0]
-	var tree: Dictionary = _build_tree(root, max_depth, 0, counter)
+	var tree: Dictionary = _build_tree(root, max_depth, 0, counter, max_nodes)
+	var truncated: bool = counter[0] > max_nodes
+	var response: Dictionary = {"tree": tree}
+	if truncated:
+		response["truncated"] = true
+		response["total_nodes"] = counter[0]
+	# 仍然保留硬墙：超 5000 走 1005，避免恶意大场景吃完 outbound buffer。
 	if counter[0] > _BUILD_TREE_NODE_LIMIT:
 		return _err(
 			CliControlErrorCodes.SCENE_TREE_TOO_LARGE,
 			"scene tree too large (>%d nodes); lower 'depth' or query a subtree" % _BUILD_TREE_NODE_LIMIT,
 		)
-	return {"tree": tree}
+	return response
 
 
 func wait_for_node_async(params: Dictionary) -> Dictionary:
@@ -255,9 +266,10 @@ func _has_property(node: Node, property: String) -> bool:
 
 
 ## depth=0 表示"无限深度"，使用硬限制 _BUILD_TREE_HARD_LIMIT (50) 防止无限递归。
-## counter 是 by-ref 计数器：超过 _BUILD_TREE_NODE_LIMIT 时短路（不再递归子节点），
-## 调用方读 counter[0] > LIMIT 决定是否走 1005 (SCENE_TREE_TOO_LARGE) 错误路径。
-func _build_tree(node: Node, max_depth: int, current_depth: int, counter: Array[int]) -> Dictionary:
+## counter 是 by-ref 计数器：超过 max_nodes 时短路（不再递归子节点），
+## 调用方读 counter[0] > max_nodes 决定是否附加 truncated 信号，
+## 读 counter[0] > _BUILD_TREE_NODE_LIMIT 决定是否走 1005 (SCENE_TREE_TOO_LARGE) 错误路径。
+func _build_tree(node: Node, max_depth: int, current_depth: int, counter: Array[int], max_nodes: int) -> Dictionary:
 	counter[0] += 1
 	var entry: Dictionary = {
 		"name": node.name,
@@ -268,13 +280,13 @@ func _build_tree(node: Node, max_depth: int, current_depth: int, counter: Array[
 		entry["visible"] = (node as CanvasItem).visible
 	if "text" in node:
 		entry["text"] = str(node.get("text"))
-	if counter[0] > _BUILD_TREE_NODE_LIMIT:
-		# 超限：不再下递归，但当前 entry 已计入；调用方一次性走错误返回
+	if counter[0] > max_nodes:
+		# 超软上限：不再下递归，但当前 entry 已计入；调用方附加 truncated 信号
 		return entry
 	var effective_max: int = _BUILD_TREE_HARD_LIMIT if max_depth == 0 else max_depth
 	if current_depth < effective_max:
 		var children: Array[Dictionary] = []
 		for child: Node in node.get_children():
-			children.append(_build_tree(child, effective_max, current_depth + 1, counter))
+			children.append(_build_tree(child, effective_max, current_depth + 1, counter, max_nodes))
 		entry["children"] = children
 	return entry

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -157,7 +157,8 @@ func test_build_tree_short_circuits_above_node_limit() -> void:
 	leaf.name = "Leaf"
 	add_child_autofree(leaf)
 	var counter: Array[int] = [LowLevelApiScript._BUILD_TREE_NODE_LIMIT]
-	var entry: Dictionary = _api._build_tree(leaf, 5, 0, counter)
+	# 第 5 参数 max_nodes = LIMIT（5000）；leaf 计入后 counter == LIMIT+1 > max_nodes，触发短路
+	var entry: Dictionary = _api._build_tree(leaf, 5, 0, counter, LowLevelApiScript._BUILD_TREE_NODE_LIMIT)
 	# leaf 自身被计入 → counter 变成 LIMIT+1
 	assert_eq(int(counter[0]), LowLevelApiScript._BUILD_TREE_NODE_LIMIT + 1)
 	# 超 limit 后立刻 return，不下递归 children
@@ -173,7 +174,8 @@ func test_build_tree_under_limit_includes_children() -> void:
 	c1.name = "C1"
 	parent.add_child(c1)
 	var counter: Array[int] = [0]
-	var entry: Dictionary = _api._build_tree(parent, 5, 0, counter)
+	# 第 5 参数 max_nodes 给硬墙 5000，远超 2 个节点，不会触发软截断
+	var entry: Dictionary = _api._build_tree(parent, 5, 0, counter, LowLevelApiScript._BUILD_TREE_NODE_LIMIT)
 	assert_has(entry, "children")
 	assert_eq((entry.children as Array).size(), 1)
 

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -180,6 +180,31 @@ func test_build_tree_under_limit_includes_children() -> void:
 	assert_eq((entry.children as Array).size(), 1)
 
 
+func test_handle_get_scene_tree_clamps_oversized_max_nodes() -> void:
+	# P1 回归：恶意/失误客户端传 max_nodes=999999 时，
+	# 入口必须 clamp 到 _BUILD_TREE_NODE_LIMIT，
+	# 否则 _build_tree 会构造完整大字典再被外层 1005 丢弃（DoS 风险）。
+	# 这里 happy path 验证 clamp 不破坏正常调用——简单场景下无 1005 报错、无 truncated 信号。
+	var result: Dictionary = _api.handle_get_scene_tree({
+		"depth": 3,
+		"max_nodes": 999999,
+	})
+	assert_does_not_have(result, "error")
+	assert_has(result, "tree")
+	# 简单场景节点数远小于 LIMIT，clamp 后等价于 max_nodes=LIMIT，不应触发 truncated
+	assert_does_not_have(result, "truncated")
+
+
+func test_handle_get_scene_tree_negative_max_nodes_falls_back_to_limit() -> void:
+	# 客户端传 0 / 负值 → 当作 "用服务端默认"，等价于不传
+	var result: Dictionary = _api.handle_get_scene_tree({
+		"depth": 3,
+		"max_nodes": -5,
+	})
+	assert_does_not_have(result, "error")
+	assert_has(result, "tree")
+
+
 # ── handle_node_exists / handle_get_children ──────────────────────
 
 func test_node_exists_true_for_real_path() -> void:

--- a/docs/superpowers/plans/2026-05-11-ai-friendly-cli-fixes.md
+++ b/docs/superpowers/plans/2026-05-11-ai-friendly-cli-fixes.md
@@ -1,0 +1,1135 @@
+# AI-Friendly CLI Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 7 issues found during AI-friendliness review so the CLI fully delivers on the "shell-first, JSON-envelope, AI-driven" contract documented in `CLAUDE.md`.
+
+**Architecture:** Surgical patches to existing modules — argparse wiring, error-code constants, defaults. No new subsystems. Each fix is isolated to 1–3 files plus the SKILL.md template / addon README that document the change.
+
+**Tech Stack:** Python 3.10+, argparse, pytest (+ pytester + monkeypatch), GDScript 4 (Godot plugin), websockets.
+
+---
+
+## Pre-flight
+
+This plan should be executed on a feature branch. The work is small enough (~6 commits) to ship as a single PR; per-task commits keep the history bisectable.
+
+```bash
+git checkout -b fix/ai-friendly-cli-cleanup
+```
+
+Tests must be run via subagent with `model: "sonnet"` per global CLAUDE.md. The harness command is `coverage run -m pytest python/tests/<file>.py -v` (note: `coverage run`, not `pytest --cov` — see `pyproject.toml` `[tool.coverage.run]` comment for why).
+
+---
+
+## File Map
+
+| File | Tasks touching it | Why |
+|---|---|---|
+| `python/godot_cli_control/cli.py` | T1, T5, T6, T7 | argparse wiring (T1), tree `--max-nodes` (T5), set/call `--text-value` (T6), daemon start headless default (T7) |
+| `python/godot_cli_control/client.py` | T5 | tree truncate response shape |
+| `python/godot_cli_control/bridge.py` | T5 | sync wrapper for new tree shape |
+| `python/godot_cli_control/pytest_plugin.py` | T2 | default port 0 |
+| `addons/godot_cli_control/bridge/low_level_api.gd` | T3, T5 | new error code 1005 + `max_nodes` param |
+| `addons/godot_cli_control/bridge/error_codes.gd` *(new)* | T3 | central GDScript error-code constants |
+| `addons/godot_cli_control/bridge/input_simulation_api.gd` | T3 | use `ErrorCodes.COMBO_IN_PROGRESS` instead of magic 1004 |
+| `python/godot_cli_control/templates/skill/SKILL.md` | T1, T3, T5, T6, T7 | document each behavioral change |
+| `addons/godot_cli_control/README.md` | T4 | error-code table refresh |
+| `addons/godot_cli_control/CHANGELOG.md` | T9 | one consolidated entry under [Unreleased] |
+| `CLAUDE.md` | T8 | strike out the now-fixed known-issues list |
+| `python/tests/test_cli.py` | T1, T5, T6, T7 | unit tests for argparse + new flags |
+| `python/tests/test_pytest_plugin.py` | T2 | test default port = 0 |
+| `python/tests/test_client.py` | T5 | test tree truncate parse |
+
+---
+
+## Task 1: Allow `--json` / `--text` after RPC subcommand
+
+**Why:** `godot-cli-control click /root/X --json` currently fails with `unrecognized arguments: --json`. LLMs habitually append flags at the tail; this is the single most-impactful AI footgun. Only `daemon ls` works today because it duplicated `_add_output_format_flags(ls_p)` ad-hoc.
+
+**Files:**
+- Modify: `python/godot_cli_control/cli.py:1099-1280` (`build_parser`)
+- Modify: `python/tests/test_cli.py` (add new test class)
+
+**Steps:**
+
+- [ ] **Step 1.1: Write failing test for RPC subcommand**
+
+Add to `python/tests/test_cli.py`:
+
+```python
+class TestOutputFormatFlagsOnSubcommands:
+    """--json / --text 必须能放在子命令前 *和* 后两种位置。
+
+    AI agent 习惯把 flag 写在尾巴；早期 build_parser 只在顶层注册，
+    `click /root/X --json` 会被 argparse 报 unrecognized。
+    """
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["click", "/root/X", "--json"],
+            ["--json", "click", "/root/X"],
+            ["click", "/root/X", "--text"],
+            ["click", "/root/X", "--no-json"],
+            ["exists", "/root/Foo", "--text"],
+            ["tree", "3", "--json"],
+            ["daemon", "status", "--json"],
+            ["daemon", "stop", "--text"],
+            ["daemon", "start", "--headless", "--json"],
+        ],
+    )
+    def test_output_flag_accepted_at_tail(self, argv: list[str]) -> None:
+        from godot_cli_control.cli import build_parser
+
+        parser = build_parser()
+        # parse_args raises SystemExit on rejection
+        ns = parser.parse_args(argv)
+        assert ns.output_format in ("json", "text")
+```
+
+- [ ] **Step 1.2: Run test to confirm failure**
+
+Dispatch subagent (`model: "sonnet"`):
+
+> Run `coverage run -m pytest python/tests/test_cli.py::TestOutputFormatFlagsOnSubcommands -v` from the repo root. Report PASS/FAIL counts and any error messages, no output dump.
+
+Expected: most parametrize cases FAIL with `SystemExit` / `unrecognized arguments`.
+
+- [ ] **Step 1.3: Add `_add_output_format_flags(sp)` to every subparser**
+
+In `python/godot_cli_control/cli.py:build_parser`:
+
+1. Add after each `daemon_subs.add_parser(...)` call (start_p, stop_p, status_p — `ls_p` already has it):
+   ```python
+   _add_output_format_flags(start_p)
+   _add_output_format_flags(stop_p)
+   _add_output_format_flags(status_p)
+   ```
+   Note: `status_p` doesn't currently have its own variable — name it (replace the bare `daemon_subs.add_parser("status", ...)` call with `status_p = daemon_subs.add_parser(...)`).
+
+2. Add inside the RPC subcommand registration loop (around line 1278, after `if spec.extra_args is not None: spec.extra_args(sp)`):
+   ```python
+   _add_output_format_flags(sp)
+   ```
+
+3. Also add to `run_p` and `init_p` (defensive — they don't emit JSON envelopes today, but consistency matters and `init` already calls `_emit_top_error` paths through future error envelope work):
+   ```python
+   _add_output_format_flags(run_p)
+   _add_output_format_flags(init_p)
+   ```
+
+- [ ] **Step 1.4: Run test to confirm pass**
+
+Dispatch subagent: same command as Step 1.2.
+Expected: all parametrize cases PASS.
+
+- [ ] **Step 1.5: Smoke check at the shell**
+
+```bash
+/Users/kesar/Projects/godot-cli-control/.venv/bin/python -m godot_cli_control click /root/X --json 2>&1 | head -2
+```
+Expected: `{"ok": false, "error": {"code": -1001, ...}}` (connection refused — that's fine, parser accepted the flag).
+
+- [ ] **Step 1.6: Update SKILL.md**
+
+In `python/godot_cli_control/templates/skill/SKILL.md` *Common pitfalls* section: remove or rewrite the `--port doesn't change daemon port` bullet to also clarify `--json` / `--text` work at any position. Specifically replace lines 295–296 with:
+
+```markdown
+- **Top-level flags work in any position** — `--json` / `--text` / `--port N` are accepted both before and after subcommands as of this fix. Pre-fix sessions only honored them at the front.
+```
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add python/godot_cli_control/cli.py python/tests/test_cli.py python/godot_cli_control/templates/skill/SKILL.md
+git commit -m "fix(cli): 子命令尾部接受 --json / --text / --port
+
+argparse 默认子命令不继承父 parser 的 optional flag。早期只在 daemon ls
+单独补了 _add_output_format_flags，导致 \`click /root/X --json\` 这类
+LLM 习惯写法被 argparse 拒。给所有 RPC 子命令 + daemon start/stop/
+status + run + init 统一注入，flag 可放任意位置。"
+```
+
+---
+
+## Task 2: pytest fixture default port → 0 (OS-assigned)
+
+**Why:** `pytest_plugin.py` line 38 hardcodes `default=str(DEFAULT_PORT)` (= 9877). Multi-project parallel test runs collide; 9877 is also the port `daemon start` no longer uses by default. Must align with daemon's OS-assigned default.
+
+**Files:**
+- Modify: `python/godot_cli_control/pytest_plugin.py:33-78`
+- Modify: `python/tests/test_pytest_plugin.py` (add test)
+
+**Steps:**
+
+- [ ] **Step 2.1: Write failing test**
+
+Add to `python/tests/test_pytest_plugin.py`:
+
+```python
+def test_default_port_is_zero(pytester: pytest.Pytester) -> None:
+    """--godot-cli-port 默认 0 = OS 自动分配，与 daemon start 默认对齐。
+
+    早期版本默认 9877 会让多项目并行测试撞端口，且 9877 不再是 daemon
+    start 默认。fixture 必须放手让 daemon 自己挑。
+    """
+    result = pytester.runpytest("--help")
+    # default 值会出现在 help 输出里
+    result.stdout.fnmatch_lines(
+        ["*--godot-cli-port*", "*default: 0*"]
+    )
+
+
+def test_godot_daemon_passes_port_zero_when_default(
+    pytester: pytest.Pytester,
+) -> None:
+    """fixture 拿默认值（不传 --godot-cli-port）时 daemon.start(port=0)。"""
+    pytester.makeconftest(
+        """
+        import godot_cli_control.pytest_plugin as plugin
+
+        OBSERVED: list = []
+
+        class FakeDaemon:
+            def __init__(self, *a, **kw): pass
+            def is_running(self): return False
+            def start(self, **kw): OBSERVED.append(kw.get("port"))
+            def stop(self): return 0
+            def current_port(self): return 5555
+
+        class FakeBridge:
+            def __init__(self, port): OBSERVED.append(f"bridge:{port}")
+            def release_all(self): pass
+            def close(self): pass
+
+        plugin.Daemon = FakeDaemon
+        plugin.GameBridge = FakeBridge
+
+        def pytest_sessionfinish(session, exitstatus):
+            assert OBSERVED[0] == 0, f"expected port=0 default, got {OBSERVED}"
+        """
+    )
+    pytester.makepyfile(
+        test_x="""
+        def test_x(godot_daemon, bridge): pass
+        """
+    )
+    result = pytester.runpytest("-v")
+    assert result.ret == 0
+```
+
+- [ ] **Step 2.2: Run tests to confirm failure**
+
+Dispatch subagent: `coverage run -m pytest python/tests/test_pytest_plugin.py::test_default_port_is_zero python/tests/test_pytest_plugin.py::test_godot_daemon_passes_port_zero_when_default -v`. Report PASS/FAIL.
+Expected: FAIL (default still 9877).
+
+- [ ] **Step 2.3: Change default to 0**
+
+In `python/godot_cli_control/pytest_plugin.py:36-40`:
+
+```python
+group.addoption(
+    "--godot-cli-port",
+    action="store",
+    default="0",  # 0 = OS-assigned，与 daemon start 默认对齐
+    help="GameBridge WebSocket port for the godot_daemon fixture (default: 0 = OS-assigned).",
+)
+```
+
+In the same file at line 100 (`bridge` fixture body) — already does `godot_daemon.current_port() or DEFAULT_PORT`, leave unchanged. The fix is only the option default.
+
+- [ ] **Step 2.4: Run tests to confirm pass**
+
+Same subagent command as Step 2.2.
+Expected: PASS.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add python/godot_cli_control/pytest_plugin.py python/tests/test_pytest_plugin.py
+git commit -m "fix(pytest): --godot-cli-port 默认 0（OS-assigned）
+
+之前默认 9877 会让多项目并行测试撞端口，且 daemon start 自身已改默认
+0；fixture 必须对齐。bridge fixture 已经走 daemon.current_port() 兜底，
+只需改 option 默认。"
+```
+
+---
+
+## Task 3: Resolve error-code 1004 collision (scene tree → 1005)
+
+**Why:** `low_level_api.gd:188` returns `1004 "scene tree too large"`; `input_simulation_api.gd` uses 1004 for `"combo in progress"` in 5 places. Same code, opposite retry semantics. SKILL.md only documents the combo case.
+
+User decision: introduce **business code 1005** for scene-tree-too-large. Centralize all GDScript codes into a constants file so future code adds force a grep.
+
+**Files:**
+- Create: `addons/godot_cli_control/bridge/error_codes.gd`
+- Modify: `addons/godot_cli_control/bridge/low_level_api.gd:18-34, 187-189`
+- Modify: `addons/godot_cli_control/bridge/input_simulation_api.gd` (re-grep first; previously observed 5 raw `_err(1004, …)` call sites + 1 comment match)
+- Modify: `python/godot_cli_control/templates/skill/SKILL.md` (error-code table + new pitfall)
+- Modify: `python/tests/test_client.py` (add code-table assertion if a constants module exists in Python; otherwise skip)
+
+**Steps:**
+
+- [ ] **Step 3.1: Create `error_codes.gd` constants module**
+
+Create `addons/godot_cli_control/bridge/error_codes.gd`:
+
+```gdscript
+class_name CliControlErrorCodes
+extends RefCounted
+## 集中错误码常量。新加业务码必须在这里登记，
+## 避免 1004 那种隐式撞码（input_sim 用 "combo in progress"，
+## low_level 又用 "scene tree too large"）。
+##
+## 三段制（详见 SKILL.md 错误码表）：
+##   1xxx        服务端业务码
+##   -32xxx      JSON-RPC 标准
+##   -1xxx       客户端（Python）侧；GDScript 这边不会产出
+
+const NODE_NOT_FOUND: int = 1001
+const PROPERTY_NOT_FOUND: int = 1002       # 也用于 "node has no 'text' property"
+const METHOD_NOT_FOUND: int = 1003         # 也用于 "screenshot unavailable"
+const COMBO_IN_PROGRESS: int = 1004
+const SCENE_TREE_TOO_LARGE: int = 1005
+
+const INVALID_PARAMS: int = -32602
+const INVALID_REQUEST: int = -32600
+const METHOD_UNKNOWN: int = -32601
+```
+
+- [ ] **Step 3.2: Update `low_level_api.gd` to use new constant**
+
+In `addons/godot_cli_control/bridge/low_level_api.gd`:
+
+1. Replace line 187–189 (`return _err(1004, "scene tree too large ...")`):
+   ```gdscript
+   return _err(
+       CliControlErrorCodes.SCENE_TREE_TOO_LARGE,
+       "scene tree too large (>%d nodes); lower 'depth' or query a subtree" % _BUILD_TREE_NODE_LIMIT,
+   )
+   ```
+
+2. While here, replace other magic numbers with constants for consistency:
+   - `_err(1001, ...)` → `_err(CliControlErrorCodes.NODE_NOT_FOUND, ...)`
+   - `_err(1002, ...)` → `_err(CliControlErrorCodes.PROPERTY_NOT_FOUND, ...)`
+   - `_err(1003, ...)` → `_err(CliControlErrorCodes.METHOD_NOT_FOUND, ...)`
+   - `_err(-32602, ...)` → `_err(CliControlErrorCodes.INVALID_PARAMS, ...)`
+
+- [ ] **Step 3.3: Update `input_simulation_api.gd`**
+
+First re-grep to find all sites:
+```bash
+grep -nE "_err\(\s*1004" addons/godot_cli_control/bridge/input_simulation_api.gd
+```
+Replace each `_err(1004, "combo in progress")` site with:
+```gdscript
+_err(CliControlErrorCodes.COMBO_IN_PROGRESS, "combo in progress")
+```
+(Earlier observation: 5 raw `_err(` call sites + 1 comment-only match. Re-grep is authoritative.)
+
+- [ ] **Step 3.4: Update SKILL.md error-code reference**
+
+In `python/godot_cli_control/templates/skill/SKILL.md`:
+
+1. In the *Server-side* error table (around line 73–78), add a new row for 1005:
+   ```markdown
+   | `1005` | Scene tree too large to serialize (default safety limit). Pass `--max-nodes` or query a subtree with `children` / `tree <subpath>`. Don't retry as-is. |
+   ```
+
+2. The 1004 row stays unchanged (combo-in-progress).
+
+3. In *Common pitfalls*, add:
+   ```markdown
+   - **`tree` returns `1005 "scene tree too large"`** — your scene has more than 5000 visible nodes (a Grid / spawned-bullets situation). Pass `--max-nodes 200` to cap, or `children <path>` for one specific subtree.
+   ```
+
+- [ ] **Step 3.5: GUT test for 1005**
+
+If GUT tests are runnable here (requires `GODOT_BIN`), add to `addons/godot_cli_control/tests/gut/test_low_level_api.gd` a test that builds a synthetic 6000-node tree and asserts `code == 1005`. If `GODOT_BIN` isn't set in this environment, skip GUT and rely on Step 3.6 (Python integration check via re-grep that no `1004` literal remains in `low_level_api.gd`).
+
+- [ ] **Step 3.6: Static check — no orphan 1004 in low_level_api.gd**
+
+Run:
+```bash
+grep -nE "(^|[^[:digit:]])1004([^[:digit:]]|$)" addons/godot_cli_control/bridge/low_level_api.gd
+```
+Expected: no matches.
+
+```bash
+grep -nE "(^|[^[:digit:]])1004([^[:digit:]]|$)" addons/godot_cli_control/bridge/input_simulation_api.gd
+```
+Expected: only matches inside comments referring to the combo case (no `_err(1004, …)` raw form).
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add addons/godot_cli_control/bridge/error_codes.gd \
+        addons/godot_cli_control/bridge/low_level_api.gd \
+        addons/godot_cli_control/bridge/input_simulation_api.gd \
+        python/godot_cli_control/templates/skill/SKILL.md
+git commit -m "fix(error-codes): scene tree 超限改 1005，与 combo 1004 解耦
+
+之前 1004 同时表 \"combo in progress\"（input_sim）与 \"scene tree too
+large\"（low_level）。两者 retry 策略截然不同，agent 拿到 1004 没法判。
+
+- 新增 CliControlErrorCodes 常量类，集中所有 GDScript 错误码
+- scene tree 超限改 1005 \"scene tree too large\"
+- low_level / input_sim 全部用常量替换裸数字
+- SKILL.md 错误码表 + pitfalls 加 1005 说明"
+```
+
+---
+
+## Task 4: Refresh addon README error-code table
+
+**Why:** `addons/godot_cli_control/README.md:102` lists only `-32600/-32601/-32602/1001/1002/1003`. Missing 1004, the new 1005, and the entire client-side `-1xxx` segment. GitHub viewers see this README first.
+
+**Files:**
+- Modify: `addons/godot_cli_control/README.md` (around the *RPC Reference* section)
+
+**Steps:**
+
+- [ ] **Step 4.1: Replace the one-liner with a proper subsection**
+
+Find the line that reads:
+```
+Error codes: `-32600` invalid request, `-32601` unknown method, `-32602` invalid params, `1001` node not found, `1002` property not found, `1003` method not found.
+```
+
+Replace with:
+
+```markdown
+### Error codes
+
+Three numeric ranges share `error.code`; they never overlap, so a single field is unambiguous.
+
+| Code | Source | Meaning |
+|---|---|---|
+| `1001` | server | Node not found at the given path |
+| `1002` | server | Property not found / shape mismatch |
+| `1003` | server | Method not found / render unavailable |
+| `1004` | server | Combo already in progress (call `combo-cancel` to retry) |
+| `1005` | server | Scene tree too large (lower `depth` or pass `--max-nodes`) |
+| `-32600` | server | Malformed JSON-RPC request |
+| `-32601` | server | Unknown method name |
+| `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist) |
+| `-1001` | client | Connection failure (daemon not running, port wrong, proxy hijacking localhost) |
+| `-1002` | client | Timeout waiting for response |
+| `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, …) |
+| `-1004` | client | Local file IO error (e.g. screenshot can't write the destination) |
+| `-1099` | client | Internal CLI bug — please file an issue |
+
+For full retry guidance see the SKILL.md shipped by `godot-cli-control init` (`.claude/skills/godot-cli-control/SKILL.md` in the target project).
+```
+
+- [ ] **Step 4.2: Static check — table is complete**
+
+```bash
+grep -c '^| `' addons/godot_cli_control/README.md
+```
+Should now show ≥ 13 (was 0 before; the grep counts the new table rows).
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add addons/godot_cli_control/README.md
+git commit -m "docs(addon): 错误码表补全 1004/1005 + 客户端 -1xxx 段
+
+之前只列到 1003，1004/1005 与所有客户端码缺失。GitHub 用户进 addon
+README 是第一入口，应自包含；引用 SKILL.md 作为完整 retry 指南。"
+```
+
+---
+
+## Task 5: `tree` truncate signal (`--max-nodes`)
+
+**Why:** Default `_BUILD_TREE_NODE_LIMIT=5000` is a hard wall (now returns 1005 after Task 3). LLMs frequently call `tree 3` blind — even 200 nodes can blow context budget. Need a soft cap with a structured `truncated: true` signal.
+
+**Files:**
+- Modify: `addons/godot_cli_control/bridge/low_level_api.gd` (`handle_get_scene_tree` + `_build_tree`)
+- Modify: `python/godot_cli_control/client.py` (`get_scene_tree` accept + pass `max_nodes`)
+- Modify: `python/godot_cli_control/bridge.py` (`tree` accept `max_nodes`)
+- Modify: `python/godot_cli_control/cli.py` (`cmd_tree` register `--max-nodes`, default 200)
+- Modify: `python/godot_cli_control/templates/skill/SKILL.md` (document new arg + truncate shape)
+- Modify: `python/tests/test_client.py` (parse-truncated test)
+- Modify: `python/tests/test_cli.py` (argparse test)
+
+**Steps:**
+
+- [ ] **Step 5.1: Write failing test for CLI argparse acceptance**
+
+Add to `python/tests/test_cli.py`:
+
+```python
+def test_tree_accepts_max_nodes_flag() -> None:
+    from godot_cli_control.cli import build_parser
+
+    parser = build_parser()
+    ns = parser.parse_args(["tree", "3", "--max-nodes", "50"])
+    assert ns.depth == "3"
+    assert ns.max_nodes == 50
+
+
+def test_tree_max_nodes_default_is_200() -> None:
+    from godot_cli_control.cli import build_parser
+
+    parser = build_parser()
+    ns = parser.parse_args(["tree"])
+    assert ns.max_nodes == 200
+```
+
+- [ ] **Step 5.2: Write failing test for client parse**
+
+Add to `python/tests/test_client.py` (or create new `TestTreeTruncate` class):
+
+```python
+@pytest.mark.asyncio
+async def test_get_scene_tree_returns_truncate_metadata() -> None:
+    """服务端在节点超限时返回 {tree, truncated, total_nodes}，client 透传。"""
+    import godot_cli_control.client as client_mod
+
+    class _FakeWS:
+        async def send(self, _): pass
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["params"] = params
+        return {
+            "tree": {"name": "root", "type": "Node", "path": "/root", "children": []},
+            "truncated": True,
+            "total_nodes": 6000,
+        }
+
+    client = client_mod.GameClient(port=1)
+    monkeypatch_target = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.get_scene_tree(depth=3, max_nodes=100)
+    finally:
+        client_mod.GameClient.request = monkeypatch_target
+    assert captured["params"] == {"depth": 3, "max_nodes": 100}
+    assert result["truncated"] is True
+    assert result["total_nodes"] == 6000
+```
+
+- [ ] **Step 5.3: Run failing tests**
+
+Subagent: `coverage run -m pytest python/tests/test_cli.py::test_tree_accepts_max_nodes_flag python/tests/test_cli.py::test_tree_max_nodes_default_is_200 python/tests/test_client.py::test_get_scene_tree_returns_truncate_metadata -v`.
+Expected: 3 FAIL.
+
+- [ ] **Step 5.4: Implement CLI flag**
+
+In `python/godot_cli_control/cli.py`:
+
+1. Add a registrator (place near the other `_register_*_args` helpers around line 358):
+   ```python
+   def _register_tree_args(p: argparse.ArgumentParser) -> None:
+       p.add_argument(
+           "depth",
+           nargs="?",
+           default=None,
+           help="遍历深度，默认 3",
+       )
+       p.add_argument(
+           "--max-nodes",
+           type=int,
+           default=200,
+           help=(
+               "节点数软上限（默认 200）。超出时服务端截断子节点并返回 "
+               "{truncated: true, total_nodes: N}，agent 据此决定是否拆分子树。"
+           ),
+       )
+   ```
+
+2. Update `cmd_tree` to forward `max_nodes`:
+   ```python
+   async def cmd_tree(client: GameClient, ns: argparse.Namespace) -> dict:
+       depth = int(ns.depth) if ns.depth else 3
+       return await client.get_scene_tree(depth=depth, max_nodes=ns.max_nodes)
+   ```
+
+3. Replace the existing `tree` `RpcSpec` so it uses `extra_args=_register_tree_args` and drops the inline `positionals=(Positional("depth", "?", ...))`.
+
+- [ ] **Step 5.5: Implement client method**
+
+In `python/godot_cli_control/client.py:get_scene_tree`:
+
+```python
+async def get_scene_tree(
+    self, depth: int = 5, max_nodes: int | None = None
+) -> dict:
+    params: dict = {"depth": depth}
+    if max_nodes is not None:
+        params["max_nodes"] = max_nodes
+    return await self.request("get_scene_tree", params)
+```
+
+- [ ] **Step 5.6: Implement sync bridge wrapper**
+
+In `python/godot_cli_control/bridge.py:tree`:
+
+```python
+def tree(self, depth: int = 3, max_nodes: int | None = None) -> dict:
+    return self._run(
+        self._client.get_scene_tree(depth=depth, max_nodes=max_nodes)
+    )
+```
+
+- [ ] **Step 5.7: Implement GDScript side**
+
+Pre-check: confirm `_build_tree` has no other callers before changing its signature.
+```bash
+grep -rn "_build_tree(" addons/godot_cli_control/bridge/
+```
+Expected: only definition + recursive call inside `_build_tree`, plus one call from `handle_get_scene_tree`. If anywhere else, update those callers too.
+
+In `addons/godot_cli_control/bridge/low_level_api.gd`:
+
+1. Modify `handle_get_scene_tree` to honor `max_nodes` (default fallback to `_BUILD_TREE_NODE_LIMIT`):
+   ```gdscript
+   func handle_get_scene_tree(params: Dictionary) -> Dictionary:
+       var max_depth: int = params.get("depth", 5) as int
+       # max_nodes 是软上限：超出立刻停止 _build_tree 递归并把信号透出。
+       # 不传时用硬墙 5000 兼容旧客户端。
+       var max_nodes: int = params.get("max_nodes", _BUILD_TREE_NODE_LIMIT) as int
+       if max_nodes <= 0:
+           max_nodes = _BUILD_TREE_NODE_LIMIT
+       var root: Node = get_tree().current_scene
+       if root == null:
+           root = get_tree().root
+       var counter: Array[int] = [0]
+       var tree: Dictionary = _build_tree(root, max_depth, 0, counter, max_nodes)
+       var truncated: bool = counter[0] > max_nodes
+       var response: Dictionary = {"tree": tree}
+       if truncated:
+           response["truncated"] = true
+           response["total_nodes"] = counter[0]
+       # 仍然保留硬墙：超 5000 走 1005，避免恶意大场景吃完 outbound buffer。
+       if counter[0] > _BUILD_TREE_NODE_LIMIT:
+           return _err(
+               CliControlErrorCodes.SCENE_TREE_TOO_LARGE,
+               "scene tree too large (>%d nodes); lower 'depth' or query a subtree" % _BUILD_TREE_NODE_LIMIT,
+           )
+       return response
+   ```
+
+2. Update `_build_tree` signature to accept `max_nodes`:
+   ```gdscript
+   func _build_tree(node: Node, max_depth: int, current_depth: int, counter: Array[int], max_nodes: int) -> Dictionary:
+       counter[0] += 1
+       var entry: Dictionary = {
+           "name": node.name,
+           "type": node.get_class(),
+           "path": str(node.get_path()),
+       }
+       if node is CanvasItem:
+           entry["visible"] = (node as CanvasItem).visible
+       if "text" in node:
+           entry["text"] = str(node.get("text"))
+       if counter[0] > max_nodes:
+           return entry
+       var effective_max: int = _BUILD_TREE_HARD_LIMIT if max_depth == 0 else max_depth
+       if current_depth < effective_max:
+           var children: Array[Dictionary] = []
+           for child: Node in node.get_children():
+               children.append(_build_tree(child, effective_max, current_depth + 1, counter, max_nodes))
+           entry["children"] = children
+       return entry
+   ```
+
+- [ ] **Step 5.8: Update SKILL.md**
+
+In `python/godot_cli_control/templates/skill/SKILL.md`:
+
+1. In the *Read* command list, change:
+   ```markdown
+   - `tree [depth]` — full scene tree
+   ```
+   to:
+   ```markdown
+   - `tree [depth] [--max-nodes N]` — full scene tree (default `--max-nodes 200`; on overflow, response includes `truncated: true` and `total_nodes: N`)
+   ```
+
+2. Add a *Tree truncation* subsection (anywhere logical in the *Command catalogue* area):
+   ```markdown
+   ### Tree truncation
+
+   `tree` caps output at 200 nodes by default to keep the JSON small enough for an LLM context window. When the cap is hit, the response carries explicit signals so you can decide whether to drill in:
+
+   ```json
+   {"ok": true, "result": {
+     "tree": { ... partial subtree ... },
+     "truncated": true,
+     "total_nodes": 6000
+   }}
+   ```
+
+   Responses are subject to a hard ceiling of 5000 nodes — beyond that you get `1005 "scene tree too large"` and must `--max-nodes` down or query a subtree:
+
+   - `tree --max-nodes 50` — quick overview
+   - `children /root/Game/Spawner` — drill into one branch
+   - `tree 1` — depth-1 only
+   ```
+
+- [ ] **Step 5.9: Run all changed-area tests**
+
+Subagent: `coverage run -m pytest python/tests/test_cli.py python/tests/test_client.py -v`.
+Expected: all PASS, no regressions.
+
+- [ ] **Step 5.10: Commit**
+
+```bash
+git add python/godot_cli_control/cli.py \
+        python/godot_cli_control/client.py \
+        python/godot_cli_control/bridge.py \
+        addons/godot_cli_control/bridge/low_level_api.gd \
+        python/godot_cli_control/templates/skill/SKILL.md \
+        python/tests/test_cli.py \
+        python/tests/test_client.py
+git commit -m "feat(tree): --max-nodes 软上限与 truncated 信号
+
+LLM 习惯盲调 \`tree 3\`；一个 200 节点 Grid 就能把 context 吃光。
+新增 --max-nodes（默认 200），超出时服务端返回 {tree (partial),
+truncated: true, total_nodes: N}，agent 据此判断是否分子树。
+
+硬墙 5000 节点不变（防恶意 / outbound buffer 保护），超出仍走 1005。"
+```
+
+---
+
+## Task 6: `set` / `call` `--text-value` escape hatch
+
+**Why:** SKILL.md documents the `null` / `true` / numeric-string footgun, but the workaround is `'"null"'` — three layers of quotes that LLMs routinely mangle in prompt templates. A flag that disables JSON parsing for `value` (and `args`) eliminates the failure mode.
+
+**Files:**
+- Modify: `python/godot_cli_control/cli.py` (`cmd_set`, `cmd_call`, `_register_call_args`, register flag for `set`)
+- Modify: `python/godot_cli_control/templates/skill/SKILL.md` (document)
+- Modify: `python/tests/test_cli.py` (test)
+
+**Steps:**
+
+- [ ] **Step 6.1: Write failing test**
+
+Add to `python/tests/test_cli.py`:
+
+```python
+def test_set_text_value_disables_json_parse() -> None:
+    """--text-value 让 set 把 value 当字面字符串，不走 JSON-or-string fallback。"""
+    from godot_cli_control.cli import build_parser, _resolve_value_for_set
+
+    parser = build_parser()
+    ns = parser.parse_args(["set", "/root/X", "flag", "true", "--text-value"])
+    assert ns.text_value is True
+    # 复用 _resolve_value_for_set 抽出来的解析函数
+    assert _resolve_value_for_set(ns) == "true"
+
+
+def test_set_default_still_json_parses() -> None:
+    from godot_cli_control.cli import build_parser, _resolve_value_for_set
+
+    parser = build_parser()
+    ns = parser.parse_args(["set", "/root/X", "flag", "true"])
+    assert ns.text_value is False
+    assert _resolve_value_for_set(ns) is True
+
+
+def test_call_text_value_disables_arg_parse() -> None:
+    from godot_cli_control.cli import build_parser, _resolve_args_for_call
+
+    parser = build_parser()
+    ns = parser.parse_args(
+        ["call", "/root/X", "set_label", "true", "42", "--text-value"]
+    )
+    assert _resolve_args_for_call(ns) == ["true", "42"]
+```
+
+- [ ] **Step 6.2: Run failing tests**
+
+Subagent: `coverage run -m pytest python/tests/test_cli.py -k "text_value" -v`.
+Expected: FAIL (function doesn't exist).
+
+- [ ] **Step 6.3: Implement helper functions and flag wiring**
+
+In `python/godot_cli_control/cli.py`:
+
+1. Add helpers (near `_parse_json_arg`):
+   ```python
+   def _resolve_value_for_set(ns: argparse.Namespace) -> Any:
+       """根据 --text-value 决定是 JSON-or-string 解析还是直接 string。"""
+       if getattr(ns, "text_value", False):
+           return ns.value
+       return _parse_json_arg(ns.value)
+
+
+   def _resolve_args_for_call(ns: argparse.Namespace) -> list:
+       raw_args: list[str] = list(ns.args or [])
+       if getattr(ns, "text_value", False):
+           return list(raw_args)
+       return [_parse_json_arg(a) for a in raw_args]
+   ```
+
+2. Update `cmd_set` and `cmd_call`:
+   ```python
+   async def cmd_set(client: GameClient, ns: argparse.Namespace) -> dict:
+       value = _resolve_value_for_set(ns)
+       return await client.set_property(ns.node_path, ns.prop, value)
+
+
+   async def cmd_call(client: GameClient, ns: argparse.Namespace) -> Any:
+       args = _resolve_args_for_call(ns)
+       return await client.call_method(ns.node_path, ns.method, args)
+   ```
+
+3. Add `_register_set_args` and update `_register_call_args`:
+   ```python
+   def _register_set_args(p: argparse.ArgumentParser) -> None:
+       p.add_argument("node_path", help="绝对节点路径")
+       p.add_argument("prop", help="属性名")
+       p.add_argument(
+           "value",
+           help="JSON 字面量或字符串。例：'42' / '\"hello\"' / '[10, 20]' / 'hello'",
+       )
+       p.add_argument(
+           "--text-value",
+           action="store_true",
+           help="把 value 当字面字符串，不走 JSON 解析（避开 'null'/'true'/数字 footgun）",
+       )
+
+
+   def _register_call_args(p: argparse.ArgumentParser) -> None:
+       p.add_argument("node_path", help="绝对节点路径，如 /root/Main")
+       p.add_argument("method", help="节点上的方法名")
+       p.add_argument(
+           "args",
+           nargs="*",
+           help="方法参数；每个先按 JSON 解析失败 fallback 字符串",
+       )
+       p.add_argument(
+           "--text-value",
+           action="store_true",
+           help="把所有 args 当字面字符串，不走 JSON 解析",
+       )
+   ```
+
+4. Update the `set` `RpcSpec` to use `extra_args=_register_set_args` and drop its inline `positionals` (matching how `call` and `combo` already do).
+
+- [ ] **Step 6.4: Run tests to confirm pass**
+
+Subagent: `coverage run -m pytest python/tests/test_cli.py -k "text_value" -v`.
+Expected: 3 PASS.
+
+- [ ] **Step 6.5: Update SKILL.md**
+
+In `python/godot_cli_control/templates/skill/SKILL.md` `### set / call value parsing` section, after the existing footgun examples, add:
+
+```markdown
+**Escape hatch (preferred for LLM prompts):** pass `--text-value` to disable JSON parsing entirely:
+
+```bash
+godot-cli-control set /root/Label text null --text-value     # ✓ stores the string "null"
+godot-cli-control set /root/Flag  on   true --text-value     # ✓ stores the string "true"
+godot-cli-control call /root/Game start 42 easy --text-value # call(42, "easy") replaced by call("42", "easy")
+```
+
+Use this when generating commands from a template — it removes the three-quote escaping headache (`'"null"'`).
+```
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add python/godot_cli_control/cli.py \
+        python/godot_cli_control/templates/skill/SKILL.md \
+        python/tests/test_cli.py
+git commit -m "feat(cli): set/call --text-value 关闭 JSON 解析
+
+null/true/false/数字字符串 footgun 的解法是 \`'\\\"null\\\"'\` —— 三层
+嵌套引号在 LLM prompt 模板里经常翻车。新增 --text-value 让 value/args
+强制按字符串处理，去掉这个心智负担。"
+```
+
+---
+
+## Task 7: `daemon start` headless via `isatty` autodetect
+
+**Why:** AI agents shell out from non-TTY stdout (CI, pipes, MCP) but currently get a Godot window unless they remember `--headless`. Interactive devs in a terminal still want the window. Autodetect via `sys.stdout.isatty()` covers 90% of real cases without breaking either workflow.
+
+User decision: **isatty autodetect**. Add `--gui` as an explicit opt-in for forced GUI, keep `--headless` as explicit opt-out.
+
+**Files:**
+- Modify: `python/godot_cli_control/cli.py` (`_add_daemon_flags`, `cmd_daemon_start`, `cmd_run`)
+- Modify: `python/godot_cli_control/templates/skill/SKILL.md` (document)
+- Modify: `addons/godot_cli_control/CHANGELOG.md` (BREAKING change banner — Task 9 consolidates)
+- Modify: `python/tests/test_cli.py` (test)
+
+**Steps:**
+
+- [ ] **Step 7.1: Write failing tests**
+
+Add to `python/tests/test_cli.py`:
+
+```python
+class TestDaemonHeadlessAutodetect:
+    def test_default_headless_when_stdout_not_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from godot_cli_control.cli import _resolve_headless
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        ns = type("NS", (), {"headless": False, "gui": False})()
+        assert _resolve_headless(ns) is True
+
+    def test_default_gui_when_stdout_is_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from godot_cli_control.cli import _resolve_headless
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        ns = type("NS", (), {"headless": False, "gui": False})()
+        assert _resolve_headless(ns) is False
+
+    def test_explicit_headless_wins_over_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from godot_cli_control.cli import _resolve_headless
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        ns = type("NS", (), {"headless": True, "gui": False})()
+        assert _resolve_headless(ns) is True
+
+    def test_explicit_gui_wins_over_pipe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from godot_cli_control.cli import _resolve_headless
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        ns = type("NS", (), {"headless": False, "gui": True})()
+        assert _resolve_headless(ns) is False
+
+    def test_gui_and_headless_mutually_exclusive(self) -> None:
+        from godot_cli_control.cli import build_parser
+
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["daemon", "start", "--headless", "--gui"])
+```
+
+- [ ] **Step 7.2: Run failing tests**
+
+Subagent: `coverage run -m pytest python/tests/test_cli.py::TestDaemonHeadlessAutodetect -v`.
+Expected: 5 FAIL (function and `--gui` flag don't exist yet).
+
+- [ ] **Step 7.3: Implement `_resolve_headless` and add `--gui`**
+
+In `python/godot_cli_control/cli.py`:
+
+1. Add helper near the top (after the EXIT_* constants):
+   ```python
+   def _resolve_headless(ns: argparse.Namespace) -> bool:
+       """决定本次 daemon start 是否走 --headless。
+
+       优先级：显式 --headless > 显式 --gui > stdout.isatty() 自动判。
+       isatty=False（pipe / redirect / 非 TTY agent shell）默认 headless；
+       isatty=True（开发者交互终端）默认开窗。
+       """
+       if getattr(ns, "headless", False):
+           return True
+       if getattr(ns, "gui", False):
+           return False
+       try:
+           return not sys.stdout.isatty()
+       except (AttributeError, ValueError):
+           # ValueError: I/O operation on closed file（罕见）
+           return True  # 安全默认
+   ```
+
+2. Modify `_add_daemon_flags`:
+   ```python
+   def _add_daemon_flags(p: argparse.ArgumentParser) -> None:
+       # ... existing options ...
+       headless_grp = p.add_mutually_exclusive_group()
+       headless_grp.add_argument(
+           "--headless",
+           action="store_true",
+           help="无窗口模式。默认值：stdout 非 TTY 时自动 headless（CI / pipe / agent）。",
+       )
+       headless_grp.add_argument(
+           "--gui",
+           action="store_true",
+           help="强制开窗。覆盖 isatty 自动判（例如 stdout 是 pipe 仍想看到窗口）。",
+       )
+   ```
+   Remove the old `p.add_argument("--headless", ...)` line. Keep `--record` / `--movie-path` / `--fps` / `--port` / `--idle-timeout` unchanged.
+
+3. Update `cmd_daemon_start` to use `_resolve_headless(ns)` instead of `ns.headless`:
+   ```python
+   daemon.start(
+       record=ns.record,
+       movie_path=ns.movie_path,
+       headless=_resolve_headless(ns),
+       fps=ns.fps,
+       port=ns.port,
+       idle_timeout=idle_seconds,
+   )
+   ```
+
+4. Same change in `cmd_run`:
+   ```python
+   daemon.start(
+       record=ns.record,
+       movie_path=ns.movie_path,
+       headless=_resolve_headless(ns),
+       fps=ns.fps,
+       port=ns.port,
+       idle_timeout=idle_seconds,
+   )
+   ```
+
+- [ ] **Step 7.4: Run tests to confirm pass**
+
+Subagent: same command as Step 7.2.
+Expected: 5 PASS.
+
+- [ ] **Step 7.5: Update SKILL.md**
+
+In `python/godot_cli_control/templates/skill/SKILL.md`:
+
+1. Quickstart section (lines 25–35): keep `daemon start --headless` example but add a note above it:
+   ```markdown
+   > As of this version, `daemon start` autodetects headless mode by checking `stdout.isatty()`. Pipes, CI, and agent shell-outs run headless by default; an interactive terminal still gets a window. The explicit flags below are only needed to override.
+   ```
+
+2. Common pitfalls — add bullet:
+   ```markdown
+   - **`daemon start` opens a window when I expected headless** — your stdout is a TTY (interactive terminal). Pass `--headless` explicitly, or shell out from a context where stdout is piped.
+   ```
+
+- [ ] **Step 7.6: Smoke test**
+
+```bash
+# Should NOT spawn a Godot window (stdout is piped):
+/Users/kesar/Projects/godot-cli-control/.venv/bin/python -m godot_cli_control daemon start --json 2>&1 | head -3
+```
+
+(This will fail to find a Godot project at the repo root; that's expected. The failure envelope just confirms the flag parsed; verify no `--headless` warning prints.)
+
+- [ ] **Step 7.7: Commit**
+
+```bash
+git add python/godot_cli_control/cli.py \
+        python/godot_cli_control/templates/skill/SKILL.md \
+        python/tests/test_cli.py
+git commit -m "feat(daemon): headless 默认 isatty 自适应
+
+stdout 非 TTY（pipe / CI / agent shell）默认 headless；
+TTY（开发者交互终端）默认开窗。新增 --gui 显式覆盖；
+--headless 仍可显式传。
+
+LLM 在 MCP / agent shell 里调 daemon start 不再需要记得加
+--headless 才能跑通。"
+```
+
+---
+
+## Task 8: Refresh root CLAUDE.md known-issues list
+
+**Why:** The root `CLAUDE.md` has a *已知遗留 issue* section listing exactly the items being fixed in this plan. After landing the fixes the list is stale.
+
+**Files:**
+- Modify: `CLAUDE.md` (the known-issues subsection)
+
+**Steps:**
+
+- [ ] **Step 8.1: Replace stale issues list**
+
+In `CLAUDE.md`, replace the entire *已知遗留 issue* section with:
+
+```markdown
+## 已知遗留 issue（PR 路过时顺手修）
+
+*（截至 2026-05-11，AI 友好性 review 列出的 7 项已全部 land。下次 review 发现新坑请补到这里。）*
+```
+
+- [ ] **Step 8.2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: 清理 CLAUDE.md 已修完的 review 项"
+```
+
+---
+
+## Task 9: Consolidated CHANGELOG entry
+
+**Why:** Every code change should land in `[Unreleased]`. Six fixes in one PR collapse into one CHANGELOG block.
+
+**Files:**
+- Modify: `addons/godot_cli_control/CHANGELOG.md` ([Unreleased] section)
+
+**Steps:**
+
+- [ ] **Step 9.1: Append entries under existing [Unreleased]**
+
+Add at the end of the `## [Unreleased]` block (before the next version heading):
+
+```markdown
+### AI-friendliness review fixes (2026-05-11)
+
+#### Fixed
+- **CLI flag position**: `--json` / `--text` / `--port` 现在在 RPC 子命令尾部也接受（之前只能写最前面）。修复每个子 parser 缺 `_add_output_format_flags` 注入。
+- **Error code 1004 collision**: `low_level_api.gd` 的 scene tree 超限改用新业务码 `1005 "scene tree too large"`，与 input_simulation `1004 "combo in progress"` 解耦。新增 `error_codes.gd` 集中常量。
+- **pytest fixture default port**: `--godot-cli-port` 默认从 9877 改为 0（OS-assigned），与 `daemon start` 默认对齐；多项目并行测试不再撞端口。
+- **Addon README error-code table**: 之前只列到 1003，补全 1004 / 1005 / 客户端 -1xxx 段。
+
+#### Added
+- `tree --max-nodes <N>`（默认 200）：节点数软上限；超出时响应含 `truncated: true` + `total_nodes`，agent 据此决定分子树。硬墙仍是 5000 节点 → `1005`。
+- `set` / `call --text-value`：禁用 JSON 解析、把 value/args 强制按字符串处理，避开 `null` / `true` / `42` 这类字面量被解析成 Variant 类型的 footgun。
+
+#### Changed
+- **BREAKING (轻微)**：`daemon start` / `run` 默认 headless 行为改为基于 `sys.stdout.isatty()` 自动判定 —— pipe / CI / agent shell 默认 headless；交互终端默认开窗。新增 `--gui` 强制开窗 flag。`--headless` 仍可显式传，覆盖自动判。脚本里依赖 "默认会开窗" 的需要加 `--gui`。
+```
+
+- [ ] **Step 9.2: Commit**
+
+```bash
+git add addons/godot_cli_control/CHANGELOG.md
+git commit -m "docs(changelog): 记录 AI 友好性 review 7 项修复"
+```
+
+---
+
+## Final verification
+
+- [ ] **Final 1: Run full Python test suite**
+
+Dispatch subagent (`model: "sonnet"`):
+> Run `coverage run -m pytest python/tests/ -v` from `/Users/kesar/Projects/godot-cli-control`. Report only: PASS/FAIL counts, names of any failing tests, and the line of the first failure if any. Do not dump full output.
+
+Expected: all PASS, coverage ≥ 80% (`fail_under` threshold from pyproject.toml).
+
+- [ ] **Final 2: Render SKILL.md and confirm no template breakage**
+
+```bash
+/Users/kesar/Projects/godot-cli-control/.venv/bin/python -c "from godot_cli_control import cli, _version, skills_install; print(skills_install.render_skill(_version.__version__, cli.format_full_help())[:200])"
+```
+
+Expected: prints rendered SKILL.md prefix; no `KeyError` / unrendered `{{...}}` placeholders.
+
+- [ ] **Final 3: Confirm GUT tests still build (best-effort)**
+
+If `GODOT_BIN` is set: `GODOT_BIN=$GODOT_BIN ./addons/godot_cli_control/tests/run_gut.sh`. Otherwise skip and rely on the GDScript static checks in T3.6.
+
+- [ ] **Final 4: PR description draft**
+
+Write a PR title + body summarizing the 7 fixes, linking to the review summary in the conversation, calling out the one BREAKING change (headless default).
+
+---
+
+## Risks
+
+- **`--gui` flag is new** — pre-existing scripts that *expected* a window without passing any flag now get one only if stdout is a TTY. If users run daemon-start under `nohup` / `&` / IDE run-buttons that pipe stdout, they'll silently flip to headless. Mitigation: CHANGELOG entry calls this out as BREAKING; SKILL.md pitfalls section explains the override.
+- **GDScript constants module** is a new file under `addons/godot_cli_control/bridge/`. Make sure it's included in the wheel via the existing `[tool.hatch.build.targets.wheel.force-include]` glob (`"addons/godot_cli_control" = "godot_cli_control/_plugin"` already covers all files in that dir).
+- **Tree truncate hard-vs-soft limit interaction**: if a user passes `--max-nodes 6000`, the GDScript clamps to 5000 hard ceiling and returns 1005. Make sure the new code honors that order: count first, then check soft cap, then check hard cap. T5.7 implementation does this correctly.
+- **Test parallelism** with the new `--godot-cli-port=0` default: pytest-xdist users will now have each worker on its own port — that's actually a fix, not a risk, but flag it in the CHANGELOG.

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -47,9 +47,9 @@ class GameBridge:
 
     # ── 场景树 ──
 
-    def tree(self, depth: int = 3) -> dict:
+    def tree(self, depth: int = 3, max_nodes: int | None = None) -> dict:
         """获取场景树。"""
-        return self._run(self._client.get_scene_tree(depth=depth))
+        return self._run(self._client.get_scene_tree(depth=depth, max_nodes=max_nodes))
 
     def node_exists(self, path: str) -> bool:
         """检查节点是否存在。"""

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -58,6 +58,24 @@ CLIENT_CODE_IO = -1004  # 本地文件 IO 错误（screenshot 写盘等），与
 CLIENT_CODE_INTERNAL = -1099  # 兜底：客户端内部异常（理论上不该到这里，但兜住契约）
 
 
+def _resolve_headless(ns: argparse.Namespace) -> bool:
+    """决定本次 daemon start 是否走 --headless。
+
+    优先级：显式 --headless > 显式 --gui > stdout.isatty() 自动判。
+    isatty=False（pipe / redirect / 非 TTY agent shell）默认 headless；
+    isatty=True（开发者交互终端）默认开窗。
+    """
+    if getattr(ns, "headless", False):
+        return True
+    if getattr(ns, "gui", False):
+        return False
+    try:
+        return not sys.stdout.isatty()
+    except (AttributeError, ValueError):
+        # ValueError: I/O operation on closed file（罕见）
+        return True  # 安全默认
+
+
 # ── RpcSpec：声明一个 RPC 子命令 ──
 
 
@@ -705,7 +723,7 @@ def cmd_daemon_start(ns: argparse.Namespace) -> int:
         daemon.start(
             record=ns.record,
             movie_path=ns.movie_path,
-            headless=ns.headless,
+            headless=_resolve_headless(ns),
             fps=ns.fps,
             port=ns.port,
             idle_timeout=idle_seconds,
@@ -901,7 +919,7 @@ def cmd_run(ns: argparse.Namespace) -> int:
             daemon.start(
                 record=ns.record,
                 movie_path=ns.movie_path,
-                headless=ns.headless,
+                headless=_resolve_headless(ns),
                 fps=ns.fps,
                 port=ns.port,
                 idle_timeout=idle_seconds,
@@ -1093,10 +1111,16 @@ def _add_daemon_flags(p: argparse.ArgumentParser) -> None:
         default=None,
         help="demo 输出路径，默认 .cli_control 下自动命名",
     )
-    p.add_argument(
+    headless_grp = p.add_mutually_exclusive_group()
+    headless_grp.add_argument(
         "--headless",
         action="store_true",
-        help="无窗口模式，CI/无显示器环境用",
+        help="无窗口模式。默认值：stdout 非 TTY 时自动 headless（CI / pipe / agent）。",
+    )
+    headless_grp.add_argument(
+        "--gui",
+        action="store_true",
+        help="强制开窗。覆盖 isatty 自动判（例如 stdout 是 pipe 仍想看到窗口）。",
     )
     p.add_argument("--fps", type=int, default=30, help="录制帧率，默认 30")
     p.add_argument(

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -113,6 +113,20 @@ def _parse_json_arg(raw: str) -> Any:
         return raw
 
 
+def _resolve_value_for_set(ns: argparse.Namespace) -> Any:
+    """根据 --text-value 决定是 JSON-or-string 解析还是直接 string。"""
+    if getattr(ns, "text_value", False):
+        return ns.value
+    return _parse_json_arg(ns.value)
+
+
+def _resolve_args_for_call(ns: argparse.Namespace) -> list:
+    raw_args: list[str] = list(ns.args or [])
+    if getattr(ns, "text_value", False):
+        return list(raw_args)
+    return [_parse_json_arg(a) for a in raw_args]
+
+
 def _preflight_combo(ns: argparse.Namespace) -> None:
     """连 daemon 前用同一份解析逻辑校验 combo 输入；抛 ValueError 即用法错。
 
@@ -222,15 +236,16 @@ async def cmd_get(client: GameClient, ns: argparse.Namespace) -> Any:
 
 
 async def cmd_set(client: GameClient, ns: argparse.Namespace) -> dict:
-    """写节点属性。``value`` 先按 JSON 解析；失败退回字符串字面量。"""
-    value = _parse_json_arg(ns.value)
+    """写节点属性。``value`` 先按 JSON 解析；失败退回字符串字面量。
+    加 ``--text-value`` 跳过 JSON 解析，强制当字符串处理。"""
+    value = _resolve_value_for_set(ns)
     return await client.set_property(ns.node_path, ns.prop, value)
 
 
 async def cmd_call(client: GameClient, ns: argparse.Namespace) -> Any:
-    """调任意节点方法。每个 arg 同样 JSON-or-string 解析。"""
-    raw_args: list[str] = list(ns.args or [])
-    args = [_parse_json_arg(a) for a in raw_args]
+    """调任意节点方法。每个 arg 同样 JSON-or-string 解析。
+    加 ``--text-value`` 跳过 JSON 解析，所有 args 强制当字符串处理。"""
+    args = _resolve_args_for_call(ns)
     return await client.call_method(ns.node_path, ns.method, args)
 
 
@@ -381,6 +396,20 @@ def _register_actions_flag(p: argparse.ArgumentParser) -> None:
     )
 
 
+def _register_set_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("node_path", help="绝对节点路径")
+    p.add_argument("prop", help="属性名")
+    p.add_argument(
+        "value",
+        help="JSON 字面量或字符串。例：'42' / '\"hello\"' / '[10, 20]' / 'hello'",
+    )
+    p.add_argument(
+        "--text-value",
+        action="store_true",
+        help="把 value 当字面字符串，不走 JSON 解析（避开 'null'/'true'/数字 footgun）",
+    )
+
+
 def _register_call_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("node_path", help="绝对节点路径，如 /root/Main")
     p.add_argument("method", help="节点上的方法名")
@@ -388,6 +417,11 @@ def _register_call_args(p: argparse.ArgumentParser) -> None:
         "args",
         nargs="*",
         help="方法参数；每个先按 JSON 解析失败 fallback 字符串",
+    )
+    p.add_argument(
+        "--text-value",
+        action="store_true",
+        help="把所有 args 当字面字符串，不走 JSON 解析",
     )
 
 
@@ -528,17 +562,13 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
     RpcSpec(
         name="set",
         handler=cmd_set,
-        description="写节点属性。value 优先按 JSON 解析（数字/数组/对象），失败退回字符串。",
-        positionals=(
-            Positional("node_path", None, "绝对节点路径"),
-            Positional("prop", None, "属性名"),
-            Positional(
-                "value",
-                None,
-                "JSON 字面量或字符串。例：'42' / '\"hello\"' / '[10, 20]' / 'hello'",
-            ),
+        description=(
+            "写节点属性。value 优先按 JSON 解析（数字/数组/对象），失败退回字符串。"
+            "加 --text-value 强制把 value 当字符串，避开 null/true/false/数字 footgun。"
         ),
+        positionals=(),  # 由 extra_args 注册（node_path + prop + value + --text-value）
         example="set /root/Main/Score text \"42\"",
+        extra_args=_register_set_args,
         text_formatter=lambda r: f"set: {r}",
     ),
     RpcSpec(

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1071,13 +1071,19 @@ def _add_output_format_flags(p: argparse.ArgumentParser) -> None:
 
     默认 json 是 0.2.0 起的新行为（向 AI agent 倾斜）。``--no-json`` 是
     ``--text`` 的别名，方便顺手敲。
+
+    所有 ``add_argument`` 均使用 ``default=argparse.SUPPRESS``，使 argparse
+    仅在 flag 被显式传入时才向 namespace 写值，而非用 default 覆盖已有值。
+    真正的全局默认值由顶层 ``parser.set_defaults(output_format=OUTPUT_JSON)``
+    负责注入（见 ``build_parser``），子命令 subparser 直接调用本函数即可，
+    不会产生"子 default 盖父 const"的经典 argparse 陷阱。
     """
     p.add_argument(
         "--json",
         dest="output_format",
         action="store_const",
         const=OUTPUT_JSON,
-        default=OUTPUT_JSON,
+        default=argparse.SUPPRESS,
         help="输出 JSON 信封（默认）",
     )
     p.add_argument(
@@ -1085,6 +1091,7 @@ def _add_output_format_flags(p: argparse.ArgumentParser) -> None:
         dest="output_format",
         action="store_const",
         const=OUTPUT_TEXT,
+        default=argparse.SUPPRESS,
         help="输出旧的人类可读字符串（不再加信封；errors 走 stderr）",
     )
     p.add_argument(
@@ -1092,6 +1099,7 @@ def _add_output_format_flags(p: argparse.ArgumentParser) -> None:
         dest="output_format",
         action="store_const",
         const=OUTPUT_TEXT,
+        default=argparse.SUPPRESS,
         help="--text 别名",
     )
 
@@ -1122,6 +1130,10 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     _add_output_format_flags(parser)
+    # 全局默认：不传任何 output-format flag 时保持 JSON 输出。
+    # 注意：各 subparser 中也调用 _add_output_format_flags，但均用 SUPPRESS 不写
+    # default，故此处 set_defaults 是唯一的全局 fallback，不会被子命令覆盖。
+    parser.set_defaults(output_format=OUTPUT_JSON)
     subs = parser.add_subparsers(dest="cmd", required=True, metavar="<command>")
 
     # daemon 组
@@ -1140,6 +1152,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="启动 Godot daemon 并写入 .cli_control/{godot.pid,port}。",
     )
     _add_daemon_flags(start_p)
+    _add_output_format_flags(start_p)
 
     stop_p = daemon_subs.add_parser(
         "stop",
@@ -1158,8 +1171,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--project", type=Path, default=None,
         help="停止指定项目根的 daemon（绝对/相对路径均可）"
     )
+    _add_output_format_flags(stop_p)
 
-    daemon_subs.add_parser(
+    status_p = daemon_subs.add_parser(
         "status",
         help="查询 daemon 状态",
         description=(
@@ -1169,6 +1183,7 @@ def build_parser() -> argparse.ArgumentParser:
             "默认输出 JSON 信封；加 --text 切回旧的字符串格式。"
         ),
     )
+    _add_output_format_flags(status_p)
 
     ls_p = daemon_subs.add_parser(
         "ls",
@@ -1204,6 +1219,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run_p.add_argument("script", help="用户脚本路径，需定义 run(bridge)")
     _add_daemon_flags(run_p)
+    _add_output_format_flags(run_p)
 
     # init：一键接入
     init_p = subs.add_parser(
@@ -1254,6 +1270,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="只写 skill 文件，跳过插件复制 / project.godot patch / godot_bin 检测",
     )
+    _add_output_format_flags(init_p)
 
     # RPC 单发命令
     for spec in RPC_SPECS:
@@ -1277,6 +1294,7 @@ def build_parser() -> argparse.ArgumentParser:
             sp.add_argument(pos.name, **kwargs)
         if spec.extra_args is not None:
             spec.extra_args(sp)
+        _add_output_format_flags(sp)
     return parser
 
 

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -71,8 +71,9 @@ def _resolve_headless(ns: argparse.Namespace) -> bool:
         return False
     try:
         return not sys.stdout.isatty()
-    except (AttributeError, ValueError):
-        # ValueError: I/O operation on closed file（罕见）
+    except (OSError, ValueError):
+        # ValueError: I/O operation on closed file
+        # OSError: 底层 fd 失效（罕见，譬如 fd 被 close 但对象未刷新）
         return True  # 安全默认
 
 
@@ -141,7 +142,7 @@ def _resolve_value_for_set(ns: argparse.Namespace) -> Any:
 def _resolve_args_for_call(ns: argparse.Namespace) -> list:
     raw_args: list[str] = list(ns.args or [])
     if getattr(ns, "text_value", False):
-        return list(raw_args)
+        return raw_args
     return [_parse_json_arg(a) for a in raw_args]
 
 

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -181,7 +181,7 @@ async def cmd_screenshot(client: GameClient, ns: argparse.Namespace) -> dict:
 
 async def cmd_tree(client: GameClient, ns: argparse.Namespace) -> dict:
     depth = int(ns.depth) if ns.depth else 3
-    return await client.get_scene_tree(depth=depth)
+    return await client.get_scene_tree(depth=depth, max_nodes=ns.max_nodes)
 
 
 async def cmd_press(client: GameClient, ns: argparse.Namespace) -> dict:
@@ -355,6 +355,24 @@ def _register_combo_args(p: argparse.ArgumentParser) -> None:
     )
 
 
+def _register_tree_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "depth",
+        nargs="?",
+        default=None,
+        help="遍历深度，默认 3",
+    )
+    p.add_argument(
+        "--max-nodes",
+        type=int,
+        default=200,
+        help=(
+            "节点数软上限（默认 200）。超出时服务端截断子节点并返回 "
+            "{truncated: true, total_nodes: N}，agent 据此决定是否拆分子树。"
+        ),
+    )
+
+
 def _register_actions_flag(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--all",
@@ -407,10 +425,9 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
         name="tree",
         handler=cmd_tree,
         description="dump 当前场景树为 JSON。",
-        positionals=(
-            Positional("depth", "?", "遍历深度，默认 3"),
-        ),
+        positionals=(),  # 由 extra_args 注册（depth + --max-nodes）
         example="tree 3",
+        extra_args=_register_tree_args,
         text_formatter=_fmt_tree_text,
     ),
     RpcSpec(

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -243,15 +243,9 @@ class GameClient:
     ) -> dict:
         """读取场景树（可选软上限）。
 
-        ``max_nodes`` 行为：
-
-        * ``None``（默认）：不发 ``max_nodes`` 参数；服务端走 5000 硬墙兼容路径，
-          ``truncated`` 字段永不出现。Python API 与早期版本完全兼容。
-        * 正整数 N：服务端在节点数超过 N 时在响应里追加
-          ``{"truncated": true, "total_nodes": M}``。超过 5000 仍走 1005 错误。
-
-        注意：CLI ``tree`` 子命令默认传 ``max_nodes=200``，与本 API 默认 ``None``
-        形成不对称——前者保护 LLM context，后者保留向后兼容。
+        ``max_nodes``：``None`` 走服务端默认（硬墙 5000，无 ``truncated`` 字段）；
+        传正整数 N 时，节点数超 N 时响应附加 ``{"truncated": true, "total_nodes": M}``。
+        服务端会把传入值 clamp 到 5000 上限，超过仍走 1005 错误。
         """
         params: dict = {"depth": depth}
         if max_nodes is not None:

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -238,8 +238,13 @@ class GameClient:
         result = await self.request("screenshot")
         return base64.b64decode(result.get("image", ""))
 
-    async def get_scene_tree(self, depth: int = 5) -> dict:
-        return await self.request("get_scene_tree", {"depth": depth})
+    async def get_scene_tree(
+        self, depth: int = 5, max_nodes: int | None = None
+    ) -> dict:
+        params: dict = {"depth": depth}
+        if max_nodes is not None:
+            params["max_nodes"] = max_nodes
+        return await self.request("get_scene_tree", params)
 
     async def wait_for_node(self, path: str, timeout: float = 5.0) -> bool:
         result = await self.request(

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -241,6 +241,18 @@ class GameClient:
     async def get_scene_tree(
         self, depth: int = 5, max_nodes: int | None = None
     ) -> dict:
+        """读取场景树（可选软上限）。
+
+        ``max_nodes`` 行为：
+
+        * ``None``（默认）：不发 ``max_nodes`` 参数；服务端走 5000 硬墙兼容路径，
+          ``truncated`` 字段永不出现。Python API 与早期版本完全兼容。
+        * 正整数 N：服务端在节点数超过 N 时在响应里追加
+          ``{"truncated": true, "total_nodes": M}``。超过 5000 仍走 1005 错误。
+
+        注意：CLI ``tree`` 子命令默认传 ``max_nodes=200``，与本 API 默认 ``None``
+        形成不对称——前者保护 LLM context，后者保留向后兼容。
+        """
         params: dict = {"depth": depth}
         if max_nodes is not None:
             params["max_nodes"] = max_nodes

--- a/python/godot_cli_control/pytest_plugin.py
+++ b/python/godot_cli_control/pytest_plugin.py
@@ -13,7 +13,7 @@
         assert bridge.get_property("/root/Player", "on_floor") is False
 
 CLI 选项：
-  --godot-cli-port            GameBridge 端口（默认 9877）
+  --godot-cli-port            GameBridge 端口（默认 0 = OS 自动分配）
   --godot-cli-no-headless     带窗口跑（默认 headless）
   --godot-cli-project-root    指定 Godot 项目根（默认 pytest rootdir）
 """
@@ -35,8 +35,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     group.addoption(
         "--godot-cli-port",
         action="store",
-        default=str(DEFAULT_PORT),
-        help="GameBridge WebSocket port for the godot_daemon fixture (default: 9877).",
+        default="0",  # 0 = OS-assigned，与 daemon start 默认对齐
+        help="GameBridge WebSocket port for the godot_daemon fixture (default: 0 = OS-assigned).",
     )
     group.addoption(
         "--godot-cli-no-headless",

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -76,9 +76,10 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 |---|---|
 | `1001` | Node not found at the given path. Most common — usually the agent passed a wrong / not-yet-loaded path. Retry after `wait-node`. |
 | `1002` | Property not found on the node, or shape mismatch (e.g. `text` on a node that doesn't have it). Don't retry; inspect with `tree`. |
-| `1003` | Method not found, or render unavailable (screenshot before the viewport is ready). |
+| `1003` | Method not found on the node. Schema error — don't retry, inspect with `tree`. |
 | `1004` | Combo already in progress. Call `combo-cancel` (or `release-all`) and re-issue. Safe to retry after that. |
 | `1005` | Scene tree too large to serialize (default safety limit). Pass `--max-nodes` or query a subtree with `children` / `tree <subpath>`. Don't retry as-is. |
+| `1006` | Resource transiently unavailable (e.g. screenshot before viewport renders the first frame). Safe to retry after `wait-time 0.05` or similar. |
 
 **JSON-RPC standard — negative integers `-32xxx`:**
 

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -106,7 +106,7 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 - `exists <path>` — boolean existence check (exit-code-as-result)
 - `visible <path>` — boolean visibility check (exit-code-as-result)
 - `children <path> [type-filter]` — direct children
-- `tree [depth]` — full scene tree
+- `tree [depth] [--max-nodes N]` — full scene tree (default `--max-nodes 200`; on overflow, response includes `truncated: true` and `total_nodes: N`)
 - `pressed` — currently held simulated input actions
 - `actions [--all]` — InputMap actions (default filters `ui_*` builtins)
 
@@ -159,6 +159,24 @@ godot-cli-control set /root/Label text '"null"'   # ✓ stores the string "null"
 godot-cli-control set /root/Flag  on   true       # ⚠️ stores boolean true
 godot-cli-control set /root/Flag  on   '"true"'   # ✓ stores the string "true"
 ```
+
+### Tree truncation
+
+`tree` caps output at 200 nodes by default to keep the JSON small enough for an LLM context window. When the cap is hit, the response carries explicit signals so you can decide whether to drill in:
+
+```json
+{"ok": true, "result": {
+  "tree": { "...": "partial subtree" },
+  "truncated": true,
+  "total_nodes": 6000
+}}
+```
+
+Responses are subject to a hard ceiling of 5000 nodes — beyond that you get `1005 "scene tree too large"` and must `--max-nodes` down or query a subtree:
+
+- `tree --max-nodes 50` — quick overview
+- `children /root/Game/Spawner` — drill into one branch
+- `tree 1` — depth-1 only
 
 ### `combo` JSON schema
 

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -160,6 +160,16 @@ godot-cli-control set /root/Flag  on   true       # ⚠️ stores boolean true
 godot-cli-control set /root/Flag  on   '"true"'   # ✓ stores the string "true"
 ```
 
+**Escape hatch (preferred for LLM prompts):** pass `--text-value` to disable JSON parsing entirely:
+
+```bash
+godot-cli-control set /root/Label text null --text-value     # ✓ stores the string "null"
+godot-cli-control set /root/Flag  on   true --text-value     # ✓ stores the string "true"
+godot-cli-control call /root/Game start 42 easy --text-value # ✓ calls with ("42", "easy") — all strings
+```
+
+Use this when generating commands from a template — it removes the three-quote escaping headache (`'"null"'`).
+
 ### Tree truncation
 
 `tree` caps output at 200 nodes by default to keep the JSON small enough for an LLM context window. When the cap is hit, the response carries explicit signals so you can decide whether to drill in:

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -34,6 +34,8 @@ godot-cli-control tree 2 | jq .result             # confirm RPC works
 godot-cli-control daemon stop
 ```
 
+> As of this version, `daemon start` autodetects headless mode by checking `stdout.isatty()`. Pipes, CI, and agent shell-outs run headless by default; an interactive terminal still gets a window. The explicit flags below are only needed to override: `--headless` forces headless even in a TTY; `--gui` forces a window even when stdout is piped.
+
 ## Exit codes
 
 | Code | Meaning |
@@ -325,6 +327,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **`combo` rejects everything with `1004`** — a combo is already running. Call `combo-cancel` (or `release-all`) to abort.
 - **`tree` returns `1005 "scene tree too large"`** — your scene has more than 5000 visible nodes (a Grid / spawned-bullets situation). Pass `--max-nodes 200` to cap, or `children <path>` for one specific subtree.
 - **`set` with a string that *looks* like JSON** — value parser parses JSON first. To force a literal `"42"` string, pass `'"42"'`; to set a literal hash sign or array text, JSON-encode it.
+- **`daemon start` opens a window when I expected headless** — your stdout is a TTY (interactive terminal). Pass `--headless` explicitly, or shell out from a context where stdout is piped.
 
 ---
 

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -76,6 +76,7 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 | `1002` | Property not found on the node, or shape mismatch (e.g. `text` on a node that doesn't have it). Don't retry; inspect with `tree`. |
 | `1003` | Method not found, or render unavailable (screenshot before the viewport is ready). |
 | `1004` | Combo already in progress. Call `combo-cancel` (or `release-all`) and re-issue. Safe to retry after that. |
+| `1005` | Scene tree too large to serialize (default safety limit). Pass `--max-nodes` or query a subtree with `children` / `tree <subpath>`. Don't retry as-is. |
 
 **JSON-RPC standard — negative integers `-32xxx`:**
 
@@ -294,6 +295,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **Daemon won't start** — check `.cli_control/godot_bin` exists and points at a real Godot 4 binary, or `export GODOT_BIN=/path/to/godot`. See `godot-cli-control init -h` for the full lookup chain.
 - **Output flags work in any position** — `--json` / `--text` / `--no-json` are accepted both before and after subcommands as of this fix. `--port N` is still top-level only; pass it before the subcommand.
 - **`combo` rejects everything with `1004`** — a combo is already running. Call `combo-cancel` (or `release-all`) to abort.
+- **`tree` returns `1005 "scene tree too large"`** — your scene has more than 5000 visible nodes (a Grid / spawned-bullets situation). Pass `--max-nodes 200` to cap, or `children <path>` for one specific subtree.
 - **`set` with a string that *looks* like JSON** — value parser parses JSON first. To force a literal `"42"` string, pass `'"42"'`; to set a literal hash sign or array text, JSON-encode it.
 
 ---

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -292,7 +292,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **Node paths must be absolute** — start with `/root/...`. Relative paths return `node not found`.
 - **`InvalidMessage` / `did not receive a valid HTTP response`** — `all_proxy` / `http_proxy` env var is hijacking localhost. The client sets `proxy=None` to defend, but if you see weird handshake errors, `unset all_proxy` first.
 - **Daemon won't start** — check `.cli_control/godot_bin` exists and points at a real Godot 4 binary, or `export GODOT_BIN=/path/to/godot`. See `godot-cli-control init -h` for the full lookup chain.
-- **Top-level `--port` doesn't change daemon port** — it only routes RPC subcommands. The daemon defaults to OS-assigned (written to `.cli_control/port`); to fix it, pass `--port` *after* the subcommand: `godot-cli-control daemon start --port 9888`.
+- **Top-level flags work in any position** — `--json` / `--text` / `--port N` are accepted both before and after subcommands as of this fix. Pre-fix sessions only honored them at the front.
 - **`combo` rejects everything with `1004`** — a combo is already running. Call `combo-cancel` (or `release-all`) to abort.
 - **`set` with a string that *looks* like JSON** — value parser parses JSON first. To force a literal `"42"` string, pass `'"42"'`; to set a literal hash sign or array text, JSON-encode it.
 

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -292,7 +292,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **Node paths must be absolute** — start with `/root/...`. Relative paths return `node not found`.
 - **`InvalidMessage` / `did not receive a valid HTTP response`** — `all_proxy` / `http_proxy` env var is hijacking localhost. The client sets `proxy=None` to defend, but if you see weird handshake errors, `unset all_proxy` first.
 - **Daemon won't start** — check `.cli_control/godot_bin` exists and points at a real Godot 4 binary, or `export GODOT_BIN=/path/to/godot`. See `godot-cli-control init -h` for the full lookup chain.
-- **Top-level flags work in any position** — `--json` / `--text` / `--port N` are accepted both before and after subcommands as of this fix. Pre-fix sessions only honored them at the front.
+- **Output flags work in any position** — `--json` / `--text` / `--no-json` are accepted both before and after subcommands as of this fix. `--port N` is still top-level only; pass it before the subcommand.
 - **`combo` rejects everything with `1004`** — a combo is already running. Call `combo-cancel` (or `release-all`) to abort.
 - **`set` with a string that *looks* like JSON** — value parser parses JSON first. To force a literal `"42"` string, pass `'"42"'`; to set a literal hash sign or array text, JSON-encode it.
 

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -47,7 +47,10 @@ class _StubClient:
         return self._record("wait_game_time", (seconds,), {})
 
     async def get_scene_tree(self, depth: int = 5, max_nodes: int | None = None) -> dict:
-        return self._record("get_scene_tree", (), {"depth": depth})
+        kwargs: dict = {"depth": depth}
+        if max_nodes is not None:
+            kwargs["max_nodes"] = max_nodes
+        return self._record("get_scene_tree", (), kwargs)
 
     async def node_exists(self, path: str) -> bool:
         return self._record("node_exists", (path,), {})
@@ -185,6 +188,15 @@ def test_tree_explicit_depth(stub_client: dict) -> None:
     c.returns["get_scene_tree"] = {}
     b.tree(depth=10)
     assert c.calls[-1][2]["depth"] == 10
+    b.close()
+
+
+def test_tree_forwards_max_nodes_to_client(stub_client: dict) -> None:
+    """bridge.tree(max_nodes=N) 必须把 N 透传到 GameClient（防 stub 漏带导致假绿）。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["get_scene_tree"] = {}
+    b.tree(max_nodes=50)
+    assert c.calls[-1] == ("get_scene_tree", (), {"depth": 3, "max_nodes": 50})
     b.close()
 
 

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -46,7 +46,7 @@ class _StubClient:
     async def wait_game_time(self, seconds: float) -> dict:
         return self._record("wait_game_time", (seconds,), {})
 
-    async def get_scene_tree(self, depth: int = 5) -> dict:
+    async def get_scene_tree(self, depth: int = 5, max_nodes: int | None = None) -> dict:
         return self._record("get_scene_tree", (), {"depth": depth})
 
     async def node_exists(self, path: str) -> bool:

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -236,6 +236,35 @@ def test_daemon_status_returns_0_when_running(
     assert "running" in out and "4242" in out and "9877" in out
 
 
+class TestOutputFormatFlagsOnSubcommands:
+    """--json / --text 必须能放在子命令前 *和* 后两种位置。
+
+    AI agent 习惯把 flag 写在尾巴；早期 build_parser 只在顶层注册，
+    `click /root/X --json` 会被 argparse 报 unrecognized。
+    """
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["click", "/root/X", "--json"],
+            ["--json", "click", "/root/X"],
+            ["click", "/root/X", "--text"],
+            ["click", "/root/X", "--no-json"],
+            ["exists", "/root/Foo", "--text"],
+            ["tree", "3", "--json"],
+            ["daemon", "status", "--json"],
+            ["daemon", "stop", "--text"],
+            ["daemon", "start", "--headless", "--json"],
+        ],
+    )
+    def test_output_flag_accepted_at_tail(self, argv: list[str]) -> None:
+        from godot_cli_control.cli import build_parser
+
+        parser = build_parser()
+        ns = parser.parse_args(argv)
+        assert ns.output_format in ("json", "text")
+
+
 def test_format_full_help_covers_every_subcommand() -> None:
     """``format_full_help`` 必须遍历到所有顶层子命令 + daemon 三动作。
     SKILL.md 完全依赖这一点 —— 漏一个，agent 那侧的 -h 就要靠 shell 出去查。"""

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1308,3 +1308,48 @@ def test_call_text_value_disables_arg_parse() -> None:
         ["call", "/root/X", "set_label", "true", "42", "--text-value"]
     )
     assert _resolve_args_for_call(ns) == ["true", "42"]
+
+
+class TestDaemonHeadlessAutodetect:
+    def test_default_headless_when_stdout_not_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from godot_cli_control.cli import _resolve_headless
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        ns = type("NS", (), {"headless": False, "gui": False})()
+        assert _resolve_headless(ns) is True
+
+    def test_default_gui_when_stdout_is_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from godot_cli_control.cli import _resolve_headless
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        ns = type("NS", (), {"headless": False, "gui": False})()
+        assert _resolve_headless(ns) is False
+
+    def test_explicit_headless_wins_over_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from godot_cli_control.cli import _resolve_headless
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        ns = type("NS", (), {"headless": True, "gui": False})()
+        assert _resolve_headless(ns) is True
+
+    def test_explicit_gui_wins_over_pipe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from godot_cli_control.cli import _resolve_headless
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        ns = type("NS", (), {"headless": False, "gui": True})()
+        assert _resolve_headless(ns) is False
+
+    def test_gui_and_headless_mutually_exclusive(self) -> None:
+        from godot_cli_control.cli import build_parser
+
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["daemon", "start", "--headless", "--gui"])

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1279,3 +1279,32 @@ def test_tree_max_nodes_default_is_200() -> None:
     parser = build_parser()
     ns = parser.parse_args(["tree"])
     assert ns.max_nodes == 200
+
+
+def test_set_text_value_disables_json_parse() -> None:
+    """--text-value 让 set 把 value 当字面字符串，不走 JSON-or-string fallback。"""
+    from godot_cli_control.cli import build_parser, _resolve_value_for_set
+
+    parser = build_parser()
+    ns = parser.parse_args(["set", "/root/X", "flag", "true", "--text-value"])
+    assert ns.text_value is True
+    assert _resolve_value_for_set(ns) == "true"
+
+
+def test_set_default_still_json_parses() -> None:
+    from godot_cli_control.cli import build_parser, _resolve_value_for_set
+
+    parser = build_parser()
+    ns = parser.parse_args(["set", "/root/X", "flag", "true"])
+    assert ns.text_value is False
+    assert _resolve_value_for_set(ns) is True
+
+
+def test_call_text_value_disables_arg_parse() -> None:
+    from godot_cli_control.cli import build_parser, _resolve_args_for_call
+
+    parser = build_parser()
+    ns = parser.parse_args(
+        ["call", "/root/X", "set_label", "true", "42", "--text-value"]
+    )
+    assert _resolve_args_for_call(ns) == ["true", "42"]

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1262,3 +1262,20 @@ def test_daemon_start_idle_timeout_default_is_zero() -> None:
     from godot_cli_control.cli import build_parser
     ns = build_parser().parse_args(["daemon", "start"])
     assert ns.idle_timeout == "0"
+
+
+def test_tree_accepts_max_nodes_flag() -> None:
+    from godot_cli_control.cli import build_parser
+
+    parser = build_parser()
+    ns = parser.parse_args(["tree", "3", "--max-nodes", "50"])
+    assert ns.depth == "3"
+    assert ns.max_nodes == 50
+
+
+def test_tree_max_nodes_default_is_200() -> None:
+    from godot_cli_control.cli import build_parser
+
+    parser = build_parser()
+    ns = parser.parse_args(["tree"])
+    assert ns.max_nodes == 200

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1353,3 +1353,45 @@ class TestDaemonHeadlessAutodetect:
         parser = build_parser()
         with pytest.raises(SystemExit):
             parser.parse_args(["daemon", "start", "--headless", "--gui"])
+
+
+def test_run_rpc_tree_truncated_envelope(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """e2e：``cmd_tree`` → ``_run_rpc`` 必须把服务端 truncated 信号
+    透传到 stdout JSON envelope 里，agent 才能据此分子树。"""
+    import json as _json
+    from unittest.mock import AsyncMock, patch
+
+    from godot_cli_control.cli import (
+        OUTPUT_JSON,
+        RPC_BY_NAME,
+        _run_rpc,
+    )
+
+    spec = RPC_BY_NAME["tree"]
+    ns = __import__("argparse").Namespace(depth="3", max_nodes=200)
+
+    truncated_payload = {
+        "tree": {"name": "root", "type": "Node", "path": "/root"},
+        "truncated": True,
+        "total_nodes": 6000,
+    }
+    mock_client = AsyncMock()
+    mock_client.get_scene_tree = AsyncMock(return_value=truncated_payload)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "godot_cli_control.cli.GameClient", return_value=mock_client
+    ):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_JSON))
+
+    assert rc == 0
+    envelope = _json.loads(capsys.readouterr().out.strip())
+    assert envelope["ok"] is True
+    assert envelope["result"]["truncated"] is True
+    assert envelope["result"]["total_nodes"] == 6000
+    assert envelope["result"]["tree"]["name"] == "root"
+    # cmd_tree 应当把 ns.max_nodes 透传给 client.get_scene_tree
+    mock_client.get_scene_tree.assert_awaited_once_with(depth=3, max_nodes=200)

--- a/python/tests/test_cli_helpers.py
+++ b/python/tests/test_cli_helpers.py
@@ -21,7 +21,9 @@ from godot_cli_control import cli
 
 
 def _ns(**kwargs: Any) -> argparse.Namespace:
-    return argparse.Namespace(**kwargs)
+    defaults = {"max_nodes": 200}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
 
 
 def _run(coro: Any) -> Any:
@@ -44,14 +46,14 @@ def test_cmd_tree_default_depth_is_3_not_5() -> None:
     client = AsyncMock()
     client.get_scene_tree = AsyncMock(return_value={"name": "root"})
     _run(cli.cmd_tree(client, _ns(depth=None)))
-    client.get_scene_tree.assert_awaited_once_with(depth=3)
+    client.get_scene_tree.assert_awaited_once_with(depth=3, max_nodes=200)
 
 
 def test_cmd_tree_explicit_depth_passed() -> None:
     client = AsyncMock()
     client.get_scene_tree = AsyncMock(return_value={})
     _run(cli.cmd_tree(client, _ns(depth=10)))
-    client.get_scene_tree.assert_awaited_once_with(depth=10)
+    client.get_scene_tree.assert_awaited_once_with(depth=10, max_nodes=200)
 
 
 def test_cmd_press_release() -> None:

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -416,3 +416,30 @@ async def test_list_input_actions_passes_include_builtin_param() -> None:
                     await client._listen_task
                 except asyncio.CancelledError:
                     pass
+
+
+@pytest.mark.asyncio
+async def test_get_scene_tree_returns_truncate_metadata() -> None:
+    """服务端在节点超限时返回 {tree, truncated, total_nodes}，client 透传。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["params"] = params
+        return {
+            "tree": {"name": "root", "type": "Node", "path": "/root", "children": []},
+            "truncated": True,
+            "total_nodes": 6000,
+        }
+
+    client = client_mod.GameClient(port=1)
+    monkeypatch_target = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.get_scene_tree(depth=3, max_nodes=100)
+    finally:
+        client_mod.GameClient.request = monkeypatch_target
+    assert captured["params"] == {"depth": 3, "max_nodes": 100}
+    assert result["truncated"] is True
+    assert result["total_nodes"] == 6000

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -443,3 +443,25 @@ async def test_get_scene_tree_returns_truncate_metadata() -> None:
     assert captured["params"] == {"depth": 3, "max_nodes": 100}
     assert result["truncated"] is True
     assert result["total_nodes"] == 6000
+
+
+@pytest.mark.asyncio
+async def test_get_scene_tree_omits_max_nodes_when_none() -> None:
+    """max_nodes=None 时 RPC params 不应携带该 key，保留旧客户端兼容路径。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["params"] = params
+        return {"tree": {"name": "root", "type": "Node", "path": "/root"}}
+
+    client = client_mod.GameClient(port=1)
+    monkeypatch_target = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        await client.get_scene_tree(depth=2)
+    finally:
+        client_mod.GameClient.request = monkeypatch_target
+    assert captured["params"] == {"depth": 2}
+    assert "max_nodes" not in captured["params"]

--- a/python/tests/test_pytest_plugin.py
+++ b/python/tests/test_pytest_plugin.py
@@ -274,6 +274,56 @@ def test_bridge_teardown_robust_against_release_all_exception(
     assert "CLOSE_CALLED=[1]" in output, "release_all 抛错后 close 必须仍跑"
 
 
+def test_default_port_is_zero(pytester: pytest.Pytester) -> None:
+    """--godot-cli-port 默认 0 = OS 自动分配，与 daemon start 默认对齐。
+
+    早期版本默认 9877 会让多项目并行测试撞端口，且 9877 不再是 daemon
+    start 默认。fixture 必须放手让 daemon 自己挑。
+    """
+    result = pytester.runpytest("--help")
+    result.stdout.fnmatch_lines(
+        ["*--godot-cli-port*", "*default: 0*"]
+    )
+
+
+def test_godot_daemon_passes_port_zero_when_default(
+    pytester: pytest.Pytester,
+) -> None:
+    """fixture 拿默认值（不传 --godot-cli-port）时 daemon.start(port=0)。"""
+    pytester.makeconftest(
+        """
+        import godot_cli_control.pytest_plugin as plugin
+
+        OBSERVED: list = []
+
+        class FakeDaemon:
+            def __init__(self, *a, **kw): pass
+            def is_running(self): return False
+            def start(self, **kw): OBSERVED.append(kw.get("port"))
+            def stop(self): return 0
+            def current_port(self): return 5555
+
+        class FakeBridge:
+            def __init__(self, port): OBSERVED.append(f"bridge:{port}")
+            def release_all(self): pass
+            def close(self): pass
+
+        plugin.Daemon = FakeDaemon
+        plugin.GameBridge = FakeBridge
+
+        def pytest_sessionfinish(session, exitstatus):
+            assert OBSERVED[0] == 0, f"expected port=0 default, got {OBSERVED}"
+        """
+    )
+    pytester.makepyfile(
+        test_x="""
+        def test_x(godot_daemon, bridge): pass
+        """
+    )
+    result = pytester.runpytest("-v")
+    assert result.ret == 0
+
+
 def test_project_root_option_is_respected(pytester: pytest.Pytester) -> None:
     """--godot-cli-project-root 必须传给 Daemon 构造函数。"""
     pytester.makeconftest(


### PR DESCRIPTION
## Summary

把 godot-cli-control 的"AI 友好型 CLI"契约里 7 个偏离主线的点一并修干净。所有修复都围绕 CLAUDE.md 里写明的核心问题：*如果一个 LLM 只能 shell 出去执行一条命令、并且只能解析单行 JSON，它能否搞清楚下一步该做什么？*

| # | 修复 | 类型 |
|---|---|---|
| 1 | `--json` / `--text` 现在在子命令尾部也接受（之前只能写最前面） | P0 fix |
| 2 | 错误码 1004 不再撞码：scene tree 超限改 `1005`；新增 `CliControlErrorCodes` 常量类 | P0 fix |
| 3 | pytest fixture `--godot-cli-port` 默认 0 (OS-assigned)，与 daemon start 对齐 | P1 fix |
| 4 | addon README 错误码表补全 1004 / 1005 / 客户端 `-1xxx` 段 | P1 doc |
| 5 | `tree --max-nodes <N>` 软上限 + `{truncated, total_nodes}` 信号，默认 200 | P2 feat |
| 6 | `set` / `call --text-value` 关闭 JSON 解析（避开 `null`/`true`/数字 footgun） | P2 feat |
| 7 | `daemon start` headless 默认走 `isatty` 自适应；新增 `--gui` 强制开窗 | P2 feat (**BREAKING**) |

完整实施计划见 `docs/superpowers/plans/2026-05-11-ai-friendly-cli-fixes.md`（已入库），CHANGELOG `[Unreleased]` 下新增 `AI-friendliness review fixes (2026-05-11)` 段。

## Breaking change

**`daemon start` 默认 headless 行为现在跟随 `sys.stdout.isatty()`**：
- pipe / CI / agent shell → 默认 headless
- 交互终端 → 默认开窗

依赖"默认会开窗"的脚本需显式加 `--gui`。`--headless` 仍可显式传，覆盖自动判。已在 CHANGELOG 标 BREAKING (轻微) 并在 SKILL.md 的 Common pitfalls 加排错条目。

## Test plan

- [x] 全套 Python 测试：298 passed / 0 failed
- [x] 覆盖率：81%（满足 pyproject.toml `fail_under=80`）
- [x] SKILL.md 模板渲染检查：无 `{{...}}` 未渲染占位符
- [x] 静态校验：`low_level_api.gd` 与 `input_simulation_api.gd` 已无裸 `_err(1004, …)` 调用
- [x] argparse 位置自由度：`click /root/X --json` / `--json click /root/X` / `daemon status --json` 均可解析
- [x] e2e 路径：`cmd_tree → _run_rpc → truncated payload → JSON envelope` 由 `test_run_rpc_tree_truncated_envelope` 锁住
- [ ] **CI matrix 验证**（Linux / macOS / Windows）—— PR 触发后由 GitHub Actions 完成
- [ ] GUT 测试（GDScript 侧）—— 需 `GODOT_BIN` 环境，未在本地跑，由 CI 跑

## 实现要点

- argparse 修复用 `default=argparse.SUPPRESS` + 顶层 `set_defaults`，避免子 parser 默认值覆盖父层解析结果
- 错误码集中到新文件 `addons/godot_cli_control/bridge/error_codes.gd`（`class_name CliControlErrorCodes`），下次新增码强制走 grep
- tree 软/硬上限解耦且 1005 硬墙检查排在 truncated 标记前，避免"先组装 partial response 再被短路"的代码异味
- headless 决策抽出 `_resolve_headless(ns)` 函数，便于单测 mock `sys.stdout.isatty`

## Code review trail

经过两轮 review：每个 task 跑 spec 合规 + 代码质量两阶段评审；branch 整体跑一次 superpowers:code-reviewer final review，提出的 4 项 Important 已在 `854d04d` 一并修干净（GDScript class 解析注释、handle_get_scene_tree 排序、get_scene_tree docstring、tree truncate e2e 测试）。Reviewer 还有 3 项 Minor（SKILL.md `--port` 二义性、plan checkboxes、`_BUILD_TREE_HARD_LIMIT` 命名）会作为 follow-up issue 跟踪。

🤖 Generated with [Claude Code](https://claude.com/claude-code)