### PR TITLE
fix(client): wait_game_time/combo 去 wall 上限，靠 ws 心跳兜底（修复 #45）

### DIFF
--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -114,8 +114,8 @@ class GameClient:
                     # 显式锁住 ws 心跳——issue #45 治本依赖：long ops 去掉
                     # seconds-scaled wall 上限后，死连接靠这层独立检测。
                     # 与 websockets 当前默认对齐，防库升级悄悄改默认。
-                    ping_interval=20,
-                    ping_timeout=20,
+                    ping_interval=20,  # 每 20s 无流量发一次 ping
+                    ping_timeout=20,   # pong 20s 未回 → 关连接（≈40s 内可发现死链）
                 )
                 self._listen_task = asyncio.create_task(self._listen())
                 logger.info("Connected to GameBridge on port %d", self._port)

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -14,6 +14,17 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_PORT: int = 9877
 
+# 长操作（wait_game_time / combo）的客户端 wall-time 生死线。
+#
+# 这类操作的「完成」是 game-time 维度（Godot 帧数推进），与 wall time 关系不可
+# 预测：Movie Maker (--write-movie) 模式下 wall ≈ 4-5× game，且随分辨率/fps/盘速
+# 漂移。任何 seconds-scaled 公式都会在某个组合下假超时（issue #45）。
+#
+# 改用固定大值后：正常完成时 server 自然回包；server 真死循环时由 600s 兜底
+# （而不是 55s 把还活着的录像炸掉）；死连接由 websockets 库的 ping/pong 心跳
+# 在 ~40s 内独立检测，与本上限无关。
+LONG_OP_CLIENT_TIMEOUT: float = 600.0
+
 
 class RpcError(RuntimeError):
     """Raised when GameBridge returns a JSON-RPC error response.
@@ -100,6 +111,11 @@ class GameClient:
                     f"ws://127.0.0.1:{self._port}",
                     proxy=None,
                     open_timeout=open_timeout,
+                    # 显式锁住 ws 心跳——issue #45 治本依赖：long ops 去掉
+                    # seconds-scaled wall 上限后，死连接靠这层独立检测。
+                    # 与 websockets 当前默认对齐，防库升级悄悄改默认。
+                    ping_interval=20,
+                    ping_timeout=20,
                 )
                 self._listen_task = asyncio.create_task(self._listen())
                 logger.info("Connected to GameBridge on port %d", self._port)
@@ -263,8 +279,9 @@ class GameClient:
     async def wait_game_time(self, seconds: float) -> dict:
         """按 Godot game time 等待 N 秒。
 
-        Movie Maker (--write-movie) 模式下 wall time 比 game time 慢约 2-3×，
-        客户端 timeout 用 seconds * 3 + 10 安全系数，与 combo() 一致。
+        客户端用固定 ``LONG_OP_CLIENT_TIMEOUT`` 生死线（issue #45）：game-time
+        与 wall-time 比值受录像模式 / 分辨率 / 盘速 / fps 影响不可预测，任何
+        seconds-scaled 公式都会在某个组合下假超时。死连接由 ws ping/pong 兜底。
         seconds <= 0 时客户端短路返回，不发 RPC。
         """
         if seconds <= 0:
@@ -272,7 +289,7 @@ class GameClient:
         return await self.request(
             "wait_game_time",
             {"seconds": seconds},
-            timeout=seconds * 3.0 + 10.0,
+            timeout=LONG_OP_CLIENT_TIMEOUT,
         )
 
     # ---- Input simulation API ----
@@ -294,14 +311,10 @@ class GameClient:
         )
 
     async def combo(self, steps: list[dict]) -> dict:
-        total = sum(
-            s.get("duration", 0) or s.get("wait", 0) for s in steps
-        )
-        # movie maker (--write-movie) 模式下 Godot 渲染比实时慢（大分辨率 +
-        # MJPEG 编码开销），客户端墙钟等待需要 3× 安全系数 + 10s base，
-        # 避免 combo 还没在游戏时间跑完就被 TimeoutError 打断。
+        # 客户端用固定 LONG_OP_CLIENT_TIMEOUT 生死线（issue #45）：见
+        # wait_game_time 注释——同样的 game-time / wall-time 不对齐问题。
         return await self.request(
-            "input_combo", {"steps": steps}, timeout=total * 3.0 + 10.0
+            "input_combo", {"steps": steps}, timeout=LONG_OP_CLIENT_TIMEOUT
         )
 
     async def combo_cancel(self) -> dict:

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import websockets
 
-from godot_cli_control.client import GameClient
+from godot_cli_control.client import LONG_OP_CLIENT_TIMEOUT, GameClient
 
 
 # ---- Test 1: proxy=None 显式传给 websockets.connect ----
@@ -471,58 +471,57 @@ async def test_get_scene_tree_omits_max_nodes_when_none() -> None:
 #
 # 旧公式 seconds*3+10 假设 wall ≤ 3× game，在 Movie Maker (--write-movie) 模式下
 # 实测 wall ≈ 4-5× game，必假超时（bridge.wait(15) → 55s timeout < 60s+ wall）。
-# 治本：去掉 seconds-scaled wall 上限，固定一个生死线（600s），死连接靠 ws ping/pong。
-
-WAIT_GAME_TIME_CLIENT_TIMEOUT = 600.0
+# 治本：去掉 seconds-scaled wall 上限，固定一个生死线，死连接靠 ws ping/pong。
+#
+# 测试用「两次差距大的 seconds 拿到同一 timeout」直接证明 decoupling，
+# 比单点等值断言更稳——后者跟「巧合 == 常量」的假阳性形态无法区分。
 
 
 @pytest.mark.asyncio
 async def test_wait_game_time_client_timeout_decoupled_from_seconds() -> None:
-    """issue #45: wait_game_time 客户端 timeout 必须与 seconds 解耦（固定 600s 生死线）。
-
-    Movie Maker 模式下 wall/game 比值不可预测，任何 seconds-scaled 公式都会在
-    某个分辨率/fps/盘速组合下踩中。改成固定大值后，死连接由 ws ping/pong 兜底。
-    """
+    """issue #45: wait_game_time 客户端 timeout 必须与 seconds 解耦。"""
     import godot_cli_control.client as client_mod
 
-    captured: dict = {}
+    captured: list = []
 
     async def fake_request(self, method, params=None, timeout=30.0):
-        captured["timeout"] = timeout
+        captured.append(timeout)
         return {"success": True}
 
     client = client_mod.GameClient(port=1)
     monkeypatch_target = client_mod.GameClient.request
     client_mod.GameClient.request = fake_request  # type: ignore
     try:
-        await client.wait_game_time(15.0)
+        await client.wait_game_time(1.0)
+        await client.wait_game_time(120.0)
     finally:
         client_mod.GameClient.request = monkeypatch_target
-    assert captured["timeout"] == WAIT_GAME_TIME_CLIENT_TIMEOUT, (
-        f"wait_game_time(15) 应使用固定 {WAIT_GAME_TIME_CLIENT_TIMEOUT}s 生死线，"
-        f"实际 {captured['timeout']}s —— Movie Maker 模式下 seconds-scaled 必假超时"
+    assert captured == [LONG_OP_CLIENT_TIMEOUT, LONG_OP_CLIENT_TIMEOUT], (
+        f"wait_game_time 应固定使用 {LONG_OP_CLIENT_TIMEOUT}s 生死线、与 seconds 无关，"
+        f"实际 {captured}"
     )
 
 
 @pytest.mark.asyncio
 async def test_combo_client_timeout_decoupled_from_steps_total() -> None:
-    """issue #45: combo() 与 wait_game_time 同源问题，client timeout 同样固定。"""
+    """issue #45: combo() 与 wait_game_time 同源问题，client timeout 同样与 total 解耦。"""
     import godot_cli_control.client as client_mod
 
-    captured: dict = {}
+    captured: list = []
 
     async def fake_request(self, method, params=None, timeout=30.0):
-        captured["timeout"] = timeout
+        captured.append(timeout)
         return {"success": True}
 
     client = client_mod.GameClient(port=1)
     monkeypatch_target = client_mod.GameClient.request
     client_mod.GameClient.request = fake_request  # type: ignore
     try:
-        await client.combo([{"action": "jump", "duration": 5.0}])
+        await client.combo([{"action": "x", "duration": 0.5}])
+        await client.combo([{"action": "x", "duration": 60.0}])
     finally:
         client_mod.GameClient.request = monkeypatch_target
-    assert captured["timeout"] == WAIT_GAME_TIME_CLIENT_TIMEOUT
+    assert captured == [LONG_OP_CLIENT_TIMEOUT, LONG_OP_CLIENT_TIMEOUT]
 
 
 @pytest.mark.asyncio

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -465,3 +465,86 @@ async def test_get_scene_tree_omits_max_nodes_when_none() -> None:
         client_mod.GameClient.request = monkeypatch_target
     assert captured["params"] == {"depth": 2}
     assert "max_nodes" not in captured["params"]
+
+
+# ---- issue #45: wait_game_time / combo 不能给 game-time 操作设 wall-time 上限 ----
+#
+# 旧公式 seconds*3+10 假设 wall ≤ 3× game，在 Movie Maker (--write-movie) 模式下
+# 实测 wall ≈ 4-5× game，必假超时（bridge.wait(15) → 55s timeout < 60s+ wall）。
+# 治本：去掉 seconds-scaled wall 上限，固定一个生死线（600s），死连接靠 ws ping/pong。
+
+WAIT_GAME_TIME_CLIENT_TIMEOUT = 600.0
+
+
+@pytest.mark.asyncio
+async def test_wait_game_time_client_timeout_decoupled_from_seconds() -> None:
+    """issue #45: wait_game_time 客户端 timeout 必须与 seconds 解耦（固定 600s 生死线）。
+
+    Movie Maker 模式下 wall/game 比值不可预测，任何 seconds-scaled 公式都会在
+    某个分辨率/fps/盘速组合下踩中。改成固定大值后，死连接由 ws ping/pong 兜底。
+    """
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["timeout"] = timeout
+        return {"success": True}
+
+    client = client_mod.GameClient(port=1)
+    monkeypatch_target = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        await client.wait_game_time(15.0)
+    finally:
+        client_mod.GameClient.request = monkeypatch_target
+    assert captured["timeout"] == WAIT_GAME_TIME_CLIENT_TIMEOUT, (
+        f"wait_game_time(15) 应使用固定 {WAIT_GAME_TIME_CLIENT_TIMEOUT}s 生死线，"
+        f"实际 {captured['timeout']}s —— Movie Maker 模式下 seconds-scaled 必假超时"
+    )
+
+
+@pytest.mark.asyncio
+async def test_combo_client_timeout_decoupled_from_steps_total() -> None:
+    """issue #45: combo() 与 wait_game_time 同源问题，client timeout 同样固定。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["timeout"] = timeout
+        return {"success": True}
+
+    client = client_mod.GameClient(port=1)
+    monkeypatch_target = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        await client.combo([{"action": "jump", "duration": 5.0}])
+    finally:
+        client_mod.GameClient.request = monkeypatch_target
+    assert captured["timeout"] == WAIT_GAME_TIME_CLIENT_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_connect_locks_ws_ping_keepalive() -> None:
+    """issue #45 治本依赖：去掉 wall 上限后，死连接靠 ws ping/pong 检测。
+
+    显式锁住 ping_interval / ping_timeout（与 websockets 默认对齐），
+    防库升级把默认改了导致死连接卡 600s。
+    """
+    fake_ws = AsyncMock()
+    with patch(
+        "godot_cli_control.client.websockets.connect",
+        new=AsyncMock(return_value=fake_ws),
+    ) as mock_connect:
+        client = GameClient(port=9999)
+        try:
+            await client.connect(retries=1)
+        finally:
+            if client._listen_task:
+                client._listen_task.cancel()
+        _, kwargs = mock_connect.call_args
+        assert kwargs.get("ping_interval") == 20, \
+            "GameClient.connect() must lock ping_interval (ws keepalive)"
+        assert kwargs.get("ping_timeout") == 20, \
+            "GameClient.connect() must lock ping_timeout (ws keepalive)"


### PR DESCRIPTION
## Summary

- 旧公式 `seconds*3+10` 在 Movie Maker (`--write-movie`) 模式下假超时——issue #45 实测 wall ≈ 4-5× game time，`bridge.wait(15)` 的 55s 客户端 timeout < ~60s server 实际耗时
- 根因：game-time 操作不该用 seconds-scaled wall 上限；比值随录像模式 / 分辨率 / 盘速 / fps 漂移，任何公式都会在某组合下踩
- 治本：`wait_game_time` / `combo` 改用固定 `LONG_OP_CLIENT_TIMEOUT=600s` 生死线（与 seconds 解耦），死连接由 ws ping/pong 兜底

## 改动面

- `client.py`：新增模块级常量 `LONG_OP_CLIENT_TIMEOUT`；`wait_game_time` / `combo` 的 timeout 改用该常量；`websockets.connect` 显式锁 `ping_interval=20, ping_timeout=20`（与库默认对齐，防升级悄悄改默认）
- `test_client.py`：3 条 contract 测试覆盖 timeout 解耦 + ping 锁定

## 为什么是治本而不是「调大系数」

| 方案 | 覆盖 | 工程量 |
|---|---|---|
| 系数 `*3+10` → `*6+15` | 普通分辨率录像 OK；4K/60fps 仍可能踩 | 1 行 |
| Bridge 自动检测录像模式 | 录像 OK；但 wall/game 漂移**不只录像引起**（慢盘、满载 CPU 同样会破 3×）；用户绕过 daemon 自己 `--write-movie` 时检测失效 | 中 |
| **本 PR：去 wall 上限 + ws 心跳兜底** | **所有场景**，因为 ws ping/pong 直接反映 server 健康度（GameBridge 的 ws poll 跟主线程绑定，主线程卡 ⇒ pong 不发） | 小 |
| Server 进度 notify + 沉默超时 | 全场景 + 未来流式 RPC 复用 | 大，引协议变更 |

详见 issue #45 讨论。

## Test plan

- [x] `pytest python/tests/test_client.py` 3 条新 contract 测试通过
- [x] `coverage run -m pytest python/tests/` 329/329 green，coverage 84% (> 80% fail_under)
- [x] 无新 deprecation / import 错误
- [ ] **录像模式真实验证**（PR 作者本地无 `--write-movie` 复现环境，请 reviewer 在 issue 报告者的同硬件 / 同分辨率组合下跑一次 `bridge.wait(15.0)` 录像，确认不再 TimeoutError）

🤖 Generated with [Claude Code](https://claude.com/claude-code)