### PR TITLE
fix(bridge): 加 action_tap / get_scene_tree / wait_game_time alias（修复 #58 + #60）

### DIFF
--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -84,12 +84,7 @@ class GameBridge:
         self._run(self._client.action_tap(action, duration))
 
     def action_tap(self, action: str, duration: float = 0.1) -> None:
-        """``tap`` 的别名 —— 与 ``GameClient.action_tap`` 命名对齐。
-
-        Why: bridge 的方法名整体跟 client 对齐（``action_press`` / ``action_release`` / ``hold`` 都同名），
-        唯独 tap 历史上被改名，导致 README 表格 + ``run --help`` 里"方法名一致"的承诺被打脸（issue #58）。
-        ``tap`` 保留供已有脚本继续用。
-        """
+        """``tap`` 的别名，与 ``GameClient.action_tap`` 同名对齐（issue #58）。"""
         self.tap(action, duration)
 
     def action_press(self, action: str) -> None:

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -45,11 +45,19 @@ class GameBridge:
         """
         self._run(self._client.wait_game_time(seconds))
 
+    def wait_game_time(self, seconds: float) -> None:
+        """``wait`` 的别名，与 ``GameClient.wait_game_time`` 同名对齐（issue #60）。"""
+        self.wait(seconds)
+
     # ── 场景树 ──
 
     def tree(self, depth: int = 3, max_nodes: int | None = None) -> dict:
         """获取场景树。"""
         return self._run(self._client.get_scene_tree(depth=depth, max_nodes=max_nodes))
+
+    def get_scene_tree(self, depth: int = 3, max_nodes: int | None = None) -> dict:
+        """``tree`` 的别名，与 ``GameClient.get_scene_tree`` 同名对齐（issue #60）。"""
+        return self.tree(depth=depth, max_nodes=max_nodes)
 
     def node_exists(self, path: str) -> bool:
         """检查节点是否存在。"""

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -83,6 +83,15 @@ class GameBridge:
         """快速点按。"""
         self._run(self._client.action_tap(action, duration))
 
+    def action_tap(self, action: str, duration: float = 0.1) -> None:
+        """``tap`` 的别名 —— 与 ``GameClient.action_tap`` 命名对齐。
+
+        Why: bridge 的方法名整体跟 client 对齐（``action_press`` / ``action_release`` / ``hold`` 都同名），
+        唯独 tap 历史上被改名，导致 README 表格 + ``run --help`` 里"方法名一致"的承诺被打脸（issue #58）。
+        ``tap`` 保留供已有脚本继续用。
+        """
+        self.tap(action, duration)
+
     def action_press(self, action: str) -> None:
         """按下动作（不释放，需手动 release）。"""
         self._run(self._client.action_press(action))

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -276,6 +276,17 @@ def test_tap_explicit_duration(stub_client: dict) -> None:
     b.close()
 
 
+def test_action_tap_is_alias_for_tap(stub_client: dict) -> None:
+    """issue #58: bridge.action_tap 必须存在并与 bridge.tap 行为一致，
+    保证 README 表格 + run --help 里"方法名一致"的承诺成立。"""
+    b, c = _make_bridge(stub_client)
+    b.action_tap("attack")
+    assert c.calls[-1] == ("action_tap", ("attack",), {"duration": 0.1})
+    b.action_tap("attack", duration=0.25)
+    assert c.calls[-1] == ("action_tap", ("attack",), {"duration": 0.25})
+    b.close()
+
+
 def test_action_press_release(stub_client: dict) -> None:
     b, c = _make_bridge(stub_client)
     b.action_press("jump")

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -173,6 +173,15 @@ def test_wait_uses_game_time_not_wall_time(stub_client: dict) -> None:
     b.close()
 
 
+def test_wait_game_time_is_alias_for_wait(stub_client: dict) -> None:
+    """issue #60: bridge.wait_game_time 必须存在并与 bridge.wait 行为一致。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["wait_game_time"] = {"success": True}
+    b.wait_game_time(1.25)
+    assert c.calls[-1] == ("wait_game_time", (1.25,), {})
+    b.close()
+
+
 def test_tree_default_depth_3_not_client_default_5(stub_client: dict) -> None:
     """bridge.tree() 默认 depth=3，比 client 默认 5 浅，避免大场景树阻塞。"""
     b, c = _make_bridge(stub_client)
@@ -197,6 +206,19 @@ def test_tree_forwards_max_nodes_to_client(stub_client: dict) -> None:
     c.returns["get_scene_tree"] = {}
     b.tree(max_nodes=50)
     assert c.calls[-1] == ("get_scene_tree", (), {"depth": 3, "max_nodes": 50})
+    b.close()
+
+
+def test_get_scene_tree_is_alias_for_tree(stub_client: dict) -> None:
+    """issue #60: bridge.get_scene_tree 必须存在并与 bridge.tree 行为一致，
+    包括默认 depth=3（比 client 默认 5 浅）+ max_nodes 透传。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["get_scene_tree"] = {"name": "root"}
+    result = b.get_scene_tree()
+    assert c.calls[-1] == ("get_scene_tree", (), {"depth": 3})
+    assert result == {"name": "root"}
+    b.get_scene_tree(depth=7, max_nodes=99)
+    assert c.calls[-1] == ("get_scene_tree", (), {"depth": 7, "max_nodes": 99})
     b.close()
 
 


### PR DESCRIPTION
## Summary

让 `GameBridge` 所有方法名与 `GameClient` 完全对齐，兑现 `run --help` 里 "bridge 是 GameClient 的同步包装，方法名一致" 的承诺。

| client（async） | bridge 短名 | 本 PR 加的 alias | issue |
|---|---|---|---|
| `action_tap` | `tap` | `action_tap` | #58 |
| `get_scene_tree` | `tree` | `get_scene_tree` | #60 |
| `wait_game_time` | `wait` | `wait_game_time` | #60 |

策略：保留短名给已有脚本继续用，加同名 alias 转发到短名。零 breaking。

## 根因

`bridge.py` 历史上为这三个方法挑了更短的别名（`tap` / `tree` / `wait`），但 README "API at a glance" 主表 + `run --help` 文案都暗示「bridge 跟 client 方法同名」。照表抄成 `bridge.action_tap(...)` / `bridge.get_scene_tree(...)` 的用户会撞 `AttributeError`（#58 由 walkthrough 脚本踩到上报，#60 是 #58 review 时发现的同模式遗留）。

## 方案选择

走 issue 推荐的方案 A（alias），权衡过的另两条路：
- **全统一到长名**（CLI + Python 一起改 `tap`→`action-tap` 等）：breaking 太大，外部 shell 脚本/CI 全要改
- **只删 bridge 短名，CLI 不动**：会引入新的 "CLI 短 vs Python 长" 不一致，治不好原病

CLI 习惯短名、Python client 习惯长名本身是合理的分工，alias 是最干净的折中。

## Test plan

- [x] `test_action_tap_is_alias_for_tap`（#58）—— 默认 / 显式 duration 两条路径
- [x] `test_get_scene_tree_is_alias_for_tree`（#60）—— 默认 depth=3 + max_nodes 透传
- [x] `test_wait_game_time_is_alias_for_wait`（#60）—— wait_game_time 透传 seconds
- [x] `coverage run -m pytest python/tests/test_bridge.py` → 36 passed
- [x] 联跑 `test_bridge.py + test_client.py` → 49 passed（#58 时验过，本次新增只动 bridge.py 不影响 client）
- [ ] 手测：godot 项目里 `bridge.action_tap(...)` / `bridge.get_scene_tree(...)` / `bridge.wait_game_time(...)` 不再抛 AttributeError

Closes #58
Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)