### PR TITLE
fix(bridge): screenshot 首帧 transient 根因消除 + 兜底 (#61)

### DIFF
--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -110,7 +110,7 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `1003` | server | Method not found on the node (schema error, don't retry) |
 | `1004` | server | Combo already in progress (call `combo-cancel` to retry) |
 | `1005` | server | Scene tree too large (lower `depth` or pass `--max-nodes`) |
-| `1006` | server | Resource transiently unavailable (e.g. screenshot before viewport ready) — safe to retry |
+| `1006` | server | Resource transiently unavailable (e.g. screenshot during scene transition). Rare under normal use — GameBridge waits for viewport first-frame before listening, and `screenshot` retries internally. Safe to retry if you do hit it. |
 | `-32600` | server | Malformed JSON-RPC request |
 | `-32601` | server | Unknown method name |
 | `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, or `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements) |

--- a/addons/godot_cli_control/bridge/error_codes.gd
+++ b/addons/godot_cli_control/bridge/error_codes.gd
@@ -16,6 +16,11 @@ const COMBO_IN_PROGRESS: int = 1004
 const SCENE_TREE_TOO_LARGE: int = 1005
 # 资源 transient 不可用（screenshot viewport texture null 等）。
 # 与 1003 拆开：1003 是 schema 错（永久），1006 是时机错（短重试可能成功）。
+# issue #61 落地后语义：GameBridge 启动 gate（H）保证 client 连上时 viewport
+# 至少画过一帧 + take_screenshot_async 内部循环（D）兜底动态 transient，
+# 所以正常用法下 1006 不应触发。但它仍是 last-resort 合法信号 ——
+# client 必须保留对 1006 的处理（不要假设它消失），未来若改为 fail-loud
+# 会让 scene 切换瞬间的截图变成硬错。
 const RESOURCE_UNAVAILABLE: int = 1006
 
 const INVALID_PARAMS: int = -32602

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -6,6 +6,11 @@ const DEFAULT_PORT: int = 9877
 const SETTING_AUTO_ENABLE: String = "godot_cli_control/auto_enable_in_debug"
 const SETTING_OUTBOUND_BUFFER_MB: String = "godot_cli_control/outbound_buffer_mb"
 const DEFAULT_OUTBOUND_BUFFER_MB: int = 10
+# 启动 gate：listen 前等 viewport 首帧 ready 的上限帧数。
+# 60fps 下 ~2s；shader 编译 / 大资源加载超过这个就走 fallback —— 仍开端口，
+# 把后续 screenshot 的 transient 兜底交给 take_screenshot_async 的循环。
+# 设计意图见 issue #61：根因消除（H）+ handler 内动态兜底（D）。
+const FIRST_FRAME_READY_MAX_FRAMES: int = 120
 
 var _tcp_server: TCPServer = TCPServer.new()
 var _active_peer: WebSocketPeer = null
@@ -56,6 +61,13 @@ func _ready() -> void:
 		ProjectSettings.get_setting(SETTING_OUTBOUND_BUFFER_MB, DEFAULT_OUTBOUND_BUFFER_MB)
 	)
 	_outbound_buffer_size = max(1, mb) * 1024 * 1024
+	# 启动 gate：等 viewport 首帧 ready 后再开 listen。
+	# 根因：issue #61。screenshot 在「viewport 从未画过一次」时拿到 null
+	# texture → 报 1006 transient；让 client connect 上来这件事本身就承诺
+	# 「至少画过一帧」，把根因消除而不是各 handler 各自打补丁。
+	# 超时不阻塞 listen —— 端口冲突 / 启动诊断信号要保留（_tcp_server.listen
+	# 失败的 printerr 在端口冲突时是用户唯一的 root cause 提示）。
+	await _wait_first_frame_ready()
 	# 启动 TCP 服务器
 	_port = _parse_port_from_args()
 	# 安全：显式绑 127.0.0.1，避免 Godot TCPServer 默认 "*" 暴露到 LAN
@@ -79,6 +91,23 @@ func _ready() -> void:
 		t.timeout.connect(_check_idle)
 		add_child(t)
 		print("GameBridge: idle-timeout %ds enabled" % _idle_timeout_secs)
+
+
+func _wait_first_frame_ready() -> void:
+	# dummy renderer (--headless) 下 RenderingServer.frame_post_draw 永不发射；
+	# 与 take_screenshot_async 用同一套检测，dummy 路径走 process_frame ×2。
+	# 上限 FIRST_FRAME_READY_MAX_FRAMES 后无论 viewport 是否 ready 都返回，
+	# 让 listen 不被 GPU 卡死 / 大场景首帧拖住，避免 daemon 启动绑架到项目复杂度。
+	var dummy: bool = RenderingServer.get_rendering_device() == null
+	if dummy:
+		await get_tree().process_frame
+		await get_tree().process_frame
+		return
+	for _i in FIRST_FRAME_READY_MAX_FRAMES:
+		await RenderingServer.frame_post_draw
+		var image: Image = get_viewport().get_texture().get_image()
+		if image != null:
+			return
 
 
 func _process(_delta: float) -> void:

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -14,6 +14,10 @@ const _BUILD_TREE_HARD_LIMIT: int = 50
 const _BUILD_TREE_NODE_LIMIT: int = 5000
 # wait_game_time_async 防呆上限：防止误传 1e9 之类的数值挂死 session
 const _MAX_WAIT_SECONDS: float = 3600.0
+# take_screenshot_async 循环上限：常态下 GameBridge 启动 gate 已保证 viewport
+# ready（issue #61 H 部分），这个循环只兜动态 transient（scene transition、
+# 窗口 resize 一瞬）。30 帧 ~500ms @ 60fps，超时报 1006 给 client 兜底。
+const SCREENSHOT_MAX_FRAMES: int = 30
 
 # ProjectSettings 路径：第三方项目通过这两条额外补 ban 自家属性 / 方法。
 # 合并到内置黑名单（去重，不能减只能加 —— 不开放 unban 是为了防止误删安全网）。
@@ -416,13 +420,25 @@ func take_screenshot_async() -> Dictionary:
 	# dummy renderer (--headless) 下 RenderingServer.frame_post_draw 永不发射，
 	# await 会永久挂死。RenderingServer.get_rendering_device() 在 dummy driver
 	# 下返回 null，用它检测后改走 process_frame 推进路径。
-	if RenderingServer.get_rendering_device() == null:
-		# dummy 路径：连续推 2 帧，让 viewport 跑一次完整 update
-		await get_tree().process_frame
-		await get_tree().process_frame
-	else:
-		await RenderingServer.frame_post_draw
-	var image: Image = get_viewport().get_texture().get_image()
+	# windowed 下循环等到 ready 是 issue #61 的 D 部分：兜底动态 transient
+	# （scene 切换 / 窗口 resize 一瞬）。常态下 GameBridge._wait_first_frame_ready
+	# 已经保证 client 连上 = viewport 至少画过一帧（H），所以通常第一次就拿到 image。
+	# SCREENSHOT_MAX_FRAMES 后仍 null 才报 1006 —— 1006 是 last-resort 兜底，
+	# 仍是合法 transient（client 仍应处理）。
+	# dummy 路径只试一次：headless 下 viewport texture 永远拿不到 image（无真 GPU），
+	# 循环 N 次只会让 Godot 内部 "Parameter t is null" push_error 噪音放大 N 倍。
+	var dummy: bool = RenderingServer.get_rendering_device() == null
+	var max_iters: int = 1 if dummy else SCREENSHOT_MAX_FRAMES
+	var image: Image = null
+	for _i in max_iters:
+		if dummy:
+			await get_tree().process_frame
+			await get_tree().process_frame
+		else:
+			await RenderingServer.frame_post_draw
+		image = get_viewport().get_texture().get_image()
+		if image != null:
+			break
 	if image == null:
 		# 1006 (transient) ≠ 1003 (schema)：agent 可短重试，等下一帧 viewport 就绪。
 		return _err(CliControlErrorCodes.RESOURCE_UNAVAILABLE, "Screenshot unavailable (viewport texture is null)")

--- a/addons/godot_cli_control/tests/gut/test_game_bridge.gd
+++ b/addons/godot_cli_control/tests/gut/test_game_bridge.gd
@@ -405,3 +405,26 @@ func test_check_idle_resets_activity_when_busy() -> void:
 	_bridge._check_idle()
 	var now: int = Time.get_ticks_msec()
 	assert_almost_eq(_bridge._last_activity_ms, now, 200, "busy 时 _check_idle 必须把活动戳推到 ~now")
+
+
+# ── 启动 gate (issue #61 H 部分) ─────────────────────────────────
+# GUT 跑 --headless → RenderingServer.get_rendering_device() == null → dummy 路径。
+# 真 windowed 路径无法在 GUT 内测（要真 GPU），靠 e2e 覆盖。
+
+func test_wait_first_frame_ready_returns_under_headless() -> void:
+	# 关键防回归：dummy 路径不能 await frame_post_draw（永不发射 → 死锁）。
+	# 用 process_frame 推两帧应在毫秒级返回，否则函数被误改成走 windowed 分支。
+	# 必须 add_child 进 tree，否则 await get_tree().process_frame 拿不到 tree。
+	if _bridge.is_inside_tree():
+		_bridge.get_parent().remove_child(_bridge)
+	add_child_autofree(_bridge)
+	var t0: int = Time.get_ticks_msec()
+	await _bridge._wait_first_frame_ready()
+	var elapsed_ms: int = Time.get_ticks_msec() - t0
+	# 2s 余量，正常应在 < 100ms 返回
+	assert_lt(elapsed_ms, 2000, "_wait_first_frame_ready 在 headless 下必须秒返不死锁")
+
+
+func test_first_frame_ready_max_frames_constant_is_positive() -> void:
+	# 防回归：常量被改成 0 或负数会让循环立刻退出 → 启动 gate 失效。
+	assert_gt(GameBridgeScript.FIRST_FRAME_READY_MAX_FRAMES, 0)

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -694,3 +694,26 @@ func test_node_exists_false_for_missing_path() -> void:
 		"path": "/root/__missing__",
 	})
 	assert_false(result.get("exists"))
+
+
+# ── take_screenshot_async（issue #61 D 部分）──────────────────────
+# GUT 跑在 --headless 下，RenderingServer.get_rendering_device() == null，
+# 走 dummy 推帧路径。这两条测试主要防 await 死锁回归（早期版本一次没等
+# 到 ready 就报 1006，绕过 H 启动 gate 后会再撞）。
+
+func test_screenshot_returns_image_or_1006_under_headless() -> void:
+	# headless 下 viewport texture 可能是 null（dummy 无真实 RenderingDevice）。
+	# 合法结果：要么拿到 base64 image，要么循环跑满后报 1006。
+	# 关键不变量：函数必须返回（不死锁）、不抛、payload 形状正确。
+	var result: Dictionary = await _api.take_screenshot_async()
+	assert_true(result.has("image") or result.has("error"),
+		"take_screenshot_async must return image or error envelope")
+	if result.has("error"):
+		var err: Dictionary = result["error"] as Dictionary
+		assert_eq(int(err.get("code")), 1006,
+			"headless null viewport must report RESOURCE_UNAVAILABLE not other code")
+
+
+func test_screenshot_max_frames_constant_is_positive() -> void:
+	# 防回归：常量被改成 0 或负数会让循环立刻退出 → 等同未修。
+	assert_gt(LowLevelApiScript.SCREENSHOT_MAX_FRAMES, 0)

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -93,7 +93,7 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 | `1003` | Method not found on the node. Schema error — don't retry, inspect with `tree`. |
 | `1004` | Combo already in progress. Call `combo-cancel` (or `release-all`) and re-issue. Safe to retry after that. |
 | `1005` | Scene tree too large to serialize (default safety limit). Pass `--max-nodes` or query a subtree with `children` / `tree <subpath>`. Don't retry as-is. |
-| `1006` | Resource transiently unavailable (e.g. screenshot before viewport renders the first frame). Safe to retry after `wait-time 0.05` or similar. |
+| `1006` | Resource transiently unavailable (e.g. screenshot during scene transition / window resize). Rare under normal use: GameBridge waits for viewport first-frame before accepting connections, and `screenshot` retries internally up to ~500ms. If you still see this, retry after `wait-time 0.05` or similar. |
 
 **JSON-RPC standard — negative integers `-32xxx`:**
 
@@ -367,6 +367,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **`tree` returns `1005 "scene tree too large"`** — your scene has more than 5000 visible nodes (a Grid / spawned-bullets situation). Pass `--max-nodes 200` to cap, or `children <path>` for one specific subtree.
 - **`set` with a string that *looks* like JSON** — value parser parses JSON first. To force a literal `"42"` string, pass `'"42"'`; to set a literal hash sign or array text, JSON-encode it.
 - **`daemon start` opens a window when I expected headless** — your stdout is a TTY (interactive terminal). Pass `--headless` explicitly, or shell out from a context where stdout is piped.
+- **`screenshot` used to fail with `1006` on the first call** — fixed. GameBridge now waits for the viewport's first frame before opening the port, so `connect succeeded` implies `viewport has rendered ≥ once`. The magic `bridge.wait(1.5)` before the first screenshot in older example scripts is no longer needed.
 
 ---
 


### PR DESCRIPTION
## Summary

修复 #61：`bridge.screenshot` 在 walkthrough 脚本第一张图偶发 `1006 RESOURCE_UNAVAILABLE` 的时序问题。两道防线：

- **H（根因消除）**：`GameBridge._ready` 在 `_tcp_server.listen()` 之前 `await _wait_first_frame_ready()`。client 能连上 = viewport 至少画过一帧。dummy renderer（headless）走 `process_frame ×2`，windowed 走循环 `await RenderingServer.frame_post_draw`（上限 120 帧）。**超时不阻塞 listen** —— 保留端口冲突等启动诊断信号。
- **D（动态兜底）**：`take_screenshot_async` windowed 路径循环最多 30 帧等到 image 非 null，兜底 scene 切换 / 窗口 resize 一瞬的动态 transient。dummy 路径只试一次，避免 Godot 内部 `push_error("Parameter t is null")` 噪音放大。
- **1006 保留**为 last-resort 信号。常态下不应触发，但仍是合法 transient —— client 不应假设它消失（错误码注释 + SKILL.md + addon README 同步说明）。

设计讨论 / 风险分析见 #61 评论流程。

## Test plan

- [x] GUT 92/92 pass；新加 4 测试全过
  - `test_screenshot_returns_image_or_1006_under_headless`
  - `test_screenshot_max_frames_constant_is_positive`
  - `test_wait_first_frame_ready_returns_under_headless`
  - `test_first_frame_ready_max_frames_constant_is_positive`
- [x] pytest 318/318 pass，coverage 83%（门槛 80%）
- [x] GUT stderr `Parameter t is null` 噪音从 30+ 降到 1
- [ ] **windowed 路径真 e2e 验证**（无法在 GUT/CI headless 下覆盖）→ 拆 follow-up issue 跟踪

## Follow-up

windowed 路径 e2e 覆盖将开单独 issue 跟踪（GUT 在 headless 下无法测 `frame_post_draw` 分支；client.py screenshot 是否加 1006 retry 兜底作为 design discussion 一并讨论）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)