### PR TITLE
fix(cli): cmd_run / cmd_init 真正输出 JSON envelope（#50）

### DIFF
--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -118,6 +118,7 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `-1002` | client | Timeout waiting for response |
 | `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, …) |
 | `-1004` | client | Local file IO error (e.g. screenshot can't write the destination) |
+| `-1005` | client | `run <script>` user script raised an uncaught exception — fix the script |
 | `-1099` | client | Internal CLI bug — please file an issue |
 
 For full retry guidance see the SKILL.md shipped by `godot-cli-control init` (`.claude/skills/godot-cli-control/SKILL.md` in the target project).

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -905,79 +905,153 @@ def cmd_run(ns: argparse.Namespace) -> int:
     json 模式下：成功 ``{"ok": true, "result": {"exit_code": 0, "script": "..."}}``；
     各类失败（脚本不存在、daemon 起不来、用户脚本 raise）封 ``{"ok": false, "error": ...}``。
     text 模式行为不变。
+
+    退出码：
+      0  脚本成功（且 daemon stop 成功）
+      1  脚本运行失败（RPC 错语义；envelope `ok=false` 时也走这里）
+      2  基础设施 / 用法错（脚本路径不存在、daemon 起不来、idle_timeout 之外的解析）
+      64 argparse 用法错（idle_timeout 解析失败等"明显参数写错"）
     """
     from .daemon import Daemon, DaemonError
     from ._duration import parse_duration
 
     fmt = _output_format(ns)
-    script_path = Path(ns.script)
-    if not script_path.exists():
-        msg = f"找不到脚本: {script_path}"
-        if fmt == OUTPUT_JSON:
-            _emit_error_payload(CLIENT_CODE_USAGE, msg)
-        else:
-            print(f"错误：{msg}", file=sys.stderr)
-        return EXIT_RPC_ERROR
 
+    # 顶层 try 兜底：cmd_run 内部任何未捕获异常（daemon.is_running 抛 OSError、
+    # _exec_user_script importlib 边界 raise 等）都要落 envelope。和 _run_rpc 的
+    # 兜底语义对齐，保 CLAUDE.md 契约 1（任何异常都必须落进信封）。
     try:
-        idle_seconds = parse_duration(getattr(ns, "idle_timeout", "0"))
-    except ValueError as e:
-        if fmt == OUTPUT_JSON:
-            _emit_error_payload(CLIENT_CODE_USAGE, str(e))
-        else:
-            print(f"错误：{e}", file=sys.stderr)
-        return EXIT_USAGE
+        script_path = Path(ns.script)
+        if not script_path.exists():
+            # 用户传错路径属于"用法错" → EXIT_INFRA_ERROR(2)，
+            # 与 CLAUDE.md 契约 3 对齐，亦与 cmd_daemon_start 错误码一致。
+            msg = f"找不到脚本: {script_path}"
+            if fmt == OUTPUT_JSON:
+                _emit_error_payload(CLIENT_CODE_USAGE, msg)
+            else:
+                print(f"错误：{msg}", file=sys.stderr)
+            return EXIT_INFRA_ERROR
 
-    daemon = Daemon(Path.cwd())
-    auto_started = False
-    if not daemon.is_running():
         try:
-            daemon.start(
-                record=ns.record,
-                movie_path=ns.movie_path,
-                headless=_resolve_headless(ns),
-                fps=ns.fps,
-                port=ns.port,
-                idle_timeout=idle_seconds,
-            )
-        except DaemonError as e:
+            idle_seconds = parse_duration(getattr(ns, "idle_timeout", "0"))
+        except ValueError as e:
             if fmt == OUTPUT_JSON:
                 _emit_error_payload(CLIENT_CODE_USAGE, str(e))
             else:
                 print(f"错误：{e}", file=sys.stderr)
-            return EXIT_RPC_ERROR
-        auto_started = True
+            return EXIT_USAGE
 
-    port = daemon.current_port() or ns.port
-    # try/finally 保护：_exec_user_script 内部抛非 catch 异常（GameBridge
-    # 连接失败、importlib 边界错误等）时仍要停 daemon，避免 Godot 进程泄漏
-    # 让下次 daemon start 报「already running」。
-    exit_code = 1
-    try:
-        exit_code = _exec_user_script(script_path, port, output_format=fmt)
-    finally:
-        if auto_started:
+        daemon = Daemon(Path.cwd())
+        auto_started = False
+        if not daemon.is_running():
             try:
-                stop_rc = daemon.stop()
+                daemon.start(
+                    record=ns.record,
+                    movie_path=ns.movie_path,
+                    headless=_resolve_headless(ns),
+                    fps=ns.fps,
+                    port=ns.port,
+                    idle_timeout=idle_seconds,
+                )
             except DaemonError as e:
-                # 停 daemon 出错走人类可读 stderr —— envelope 仍由脚本结果主导。
-                # 这一行在 json 模式下也保留 stderr 提示，避免 silent leak。
-                print(f"警告：停止 daemon 失败：{e}", file=sys.stderr)
-                stop_rc = 1
-            if exit_code == 0 and stop_rc != 0:
-                exit_code = stop_rc
-    return exit_code
+                # daemon 起不来是基础设施错（端口冲突、godot bin 不可执行等），
+                # 走 EXIT_INFRA_ERROR(2) 与 cmd_daemon_start(line 734) 一致。
+                if fmt == OUTPUT_JSON:
+                    _emit_error_payload(CLIENT_CODE_USAGE, str(e))
+                else:
+                    print(f"错误：{e}", file=sys.stderr)
+                return EXIT_INFRA_ERROR
+            auto_started = True
+
+        port = daemon.current_port() or ns.port
+        # try/finally 保护：_exec_user_script 内部抛非 catch 异常（GameBridge
+        # 连接失败、importlib 边界错误等）时仍要停 daemon，避免 Godot 进程泄漏
+        # 让下次 daemon start 报「already running」。
+        exit_code = 1
+        # json + 脚本成功时由本函数 emit envelope（这样可以塞
+        # daemon_stop_warning，让 envelope 与 exit code 在「脚本 OK + daemon
+        # stop 失败」组合下一致）。脚本失败时仍由 _exec_user_script 直接 emit
+        # error envelope（脚本错是主因，daemon stop 的次要状态不应覆盖它）。
+        success_payload: dict[str, Any] | None = (
+            {} if fmt == OUTPUT_JSON else None
+        )
+        try:
+            exit_code = _exec_user_script(
+                script_path,
+                port,
+                output_format=fmt,
+                success_payload_out=success_payload,
+            )
+        finally:
+            stop_warning: str | None = None
+            if auto_started:
+                try:
+                    stop_rc = daemon.stop()
+                except DaemonError as e:
+                    # 停 daemon 出错走人类可读 stderr —— envelope 仍由脚本结果主导。
+                    # 这一行在 json 模式下也保留 stderr 提示，避免 silent leak。
+                    print(f"警告：停止 daemon 失败：{e}", file=sys.stderr)
+                    stop_rc = 1
+                    stop_warning = f"daemon stop raised: {e}"
+                else:
+                    if stop_rc != 0:
+                        # rc 0 / 2 由 Daemon.stop 定义：2 = ffmpeg transcode 失败
+                        # 但进程已停。让 envelope 携带这一信号，给 agent retry 提示。
+                        stop_warning = f"daemon stop rc={stop_rc}"
+                if exit_code == 0 and stop_rc != 0:
+                    exit_code = stop_rc
+            if (
+                fmt == OUTPUT_JSON
+                and success_payload is not None
+                and success_payload  # 仅在 _exec_user_script 已成功回填字段时 emit
+            ):
+                if stop_warning is not None:
+                    success_payload["daemon_stop_warning"] = stop_warning
+                _emit_success_payload(success_payload)
+        return exit_code
+    except Exception as e:  # noqa: BLE001
+        # 与 _run_rpc 的 except Exception 兜底对齐：traceback 走 stderr 帮人
+        # debug，envelope 给 agent 一个 CLIENT_CODE_INTERNAL 解释失败原因。
+        traceback.print_exc(file=sys.stderr)
+        if fmt == OUTPUT_JSON:
+            _emit_error_payload(
+                CLIENT_CODE_INTERNAL, f"{type(e).__name__}: {e}"
+            )
+        else:
+            print(f"错误：内部异常 {type(e).__name__}: {e}", file=sys.stderr)
+        return EXIT_INFRA_ERROR
 
 
 def _exec_user_script(
-    script_path: Path, port: int, *, output_format: str = "text"
+    script_path: Path,
+    port: int,
+    *,
+    output_format: str = "text",
+    success_payload_out: dict[str, Any] | None = None,
 ) -> int:
     """加载脚本模块、调用 ``run(bridge)``，捕获错误返回 exit code。
 
-    json 模式：每个分支负责输出 envelope（成功 ``{exit_code:0, script:...}``、
-    脚本异常 → ``CLIENT_CODE_SCRIPT_ERROR``、连接失败 → ``CLIENT_CODE_CONNECTION``、
-    结构性错误 → ``CLIENT_CODE_USAGE``）。stderr 仍写完整 traceback / 友好提示，
-    保留 human debug 信息。
+    json 模式：每个分支负责输出 envelope。
+      - 成功 → ``{exit_code:0, script:...}``
+      - ``spec_from_file_location`` 返回 None / 缺 ``run(bridge)`` → ``CLIENT_CODE_USAGE``
+      - 用户脚本"加载阶段"（``exec_module`` 时顶层 raise，含 ImportError /
+        SyntaxError / 顶层赋值出错）→ ``CLIENT_CODE_SCRIPT_ERROR``
+      - 用户脚本"运行阶段"（``run(bridge)`` 内 raise）→ ``CLIENT_CODE_SCRIPT_ERROR``
+      - GameBridge 连接失败 → ``CLIENT_CODE_CONNECTION``
+
+    stderr 仍写完整 traceback / 友好提示，保留 human debug 信息。json 模式
+    下用户脚本期间的 stdout（含 ``exec_module`` 跑顶层语句、``run(bridge)``
+    内部）被整体 redirect 到 stderr，envelope 永远是单行 stdout——单纯包
+    ``module.run`` 不够，因为顶层 ``print()`` 在 import 时就会输出，于是
+    覆盖范围拉到 ``exec_module`` 起。
+
+    ``success_payload_out``：调用方（cmd_run）若需要在 success envelope 里
+    附加 daemon stop 警告等额外字段、由调用方自己 emit，可传入一个空 dict；
+    本函数仅回填 ``exit_code`` / ``script`` 不 emit success envelope。
+    传 None（默认）保留旧行为：success 时 _exec_user_script 直接 emit
+    envelope（error envelope 永远由本函数 emit，外层不接管，避免脚本失败
+    走顶层兜底误判为框架内部 bug）。
+
     text 模式行为完全不变。
     """
     import importlib.util
@@ -995,14 +1069,20 @@ def _exec_user_script(
     def _emit_script_failure(stage: str, exc: BaseException) -> None:
         # stderr 永远拿到完整 traceback —— human 调试需要堆栈；json envelope
         # 只放 exception type + last line，避免一行单 message 太长。
-        # 用 print_exception(exc) 而非 print_exc()：本函数可能在 except 块
-        # 之外被调（脚本运行错误为了把 envelope 输出在 redirect_stdout 外
-        # 我们先存 exc 再处理），active exc_info 此时已被清空。
+        # 用 print_exception(exc) 而非 print_exc()：本函数总是在 except 块
+        # 外被调（exception 先存进本地变量、退出 redirect 上下文后才处理），
+        # active exc_info 此时已被清空。
         print(f"错误：脚本 {script_path} {stage}失败：", file=sys.stderr)
         traceback.print_exception(exc)
         if is_json:
-            msg = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
-            _emit_error_payload(CLIENT_CODE_SCRIPT_ERROR, f"{stage}失败：{msg}")
+            msg = (
+                f"{type(exc).__name__}: {exc}"
+                if str(exc)
+                else type(exc).__name__
+            )
+            _emit_error_payload(
+                CLIENT_CODE_SCRIPT_ERROR, f"脚本 {stage}失败：{msg}"
+            )
 
     spec = importlib.util.spec_from_file_location("user_script", script_path)
     if spec is None or spec.loader is None:
@@ -1018,58 +1098,83 @@ def _exec_user_script(
     sys.path.insert(0, inserted_path)
     sys.modules["user_script"] = module
     bridge: GameBridge | None = None
+    # json 模式下整段"用户代码执行"包在 redirect_stdout 内：从 exec_module
+    # 跑脚本顶层（用户可能 ``print("Loading…")``）到 ``module.run(bridge)``
+    # 内部 print 一律走 stderr，envelope 唯一占用 stdout 单行。异常先存进
+    # 本地变量、出 redirect 上下文后再 emit envelope —— 在 redirect 内 emit
+    # 会把 envelope 也写到 stderr。
+    # text 模式用 nullcontext 不绕路、零开销。
+    stdout_redirect: contextlib.AbstractContextManager[Any] = (
+        contextlib.redirect_stdout(sys.stderr)
+        if is_json
+        else contextlib.nullcontext()
+    )
     try:
-        # 保留完整 traceback —— 用户脚本出错时调试信息比「错误：xxx」一行有用得多。
-        try:
-            spec.loader.exec_module(module)
-        except Exception as e:  # noqa: BLE001 - 用户脚本任何异常都要抓
-            _emit_script_failure("加载", e)
+        load_error: BaseException | None = None
+        run_error: BaseException | None = None
+        missing_run = False
+        connection_error: ConnectionError | None = None
+        ran = False
+
+        with stdout_redirect:
+            try:
+                spec.loader.exec_module(module)
+            except Exception as e:  # noqa: BLE001 - 用户脚本任何异常都要抓
+                load_error = e
+            else:
+                if not hasattr(module, "run"):
+                    missing_run = True
+                else:
+                    # GameBridge.__init__ 在连接 daemon 失败时抛 ConnectionError；
+                    # 不友好地走默认 traceback 路径会让用户以为是脚本出错。
+                    # 单独捕获给一行可读信息（daemon 没起、端口写错、防火墙
+                    # 拦截 等）。"运行 ..." 这条状态行写 stderr，redirect 影响
+                    # 不到（contextlib.redirect_stdout 只覆盖 sys.stdout）。
+                    print(f"运行 {script_path}...", file=sys.stderr)
+                    try:
+                        bridge = GameBridge(port=port)
+                    except ConnectionError as e:
+                        connection_error = e
+                    else:
+                        try:
+                            module.run(bridge)
+                            ran = True
+                        except Exception as e:  # noqa: BLE001
+                            run_error = e
+
+        if load_error is not None:
+            _emit_script_failure("加载", load_error)
             return 1
-        if not hasattr(module, "run"):
+        if missing_run:
             _emit_usage(f"脚本 {script_path} 中缺少 run(bridge) 函数")
             return 1
-
-        print(f"运行 {script_path}...", file=sys.stderr)
-        # GameBridge.__init__ 在连接 daemon 失败时抛 ConnectionError；不友好地
-        # 走 cmd_run 默认 traceback 路径会让用户以为是脚本出错。单独捕获给
-        # 一行可读信息（daemon 没起、端口写错、防火墙拦截 等）。
-        try:
-            bridge = GameBridge(port=port)
-        except ConnectionError as e:
+        if connection_error is not None:
             if is_json:
                 _emit_error_payload(
                     CLIENT_CODE_CONNECTION,
-                    f"连接 daemon 失败 (port={port}): {e}",
+                    f"连接 daemon 失败 (port={port}): {connection_error}",
                 )
             print(
-                f"错误：连接 daemon 失败 (port={port}): {e}\n"
+                f"错误：连接 daemon 失败 (port={port}): {connection_error}\n"
                 "提示：先运行 `godot-cli-control daemon start` 或检查端口是否被占用。",
                 file=sys.stderr,
             )
             return 1
-        # 用户脚本里如果 print()，在 json 模式下会污染 envelope 唯一一行 stdout。
-        # 把脚本期间的 stdout 重定向到 stderr：脚本可读输出仍可见，envelope 不破。
-        # 注意：异常处理 / envelope 发布必须在 redirect 上下文 **外** 完成，
-        # 否则 envelope 也会被一起重定向到 stderr —— 之前 first cut 就栽在这里。
-        script_error: BaseException | None = None
-        if is_json:
-            with contextlib.redirect_stdout(sys.stderr):
-                try:
-                    module.run(bridge)
-                except Exception as e:  # noqa: BLE001
-                    script_error = e
-        else:
-            try:
-                module.run(bridge)
-            except Exception as e:  # noqa: BLE001
-                script_error = e
-        if script_error is not None:
-            _emit_script_failure("运行", script_error)
+        if run_error is not None:
+            _emit_script_failure("运行", run_error)
+            return 1
+        if not ran:
+            # 理论上不可达：上面四种 error 状态都已 return。兜底 envelope 保契约。
+            _emit_usage("脚本未执行（内部状态异常）")
             return 1
         if is_json:
-            _emit_success_payload(
-                {"exit_code": 0, "script": str(script_path)}
-            )
+            success_payload = {"exit_code": 0, "script": str(script_path)}
+            if success_payload_out is not None:
+                # 让 cmd_run 在 finally 拿到 daemon stop 结果后统一 emit，
+                # 这样 envelope 才能携带 daemon_stop_warning，与 exit code 对齐。
+                success_payload_out.update(success_payload)
+            else:
+                _emit_success_payload(success_payload)
         return 0
     finally:
         if bridge is not None:
@@ -1082,28 +1187,43 @@ def _exec_user_script(
 
 
 def cmd_init(ns: argparse.Namespace) -> int:
-    from .init_cmd import run_init
+    from .init_cmd import INIT_RESULT_ERROR_KEY, run_init
 
     fmt = _output_format(ns)
     # json 模式下让 run_init 抑制人类可读 print，把结构化字段回填到本地 dict。
     # text 模式仍走原路径（result=None 等价于不收集）。
     result: dict[str, Any] | None = {} if fmt == OUTPUT_JSON else None
-    rc = run_init(
-        # 保留 .resolve()：run_init 内部用 relative_to(project_root) 打印 skill
-        # 路径，相对路径会让 relative_to 在 cwd 不寻常时抛 ValueError。
-        project_root=(Path(ns.path).resolve() if ns.path else Path.cwd()),
-        force=ns.force,
-        write_skills=not ns.no_skills,
-        skills_only=ns.skills_only,
-        clobber_skills=not ns.skills_no_clobber,
-        output_format=fmt,
-        result=result,
-    )
+
+    # 顶层 try 兜底：run_init 内部任何未捕获异常（shutil.copytree、
+    # reimport_project 抛 OSError / subprocess 边界异常等）都要落 envelope。
+    # 和 _run_rpc 的兜底语义对齐，保 CLAUDE.md 契约 1。
+    try:
+        rc = run_init(
+            # 保留 .resolve()：run_init 内部用 relative_to(project_root) 打印
+            # skill 路径，相对路径会让 relative_to 在 cwd 不寻常时抛 ValueError。
+            project_root=(Path(ns.path).resolve() if ns.path else Path.cwd()),
+            force=ns.force,
+            write_skills=not ns.no_skills,
+            skills_only=ns.skills_only,
+            clobber_skills=not ns.skills_no_clobber,
+            output_format=fmt,
+            result=result,
+        )
+    except Exception as e:  # noqa: BLE001
+        traceback.print_exc(file=sys.stderr)
+        if fmt == OUTPUT_JSON:
+            _emit_error_payload(
+                CLIENT_CODE_INTERNAL, f"{type(e).__name__}: {e}"
+            )
+        else:
+            print(f"错误：内部异常 {type(e).__name__}: {e}", file=sys.stderr)
+        return EXIT_INFRA_ERROR
+
     if fmt == OUTPUT_JSON and result is not None:
         if rc == 0:
             _emit_success_payload(result)
         else:
-            message = result.pop("_error_message", None) or "init failed"
+            message = result.pop(INIT_RESULT_ERROR_KEY, None) or "init failed"
             _emit_error_payload(CLIENT_CODE_USAGE, message)
     return rc
 

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import json
 import sys
 import traceback
@@ -55,6 +56,7 @@ CLIENT_CODE_CONNECTION = -1001
 CLIENT_CODE_TIMEOUT = -1002
 CLIENT_CODE_USAGE = -1003
 CLIENT_CODE_IO = -1004  # 本地文件 IO 错误（screenshot 写盘等），与连接错误分开
+CLIENT_CODE_SCRIPT_ERROR = -1005  # `run <script>` 用户脚本抛出未捕获异常（agent 错的是脚本，不是 CLI 框架）
 CLIENT_CODE_INTERNAL = -1099  # 兜底：客户端内部异常（理论上不该到这里，但兜住契约）
 
 
@@ -898,19 +900,32 @@ def cmd_daemon_ls(ns: argparse.Namespace) -> int:
 
 
 def cmd_run(ns: argparse.Namespace) -> int:
-    """加载用户脚本（要求定义 ``run(bridge)``），自动启停 daemon。"""
+    """加载用户脚本（要求定义 ``run(bridge)``），自动启停 daemon。
+
+    json 模式下：成功 ``{"ok": true, "result": {"exit_code": 0, "script": "..."}}``；
+    各类失败（脚本不存在、daemon 起不来、用户脚本 raise）封 ``{"ok": false, "error": ...}``。
+    text 模式行为不变。
+    """
     from .daemon import Daemon, DaemonError
     from ._duration import parse_duration
 
+    fmt = _output_format(ns)
     script_path = Path(ns.script)
     if not script_path.exists():
-        print(f"错误：找不到脚本: {script_path}", file=sys.stderr)
-        return 1
+        msg = f"找不到脚本: {script_path}"
+        if fmt == OUTPUT_JSON:
+            _emit_error_payload(CLIENT_CODE_USAGE, msg)
+        else:
+            print(f"错误：{msg}", file=sys.stderr)
+        return EXIT_RPC_ERROR
 
     try:
         idle_seconds = parse_duration(getattr(ns, "idle_timeout", "0"))
     except ValueError as e:
-        print(f"错误：{e}", file=sys.stderr)
+        if fmt == OUTPUT_JSON:
+            _emit_error_payload(CLIENT_CODE_USAGE, str(e))
+        else:
+            print(f"错误：{e}", file=sys.stderr)
         return EXIT_USAGE
 
     daemon = Daemon(Path.cwd())
@@ -926,8 +941,11 @@ def cmd_run(ns: argparse.Namespace) -> int:
                 idle_timeout=idle_seconds,
             )
         except DaemonError as e:
-            print(f"错误：{e}", file=sys.stderr)
-            return 1
+            if fmt == OUTPUT_JSON:
+                _emit_error_payload(CLIENT_CODE_USAGE, str(e))
+            else:
+                print(f"错误：{e}", file=sys.stderr)
+            return EXIT_RPC_ERROR
         auto_started = True
 
     port = daemon.current_port() or ns.port
@@ -936,12 +954,14 @@ def cmd_run(ns: argparse.Namespace) -> int:
     # 让下次 daemon start 报「already running」。
     exit_code = 1
     try:
-        exit_code = _exec_user_script(script_path, port)
+        exit_code = _exec_user_script(script_path, port, output_format=fmt)
     finally:
         if auto_started:
             try:
                 stop_rc = daemon.stop()
             except DaemonError as e:
+                # 停 daemon 出错走人类可读 stderr —— envelope 仍由脚本结果主导。
+                # 这一行在 json 模式下也保留 stderr 提示，避免 silent leak。
                 print(f"警告：停止 daemon 失败：{e}", file=sys.stderr)
                 stop_rc = 1
             if exit_code == 0 and stop_rc != 0:
@@ -949,15 +969,44 @@ def cmd_run(ns: argparse.Namespace) -> int:
     return exit_code
 
 
-def _exec_user_script(script_path: Path, port: int) -> int:
-    """加载脚本模块、调用 ``run(bridge)``，捕获错误返回 exit code。"""
+def _exec_user_script(
+    script_path: Path, port: int, *, output_format: str = "text"
+) -> int:
+    """加载脚本模块、调用 ``run(bridge)``，捕获错误返回 exit code。
+
+    json 模式：每个分支负责输出 envelope（成功 ``{exit_code:0, script:...}``、
+    脚本异常 → ``CLIENT_CODE_SCRIPT_ERROR``、连接失败 → ``CLIENT_CODE_CONNECTION``、
+    结构性错误 → ``CLIENT_CODE_USAGE``）。stderr 仍写完整 traceback / 友好提示，
+    保留 human debug 信息。
+    text 模式行为完全不变。
+    """
     import importlib.util
 
     from .bridge import GameBridge
 
+    is_json = output_format == OUTPUT_JSON
+
+    def _emit_usage(message: str) -> None:
+        if is_json:
+            _emit_error_payload(CLIENT_CODE_USAGE, message)
+        else:
+            print(f"错误：{message}", file=sys.stderr)
+
+    def _emit_script_failure(stage: str, exc: BaseException) -> None:
+        # stderr 永远拿到完整 traceback —— human 调试需要堆栈；json envelope
+        # 只放 exception type + last line，避免一行单 message 太长。
+        # 用 print_exception(exc) 而非 print_exc()：本函数可能在 except 块
+        # 之外被调（脚本运行错误为了把 envelope 输出在 redirect_stdout 外
+        # 我们先存 exc 再处理），active exc_info 此时已被清空。
+        print(f"错误：脚本 {script_path} {stage}失败：", file=sys.stderr)
+        traceback.print_exception(exc)
+        if is_json:
+            msg = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
+            _emit_error_payload(CLIENT_CODE_SCRIPT_ERROR, f"{stage}失败：{msg}")
+
     spec = importlib.util.spec_from_file_location("user_script", script_path)
     if spec is None or spec.loader is None:
-        print(f"错误：无法加载脚本: {script_path}", file=sys.stderr)
+        _emit_usage(f"无法加载脚本: {script_path}")
         return 1
     module = importlib.util.module_from_spec(spec)
     # 让脚本同目录的辅助模块（``from helpers import foo``）可被解析；
@@ -973,15 +1022,11 @@ def _exec_user_script(script_path: Path, port: int) -> int:
         # 保留完整 traceback —— 用户脚本出错时调试信息比「错误：xxx」一行有用得多。
         try:
             spec.loader.exec_module(module)
-        except Exception:  # noqa: BLE001 - 用户脚本任何异常都要抓
-            print(f"错误：加载脚本 {script_path} 失败：", file=sys.stderr)
-            traceback.print_exc()
+        except Exception as e:  # noqa: BLE001 - 用户脚本任何异常都要抓
+            _emit_script_failure("加载", e)
             return 1
         if not hasattr(module, "run"):
-            print(
-                f"错误：脚本 {script_path} 中缺少 run(bridge) 函数",
-                file=sys.stderr,
-            )
+            _emit_usage(f"脚本 {script_path} 中缺少 run(bridge) 函数")
             return 1
 
         print(f"运行 {script_path}...", file=sys.stderr)
@@ -991,18 +1036,40 @@ def _exec_user_script(script_path: Path, port: int) -> int:
         try:
             bridge = GameBridge(port=port)
         except ConnectionError as e:
+            if is_json:
+                _emit_error_payload(
+                    CLIENT_CODE_CONNECTION,
+                    f"连接 daemon 失败 (port={port}): {e}",
+                )
             print(
                 f"错误：连接 daemon 失败 (port={port}): {e}\n"
                 "提示：先运行 `godot-cli-control daemon start` 或检查端口是否被占用。",
                 file=sys.stderr,
             )
             return 1
-        try:
-            module.run(bridge)
-        except Exception:  # noqa: BLE001
-            print(f"错误：脚本 {script_path} 运行失败：", file=sys.stderr)
-            traceback.print_exc()
+        # 用户脚本里如果 print()，在 json 模式下会污染 envelope 唯一一行 stdout。
+        # 把脚本期间的 stdout 重定向到 stderr：脚本可读输出仍可见，envelope 不破。
+        # 注意：异常处理 / envelope 发布必须在 redirect 上下文 **外** 完成，
+        # 否则 envelope 也会被一起重定向到 stderr —— 之前 first cut 就栽在这里。
+        script_error: BaseException | None = None
+        if is_json:
+            with contextlib.redirect_stdout(sys.stderr):
+                try:
+                    module.run(bridge)
+                except Exception as e:  # noqa: BLE001
+                    script_error = e
+        else:
+            try:
+                module.run(bridge)
+            except Exception as e:  # noqa: BLE001
+                script_error = e
+        if script_error is not None:
+            _emit_script_failure("运行", script_error)
             return 1
+        if is_json:
+            _emit_success_payload(
+                {"exit_code": 0, "script": str(script_path)}
+            )
         return 0
     finally:
         if bridge is not None:
@@ -1017,7 +1084,11 @@ def _exec_user_script(script_path: Path, port: int) -> int:
 def cmd_init(ns: argparse.Namespace) -> int:
     from .init_cmd import run_init
 
-    return run_init(
+    fmt = _output_format(ns)
+    # json 模式下让 run_init 抑制人类可读 print，把结构化字段回填到本地 dict。
+    # text 模式仍走原路径（result=None 等价于不收集）。
+    result: dict[str, Any] | None = {} if fmt == OUTPUT_JSON else None
+    rc = run_init(
         # 保留 .resolve()：run_init 内部用 relative_to(project_root) 打印 skill
         # 路径，相对路径会让 relative_to 在 cwd 不寻常时抛 ValueError。
         project_root=(Path(ns.path).resolve() if ns.path else Path.cwd()),
@@ -1025,7 +1096,16 @@ def cmd_init(ns: argparse.Namespace) -> int:
         write_skills=not ns.no_skills,
         skills_only=ns.skills_only,
         clobber_skills=not ns.skills_no_clobber,
+        output_format=fmt,
+        result=result,
     )
+    if fmt == OUTPUT_JSON and result is not None:
+        if rc == 0:
+            _emit_success_payload(result)
+        else:
+            message = result.pop("_error_message", None) or "init failed"
+            _emit_error_payload(CLIENT_CODE_USAGE, message)
+    return rc
 
 
 # ── 输出信封 ──

--- a/python/godot_cli_control/init_cmd.py
+++ b/python/godot_cli_control/init_cmd.py
@@ -19,6 +19,7 @@ import re
 import shutil
 import sys
 from pathlib import Path
+from typing import Any
 
 from .daemon import find_godot_binary, reimport_project
 
@@ -36,6 +37,9 @@ def run_init(
     write_skills: bool = True,
     skills_only: bool = False,
     clobber_skills: bool = True,
+    *,
+    output_format: str = "text",
+    result: dict[str, Any] | None = None,
 ) -> int:
     """实施接入流程。返回进程 exit code。
 
@@ -46,26 +50,59 @@ def run_init(
     ``clobber_skills=False``：写 skill 时遇到已存在文件就跳过（用户改过
     SKILL.md、希望保留本地版又允许 init 把缺失那条补上时用）。与
     ``write_skills=False`` / ``skills_only=True`` 都兼容。
+
+    ``output_format='json'``：抑制全部人类可读 print；调用方（cli.cmd_init）
+    传入 ``result`` 字典，本函数会回填结构化字段，由 cli 侧封 JSON envelope。
+    ``output_format='text'``（默认）保持旧行为，``result`` 可省略 / 也可传入
+    并被回填，互不冲突。错误路径在 text 模式下打印到 stderr，json 模式下
+    把 message 塞进 ``result['_error_message']`` 供 envelope 取用。
     """
-    if not (project_root / "project.godot").is_file():
-        print(
-            f"错误：{project_root} 下没有 project.godot —— 不像 Godot 项目根。\n"
-            "如果你确实在 Godot 项目内，请用 --path 指向项目根。",
-            file=sys.stderr,
-        )
+    quiet = output_format == "json"
+
+    def _say(msg: str) -> None:
+        if not quiet:
+            print(msg)
+
+    def _warn(msg: str) -> None:
+        # 错误 / 警告：text 模式 stderr 可读；json 模式吞掉，由 envelope 负责。
+        if not quiet:
+            print(msg, file=sys.stderr)
+
+    def _record(**kw: Any) -> None:
+        if result is not None:
+            result.update(kw)
+
+    def _fail(message: str) -> int:
+        _warn(f"错误：{message}")
+        if result is not None:
+            result["_error_message"] = message
         return 1
 
+    _record(
+        project_root=str(project_root),
+        skills_only=skills_only,
+        write_skills=write_skills,
+        plugin_copied=False,
+        plugin_overwritten=False,
+        project_godot_changes=[],
+        godot_bin=None,
+        skills_written=[],
+    )
+
+    if not (project_root / "project.godot").is_file():
+        return _fail(
+            f"{project_root} 下没有 project.godot —— 不像 Godot 项目根。\n"
+            "如果你确实在 Godot 项目内，请用 --path 指向项目根。"
+        )
+
     if not skills_only:
-        # 原 1-4 步整体保持不动，仅缩进到此 if 块下
         plugin_src = locate_plugin_source()
         if plugin_src is None:
-            print(
-                "错误：找不到插件源（addons/godot_cli_control/）。\n"
+            return _fail(
+                "找不到插件源（addons/godot_cli_control/）。\n"
                 "如果是从源码 editable install，请确保仓库布局完整；\n"
-                "如果是从 wheel 安装，包资源可能损坏，请重装。",
-                file=sys.stderr,
+                "如果是从 wheel 安装，包资源可能损坏，请重装。"
             )
-            return 1
 
         addons_dir = project_root / ADDONS_DIRNAME
         plugin_dst = addons_dir / PLUGIN_DIR_NAME
@@ -73,19 +110,22 @@ def run_init(
             if force:
                 shutil.rmtree(plugin_dst)
                 _copy_plugin(plugin_src, plugin_dst)
-                print(f"覆盖：{plugin_dst}")
+                _say(f"覆盖：{plugin_dst}")
+                _record(plugin_copied=True, plugin_overwritten=True)
             else:
-                print(f"已存在：{plugin_dst}（用 --force 覆盖）")
+                _say(f"已存在：{plugin_dst}（用 --force 覆盖）")
         else:
             addons_dir.mkdir(parents=True, exist_ok=True)
             _copy_plugin(plugin_src, plugin_dst)
-            print(f"复制：{plugin_src} → {plugin_dst}")
+            _say(f"复制：{plugin_src} → {plugin_dst}")
+            _record(plugin_copied=True)
 
         patched, changes = _patch_project_godot(project_root / "project.godot")
         if changes:
-            print(f"修改 project.godot：{', '.join(changes)}")
+            _say(f"修改 project.godot：{', '.join(changes)}")
         elif patched:
-            print("project.godot 已配置好（未改动）")
+            _say("project.godot 已配置好（未改动）")
+        _record(project_godot_changes=changes)
 
         godot_bin = find_godot_binary()
         if godot_bin:
@@ -96,19 +136,19 @@ def run_init(
             except OSError:
                 pass
             (control_dir / "godot_bin").write_text(godot_bin + "\n")
-            print(f"检测到 Godot：{godot_bin}（已写入 .cli_control/godot_bin）")
+            _say(f"检测到 Godot：{godot_bin}（已写入 .cli_control/godot_bin）")
+            _record(godot_bin=godot_bin)
             # 无条件重新导入：拷了新 .gd、改了 autoload，cache 必然 stale。
             # 不靠 daemon._ensure_imported 兜底是因为它要等 daemon start 才跑，
             # 用户这时已经看到 parse error；放在 init 里把"setup 完成"打到位，
             # 后续 daemon start 纯起服务、无隐性首次延迟。
             reimport_project(project_root, godot_bin)
         else:
-            print(
+            _warn(
                 "警告：未自动检测到 Godot 二进制。\n"
                 "请 `export GODOT_BIN=/path/to/godot` 或写到 "
                 ".cli_control/godot_bin。\n"
-                "（跳过资源重新导入；首次 daemon start 会兜底重建 cache）",
-                file=sys.stderr,
+                "（跳过资源重新导入；首次 daemon start 会兜底重建 cache）"
             )
 
     if write_skills:
@@ -132,13 +172,14 @@ def run_init(
             force=clobber_skills,
         )
         for p in written:
-            print(f"写入 skill：{p.relative_to(project_root)}")
+            _say(f"写入 skill：{p.relative_to(project_root)}")
+        _record(skills_written=[str(p) for p in written])
 
-    print()
-    print("已就绪。下一步：")
-    print("  godot-cli-control daemon start          # 启动 daemon")
-    print("  godot-cli-control tree 3                # 验证 RPC 通了")
-    print("  godot-cli-control daemon stop           # 停止")
+    _say("")
+    _say("已就绪。下一步：")
+    _say("  godot-cli-control daemon start          # 启动 daemon")
+    _say("  godot-cli-control tree 3                # 验证 RPC 通了")
+    _say("  godot-cli-control daemon stop           # 停止")
     return 0
 
 

--- a/python/godot_cli_control/init_cmd.py
+++ b/python/godot_cli_control/init_cmd.py
@@ -30,6 +30,12 @@ AUTOLOAD_KEY = "GameBridgeNode"
 AUTOLOAD_VALUE = '"*res://addons/godot_cli_control/bridge/game_bridge.gd"'
 PLUGIN_CFG_PATH = "res://addons/godot_cli_control/plugin.cfg"
 
+# `run_init` 在 ``output_format='json'`` 模式下用此 key 把"预期错误"
+# 的可读 message 回填到调用方传入的 ``result`` dict，由 ``cli.cmd_init``
+# 取出来塞 JSON envelope。dunder 前缀显式声明"带外通道、非业务字段"，
+# 避免与未来真实业务字段（如 `__init__` 之类）冲突。
+INIT_RESULT_ERROR_KEY = "__init_error_message__"
+
 
 def run_init(
     project_root: Path,
@@ -55,7 +61,7 @@ def run_init(
     传入 ``result`` 字典，本函数会回填结构化字段，由 cli 侧封 JSON envelope。
     ``output_format='text'``（默认）保持旧行为，``result`` 可省略 / 也可传入
     并被回填，互不冲突。错误路径在 text 模式下打印到 stderr，json 模式下
-    把 message 塞进 ``result['_error_message']`` 供 envelope 取用。
+    把 message 塞进 ``result[INIT_RESULT_ERROR_KEY]`` 供 envelope 取用。
     """
     quiet = output_format == "json"
 
@@ -75,7 +81,7 @@ def run_init(
     def _fail(message: str) -> int:
         _warn(f"错误：{message}")
         if result is not None:
-            result["_error_message"] = message
+            result[INIT_RESULT_ERROR_KEY] = message
         return 1
 
     _record(

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -64,7 +64,21 @@ $ godot-cli-control click /root/DoesNotExist
 
 $ godot-cli-control --text exists /root/Main
 true
+
+$ godot-cli-control init
+{"ok": true, "result": {"project_root": "/path/to/proj", "plugin_copied": true, "plugin_overwritten": false, "project_godot_changes": ["autoload/GameBridgeNode", "editor_plugins/enabled"], "godot_bin": "/usr/bin/godot", "skills_written": [".../SKILL.md", ".../SKILL.md"], "skills_only": false, "write_skills": true}}
+
+$ godot-cli-control run my_script.py
+{"ok": true, "result": {"exit_code": 0, "script": "my_script.py"}}
+
+$ godot-cli-control run broken.py
+{"ok": false, "error": {"code": -1005, "message": "运行失败：RuntimeError: assertion failed"}}
 ```
+
+Both `init` and `run` honour the same envelope. In `run --json` mode the
+user script's `print()` output is redirected to stderr so the envelope stays
+on a single stdout line — anything your script writes is still visible in
+the terminal, just not in the parseable payload.
 
 ## Error code reference
 
@@ -97,6 +111,7 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 | `-1002` | Timeout waiting for a response. Daemon may be hung mid-frame; check Godot stderr. |
 | `-1003` | Usage error (e.g. `combo` got no steps, malformed `--steps-json`, `combo -` from a TTY). Fix the invocation. |
 | `-1004` | Local file IO error (e.g. `screenshot` can't write the destination — bad path, no write permission). **Not** a daemon problem. |
+| `-1005` | `run <script>` user script raised an uncaught exception. The error message has the exception type + last-line summary; full traceback is on stderr. Fix the script, not the CLI. |
 | `-1099` | Internal client error (unforeseen exception). Bug in this CLI; please file an issue. Stderr has the full traceback. |
 
 Server vs client ranges never overlap, so a single `code` field is unambiguous.

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -357,6 +357,197 @@ def test_new_rpc_subcommands_parse(
         )
 
 
+# ── run / _exec_user_script JSON envelope（issue #50）──
+
+
+def test_exec_user_script_json_success_emits_envelope(
+    tmp_path: Path, stub_bridge: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """成功跑完 → stdout 一行 ``{"ok": true, "result": {"exit_code": 0, ...}}``。"""
+    import json as _json
+
+    from godot_cli_control.cli import _exec_user_script
+
+    script = tmp_path / "user_script.py"
+    _write(script, "def run(bridge):\n    pass\n")
+
+    rc = _exec_user_script(script, port=9999, output_format="json")
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    payload = _json.loads(out)
+    assert payload["ok"] is True
+    assert payload["result"]["exit_code"] == 0
+    assert payload["result"]["script"] == str(script)
+
+
+def test_exec_user_script_json_redirects_script_stdout_to_stderr(
+    tmp_path: Path, stub_bridge: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """用户脚本里 print() 在 json 模式下必须走 stderr —— 否则会把 envelope 撕成两行。"""
+    import json as _json
+
+    from godot_cli_control.cli import _exec_user_script
+
+    script = tmp_path / "user_script.py"
+    _write(
+        script,
+        "def run(bridge):\n"
+        "    print('LEAK_TO_STDOUT_IF_BROKEN')\n",
+    )
+
+    rc = _exec_user_script(script, port=9999, output_format="json")
+    captured = capsys.readouterr()
+    assert rc == 0
+    out_lines = [l for l in captured.out.splitlines() if l.strip()]
+    assert len(out_lines) == 1, f"stdout 不是单行 envelope：{captured.out!r}"
+    payload = _json.loads(out_lines[0])
+    assert payload["ok"] is True
+    # 脚本的 print 必须能在 stderr 看到，便于人 debug
+    assert "LEAK_TO_STDOUT_IF_BROKEN" in captured.err
+
+
+def test_exec_user_script_json_error_on_runtime_exception(
+    tmp_path: Path, stub_bridge: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """脚本 raise → stdout 一行 error envelope（CLIENT_CODE_SCRIPT_ERROR = -1005）；
+    完整 traceback 仍在 stderr。"""
+    import json as _json
+
+    from godot_cli_control.cli import _exec_user_script
+
+    script = tmp_path / "user_script.py"
+    _write(
+        script,
+        "def run(bridge):\n"
+        "    raise RuntimeError('boom from user script')\n",
+    )
+
+    rc = _exec_user_script(script, port=9999, output_format="json")
+    captured = capsys.readouterr()
+    assert rc == 1
+    out_lines = [l for l in captured.out.splitlines() if l.strip()]
+    assert len(out_lines) == 1
+    payload = _json.loads(out_lines[0])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1005
+    assert "RuntimeError" in payload["error"]["message"]
+    assert "boom from user script" in payload["error"]["message"]
+    # 完整 traceback 仍留在 stderr 给人看
+    assert "Traceback" in captured.err
+    assert "RuntimeError: boom from user script" in captured.err
+
+
+def test_exec_user_script_json_error_on_missing_run(
+    tmp_path: Path, stub_bridge: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """缺 run() → ``-1003`` (CLIENT_CODE_USAGE) envelope。"""
+    import json as _json
+
+    from godot_cli_control.cli import _exec_user_script
+
+    script = tmp_path / "user_script.py"
+    _write(script, "x = 1\n")
+
+    rc = _exec_user_script(script, port=9999, output_format="json")
+    out = capsys.readouterr().out.strip()
+    assert rc == 1
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert "run(bridge)" in payload["error"]["message"]
+
+
+def test_exec_user_script_json_error_on_connection_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """daemon 没起 → ``-1001`` (CLIENT_CODE_CONNECTION) envelope。"""
+    import json as _json
+
+    def _raise_conn(*_: Any, **__: Any) -> None:
+        raise ConnectionError("Failed to connect after 1 attempts")
+
+    import godot_cli_control.bridge as bridge_mod
+
+    monkeypatch.setattr(bridge_mod, "GameBridge", _raise_conn)
+
+    script = tmp_path / "user_script.py"
+    _write(script, "def run(bridge):\n    pass\n")
+
+    from godot_cli_control.cli import _exec_user_script
+
+    rc = _exec_user_script(script, port=9999, output_format="json")
+    captured = capsys.readouterr()
+    out = captured.out.strip()
+    assert rc == 1
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1001
+    assert "9999" in payload["error"]["message"]
+    # 友好提示仍留在 stderr
+    assert "daemon start" in captured.err
+
+
+def test_cmd_run_emits_envelope_when_script_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``godot-cli-control run nonexistent.py --json`` → 单行 error envelope。"""
+    import argparse
+    import json as _json
+
+    from godot_cli_control.cli import OUTPUT_JSON, cmd_run
+
+    ns = argparse.Namespace(
+        script=str(tmp_path / "does-not-exist.py"),
+        record=False,
+        movie_path=None,
+        headless=False,
+        gui=False,
+        fps=30,
+        port=0,
+        idle_timeout="0",
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_run(ns)
+    out = capsys.readouterr().out.strip()
+    assert rc == 1
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert "does-not-exist.py" in payload["error"]["message"]
+
+
+def test_cmd_run_emits_envelope_on_idle_timeout_parse_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--idle-timeout xyz`` 解析失败 → envelope (code -1003) + exit 64。"""
+    import argparse
+    import json as _json
+
+    from godot_cli_control.cli import EXIT_USAGE, OUTPUT_JSON, cmd_run
+
+    script = tmp_path / "s.py"
+    script.write_text("def run(bridge): pass\n", encoding="utf-8")
+    ns = argparse.Namespace(
+        script=str(script),
+        record=False,
+        movie_path=None,
+        headless=False,
+        gui=False,
+        fps=30,
+        port=0,
+        idle_timeout="totally-not-a-duration",
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_run(ns)
+    out = capsys.readouterr().out.strip()
+    assert rc == EXIT_USAGE
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+
+
 def test_screenshot_now_requires_path() -> None:
     """0.2.0 BREAKING：screenshot 不再支持省略 output_path（旧版本会喷 base64 到
     stdout，把 LLM 上下文撑爆）。argparse 必须直接拒绝。"""

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -492,11 +492,12 @@ def test_exec_user_script_json_error_on_connection_failure(
 def test_cmd_run_emits_envelope_when_script_missing(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """``godot-cli-control run nonexistent.py --json`` → 单行 error envelope。"""
+    """``godot-cli-control run nonexistent.py --json`` → 单行 error envelope +
+    EXIT_INFRA_ERROR(2)。用户传错路径按 CLAUDE.md 契约 3 归入"用法错=2"。"""
     import argparse
     import json as _json
 
-    from godot_cli_control.cli import OUTPUT_JSON, cmd_run
+    from godot_cli_control.cli import EXIT_INFRA_ERROR, OUTPUT_JSON, cmd_run
 
     ns = argparse.Namespace(
         script=str(tmp_path / "does-not-exist.py"),
@@ -511,7 +512,7 @@ def test_cmd_run_emits_envelope_when_script_missing(
     )
     rc = cmd_run(ns)
     out = capsys.readouterr().out.strip()
-    assert rc == 1
+    assert rc == EXIT_INFRA_ERROR
     payload = _json.loads(out)
     assert payload["ok"] is False
     assert payload["error"]["code"] == -1003
@@ -546,6 +547,193 @@ def test_cmd_run_emits_envelope_on_idle_timeout_parse_error(
     payload = _json.loads(out)
     assert payload["ok"] is False
     assert payload["error"]["code"] == -1003
+
+
+def test_exec_user_script_json_top_level_print_does_not_leak(
+    tmp_path: Path, stub_bridge: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """用户脚本"顶层"（exec_module 阶段）print() 在 json 模式也必须走 stderr。
+    redirect_stdout 范围若只包 module.run、不包 exec_module，顶层 print 会
+    污染 envelope 单行契约——review P1 焦点。"""
+    import json as _json
+
+    from godot_cli_control.cli import _exec_user_script
+
+    script = tmp_path / "user_script.py"
+    _write(
+        script,
+        # 顶层 + run 都打——任一漏出 stdout 都会让 JSON 解析崩
+        "print('TOP_LEVEL_LEAK')\n"
+        "def run(bridge):\n"
+        "    print('RUN_LEAK')\n",
+    )
+
+    rc = _exec_user_script(script, port=9999, output_format="json")
+    captured = capsys.readouterr()
+    assert rc == 0
+    out_lines = [l for l in captured.out.splitlines() if l.strip()]
+    assert len(out_lines) == 1, (
+        f"stdout 不是单行 envelope（顶层 print 漏了？）：{captured.out!r}"
+    )
+    payload = _json.loads(out_lines[0])
+    assert payload["ok"] is True
+    assert payload["result"]["exit_code"] == 0
+    # 两条 print 都应该在 stderr 仍能看到，便于 human debug
+    assert "TOP_LEVEL_LEAK" in captured.err
+    assert "RUN_LEAK" in captured.err
+
+
+def test_exec_user_script_json_error_on_top_level_exception(
+    tmp_path: Path, stub_bridge: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """脚本顶层 raise（exec_module 阶段）也走 CLIENT_CODE_SCRIPT_ERROR；
+    完整 traceback 仍在 stderr。"""
+    import json as _json
+
+    from godot_cli_control.cli import _exec_user_script
+
+    script = tmp_path / "user_script.py"
+    _write(
+        script,
+        "raise ImportError('cannot find frobnicator')\n"
+        "def run(bridge): pass\n",
+    )
+
+    rc = _exec_user_script(script, port=9999, output_format="json")
+    captured = capsys.readouterr()
+    out = captured.out.strip()
+    assert rc == 1
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1005
+    assert "加载" in payload["error"]["message"]
+    assert "ImportError" in payload["error"]["message"]
+    assert "Traceback" in captured.err
+
+
+def test_cmd_run_emits_envelope_on_daemon_start_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """daemon.start raise DaemonError → envelope + EXIT_INFRA_ERROR(2)。
+    遗漏过的 review P2 #4 case：单测之前只覆盖了"脚本不存在""idle 解析失败"。"""
+    import argparse
+    import json as _json
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control.cli import EXIT_INFRA_ERROR, OUTPUT_JSON, cmd_run
+
+    def _fake_is_running(self: Any) -> bool:
+        return False
+
+    def _fake_start(self: Any, **__: Any) -> None:
+        raise daemon_mod.DaemonError("port already bound")
+
+    monkeypatch.setattr(daemon_mod.Daemon, "is_running", _fake_is_running)
+    monkeypatch.setattr(daemon_mod.Daemon, "start", _fake_start)
+
+    script = tmp_path / "s.py"
+    _write(script, "def run(bridge): pass\n")
+    ns = argparse.Namespace(
+        script=str(script),
+        record=False,
+        movie_path=None,
+        headless=False,
+        gui=False,
+        fps=30,
+        port=0,
+        idle_timeout="0",
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_run(ns)
+    out = capsys.readouterr().out.strip()
+    assert rc == EXIT_INFRA_ERROR
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert "port already bound" in payload["error"]["message"]
+
+
+def test_cmd_run_catches_unexpected_exception_into_envelope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """cmd_run 顶层未捕获异常必须落 envelope（CLIENT_CODE_INTERNAL = -1099）+
+    EXIT_INFRA_ERROR(2)。CLAUDE.md 契约 1 ──"任何异常都必须落进信封"。"""
+    import argparse
+    import json as _json
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control.cli import EXIT_INFRA_ERROR, OUTPUT_JSON, cmd_run
+
+    def _kaboom(self: Any) -> bool:
+        # daemon.is_running 抛了不应抛的 OSError —— 模拟 race / FS 损坏
+        raise OSError("disk on fire")
+
+    monkeypatch.setattr(daemon_mod.Daemon, "is_running", _kaboom)
+
+    script = tmp_path / "s.py"
+    _write(script, "def run(bridge): pass\n")
+    ns = argparse.Namespace(
+        script=str(script),
+        record=False,
+        movie_path=None,
+        headless=False,
+        gui=False,
+        fps=30,
+        port=0,
+        idle_timeout="0",
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_run(ns)
+    captured = capsys.readouterr()
+    out = captured.out.strip()
+    assert rc == EXIT_INFRA_ERROR
+    # envelope 是唯一 stdout，traceback 走 stderr
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1099
+    assert "OSError" in payload["error"]["message"]
+    assert "disk on fire" in payload["error"]["message"]
+    assert "Traceback" in captured.err
+
+
+def test_cmd_init_catches_unexpected_exception_into_envelope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """cmd_init 顶层未捕获异常也落 envelope。模拟 run_init 内部 raise
+    非预期异常（例如 reimport_project 抛 OSError）。"""
+    import argparse
+    import json as _json
+
+    from godot_cli_control.cli import EXIT_INFRA_ERROR, OUTPUT_JSON, cmd_init
+
+    def _boom(*_: Any, **__: Any) -> int:
+        raise OSError("permission denied on addons/")
+
+    monkeypatch.setattr("godot_cli_control.init_cmd.run_init", _boom)
+
+    ns = argparse.Namespace(
+        path=str(tmp_path),
+        force=False,
+        no_skills=False,
+        skills_only=False,
+        skills_no_clobber=False,
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_init(ns)
+    captured = capsys.readouterr()
+    out = captured.out.strip()
+    assert rc == EXIT_INFRA_ERROR
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1099
+    assert "OSError" in payload["error"]["message"]
+    assert "Traceback" in captured.err
 
 
 def test_screenshot_now_requires_path() -> None:

--- a/python/tests/test_init.py
+++ b/python/tests/test_init.py
@@ -387,18 +387,22 @@ def test_run_init_json_mode_suppresses_human_prints_and_collects_result(
 def test_run_init_json_mode_records_error_message_on_failure(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """json 模式 + 非 Godot 目录：rc=1，``result['_error_message']`` 必须有值，
-    且不许往 stderr 喷（envelope 是唯一通道）。"""
-    from godot_cli_control.init_cmd import run_init
+    """json 模式 + 非 Godot 目录：rc=1，``result[INIT_RESULT_ERROR_KEY]`` 必须有值，
+    且不许往 stderr 喷"错误：..."字符串（envelope 是唯一通道）。"""
+    from godot_cli_control.init_cmd import INIT_RESULT_ERROR_KEY, run_init
 
     result: dict[str, object] = {}
     rc = run_init(tmp_path, output_format="json", result=result)
     captured = capsys.readouterr()
 
     assert rc == 1
+    # stdout 必须完全干净——envelope 由 cli 侧封；
+    # stderr 不能含项目自定义"错误："标签或 Python traceback
+    # （第三方 import warning 之类无害噪声仍允许，避免断言过紧）。
     assert captured.out == ""
-    assert captured.err == ""
-    assert "project.godot" in result["_error_message"]
+    assert "错误：" not in captured.err
+    assert "Traceback" not in captured.err
+    assert "project.godot" in result[INIT_RESULT_ERROR_KEY]
 
 
 def test_cmd_init_emits_success_envelope_in_json_mode(

--- a/python/tests/test_init.py
+++ b/python/tests/test_init.py
@@ -348,3 +348,120 @@ def test_init_skills_no_clobber_preserves_existing(tmp_path: Path) -> None:
     assert "USER_CUSTOM_KEEP_ME" not in (
         proj / CODEX_REL
     ).read_text(encoding="utf-8")
+
+
+# ── run_init JSON 输出契约（issue #50）──
+
+
+def test_run_init_json_mode_suppresses_human_prints_and_collects_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``output_format='json'``：stdout 必须完全干净（envelope 由 cli 侧封），
+    结构化字段全部回填到 ``result`` dict。"""
+    from godot_cli_control.init_cmd import run_init
+
+    monkeypatch.delenv("GODOT_BIN", raising=False)
+    monkeypatch.setattr(
+        "godot_cli_control.init_cmd.find_godot_binary", lambda: None
+    )
+    proj = _make_min_godot_project(tmp_path)
+
+    result: dict[str, object] = {}
+    rc = run_init(proj, output_format="json", result=result)
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    # json 模式下 run_init 自身不能往 stdout 写任何东西 —— cli.cmd_init 才负责输出 envelope
+    assert captured.out == ""
+    # 结构化字段 cli 侧拿来塞 envelope
+    assert result["project_root"] == str(proj)
+    assert result["plugin_copied"] is True
+    assert result["plugin_overwritten"] is False
+    assert "autoload/GameBridgeNode" in result["project_godot_changes"]
+    assert result["godot_bin"] is None
+    assert len(result["skills_written"]) == 2
+
+
+def test_run_init_json_mode_records_error_message_on_failure(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """json 模式 + 非 Godot 目录：rc=1，``result['_error_message']`` 必须有值，
+    且不许往 stderr 喷（envelope 是唯一通道）。"""
+    from godot_cli_control.init_cmd import run_init
+
+    result: dict[str, object] = {}
+    rc = run_init(tmp_path, output_format="json", result=result)
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert captured.out == ""
+    assert captured.err == ""
+    assert "project.godot" in result["_error_message"]
+
+
+def test_cmd_init_emits_success_envelope_in_json_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """端到端：``godot-cli-control init --json`` 在快乐路径必须输出单行 envelope。"""
+    import argparse
+    import json as _json
+
+    from godot_cli_control.cli import OUTPUT_JSON, cmd_init
+
+    monkeypatch.delenv("GODOT_BIN", raising=False)
+    monkeypatch.setattr(
+        "godot_cli_control.init_cmd.find_godot_binary", lambda: None
+    )
+    proj = _make_min_godot_project(tmp_path)
+
+    ns = argparse.Namespace(
+        path=str(proj),
+        force=False,
+        no_skills=False,
+        skills_only=False,
+        skills_no_clobber=False,
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_init(ns)
+    out = capsys.readouterr().out.strip()
+
+    assert rc == 0
+    # 单行 JSON envelope —— AI agent 的契约根基
+    assert out.count("\n") == 0
+    payload = _json.loads(out)
+    assert payload["ok"] is True
+    result = payload["result"]
+    assert result["plugin_copied"] is True
+    assert isinstance(result["project_godot_changes"], list)
+    assert result["skills_only"] is False
+
+
+def test_cmd_init_emits_error_envelope_on_non_godot_dir(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """非 Godot 项目目录 + ``--json`` → 单行 error envelope，stdout 不含人类字串。"""
+    import argparse
+    import json as _json
+
+    from godot_cli_control.cli import OUTPUT_JSON, cmd_init
+
+    ns = argparse.Namespace(
+        path=str(tmp_path),
+        force=False,
+        no_skills=False,
+        skills_only=False,
+        skills_no_clobber=False,
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_init(ns)
+    out = capsys.readouterr().out.strip()
+
+    assert rc == 1
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003  # CLIENT_CODE_USAGE
+    assert "project.godot" in payload["error"]["message"]


### PR DESCRIPTION
Closes #50.

## Summary

PR 经过 review 反馈一次迭代（commit `c173025`），现修复 9 项：1 P1 + 3 P2 + 5 P3。

- PR #46 给所有子 parser 注入了 `--json` flag，但 `run` / `init` 的 dispatcher 仍走 `print(...)` 人类可读路径——AI agent 假设拿到 envelope，实际解析人类字串失败。属"quiet lie"，破坏默认 `--json` 这条 AI 友好契约的根基。
- `run_init` 加 keyword-only `output_format` + `result`：json 模式吞 print、回填结构化字段；text 模式行为零变化。
- `cmd_init`：success → `{ok:true, result:{project_root, plugin_copied, plugin_overwritten, project_godot_changes, godot_bin, skills_written, skills_only}}`；非 Godot 目录 → `{ok:false, error:{code:-1003, ...}}`；**未捕获异常 → `{code:-1099}` + EXIT_INFRA_ERROR**。
- `cmd_run` / `_exec_user_script`：success → `{exit_code:0, script:...}`（daemon stop 异常时加 `daemon_stop_warning`）；脚本 raise → 新增 `-1005 CLIENT_CODE_SCRIPT_ERROR`（让 agent 区分"框架自身错"vs"我脚本错"）；缺 `run(bridge)` → `-1003`；连接失败 → `-1001`；**未捕获异常 → `-1099`**。
- 脚本**顶层** print() 和 `module.run()` 内的 print() 都走 `contextlib.redirect_stdout(sys.stderr)` 隔离（review P1 焦点：之前只包 `module.run`，顶层 print 会泄 envelope）—— envelope 永远单行 stdout。
- exit code 与 CLAUDE.md 契约 3 对齐：脚本不存在 / daemon.start 失败 → `EXIT_INFRA_ERROR(2)`，与 `cmd_daemon_start` 一致。
- SKILL.md 模板 + addon README 错误码表补 `-1005`；envelope examples 段加 `init` / `run` 两个示例。

## Test plan

- [x] `coverage run -m pytest python/tests/` —— **315 passed, 0 failed**
- [x] `coverage report --fail-under=80` —— **82%**，过门槛
- [x] 14 条新测试覆盖：
  - `run_init` json 模式 stdout 干净 + 字段回填
  - `run_init` json 错误路径 stdout 完全干净、`INIT_RESULT_ERROR_KEY` 进 result
  - `cmd_init` success / error / **顶层异常兜底** envelope
  - `_exec_user_script` json success / **顶层 print 不泄** / 脚本 raise / **顶层 raise** / 缺 `run` / 连接失败
  - `cmd_run` 脚本不存在 / idle_timeout 解析失败 / **daemon.start 失败** / **顶层异常兜底** → envelope + 正确 exit code
- [x] `format_full_help()` 渲染不崩（SKILL.md `init` 注入路径仍可用）
- [ ] 手测 `godot-cli-control init --json` / `run script.py --json` 在真实 Godot 项目上跑（需要用户在自己机器上验，含 record 模式 daemon stop 失败时的 `daemon_stop_warning` 字段）

🤖 Generated with [Claude Code](https://claude.com/claude-code)