### PR TITLE
fix(bridge): 输入持续性 —— 断连按 close code 区分清/不清 + hold duration 校验

### DIFF
--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -114,7 +114,7 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `1006` | server | Resource transiently unavailable (e.g. screenshot during scene transition). Rare under normal use — GameBridge waits for viewport first-frame before listening, and `screenshot` retries internally. Safe to retry if you do hit it. |
 | `-32600` | server | Malformed JSON-RPC request |
 | `-32601` | server | Unknown method name |
-| `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, or `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements) |
+| `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements, or `hold` given `duration ≤ 0` — use `press` for an indefinite hold) |
 | `-1001` | client | Connection failure (daemon not running, port wrong, proxy hijacking localhost) |
 | `-1002` | client | Timeout waiting for response |
 | `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, …) |

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -143,10 +143,7 @@ func _poll_active_peer() -> void:
 	_active_peer.poll()
 	var state: WebSocketPeer.State = _active_peer.get_ready_state()
 	if state == WebSocketPeer.STATE_CLOSED:
-		print("GameBridge: Client disconnected")
-		_input_sim_api.release_all()
-		_active_peer = null
-		_active_stream = null
+		_handle_disconnect(_active_peer.get_close_code())
 		return
 	if state != WebSocketPeer.STATE_OPEN:
 		return
@@ -154,6 +151,25 @@ func _poll_active_peer() -> void:
 		var packet: PackedByteArray = _active_peer.get_packet()
 		var message: String = packet.get_string_from_utf8()
 		_handle_message(message)
+
+
+func _handle_disconnect(close_code: int) -> void:
+	print("GameBridge: Client disconnected (close_code=%d)" % close_code)
+	# 区分「命令正常结束」与「异常掉线」，决定是否 release_all：
+	#   - CLI 每条子命令都是独立连接、跑完即干净关闭（WebSocket close frame，
+	#     code 1000）。此时**不** release_all —— 否则 `hold <dur>` 的定时器还没
+	#     倒计时就被清掉（只生效一帧），sticky `press` 也无法跨命令存活。持有的
+	#     输入靠各自机制收尾：hold/tap/combo 的 advance_timers 定时器自然结束，
+	#     sticky press 持续到显式 release / release-all。
+	#   - 客户端崩溃 / 被 kill / 网络断开时不会发 close frame，get_close_code()
+	#     返回 -1（< 0）。此时 release_all 兜底，避免卡死键 + 跨会话脏状态残留。
+	#   （daemon 启动期的端口探活连接也可能是 -1，但那时没有任何持有输入，
+	#    release_all 无副作用。）
+	# pytest 的 bridge fixture 仍在 teardown 自己调 release_all() 做清理。
+	if close_code < 0:
+		_input_sim_api.release_all()
+	_active_peer = null
+	_active_stream = null
 
 
 func _register_methods() -> void:

--- a/addons/godot_cli_control/bridge/input_simulation_api.gd
+++ b/addons/godot_cli_control/bridge/input_simulation_api.gd
@@ -113,6 +113,14 @@ func handle_hold(params: Dictionary) -> Dictionary:
 	if not InputMap.has_action(action):
 		return _err(CliControlErrorCodes.METHOD_NOT_FOUND, "Unknown action: %s" % action)
 	var duration: float = params.get("duration", 0.0) as float
+	# duration <= 0 是无意义的「按住 0 秒」：advance_timers 下一帧就释放 → 只生效
+	# 一帧。无限按住请用 press（sticky）。CLI preflight 也会拦，这里是防御纵深，
+	# 挡住绕过 CLI 的直连 RPC。
+	if duration <= 0.0:
+		return _err(
+			CliControlErrorCodes.INVALID_PARAMS,
+			"hold duration must be > 0 (got %s); use press for an indefinite hold" % duration,
+		)
 	_do_press(action)
 	_held_actions[action] = duration
 	return {"success": true}

--- a/addons/godot_cli_control/tests/gut/test_game_bridge.gd
+++ b/addons/godot_cli_control/tests/gut/test_game_bridge.gd
@@ -70,9 +70,16 @@ class StubInputSimulationApi:
 		# _register_methods 之前测试会手动调一次。
 		combo_callback = send_response
 
+	# 断连测试用的 release_all 调用计数（不 override 行为，仅记账后走父类）
+	var release_all_calls: int = 0
+
 	func handle_action_press(params: Dictionary) -> Dictionary:
 		press_calls.append(params)
 		return press_return
+
+	func release_all() -> void:
+		release_all_calls += 1
+		super()
 
 	func handle_combo(params: Dictionary, request_id: String) -> void:
 		# 不立刻回响 —— 把 (params, request_id) 记下来；测试通过 finish_combo
@@ -120,6 +127,49 @@ func _send(raw: String) -> void:
 func _last_frame() -> Dictionary:
 	assert_true(_bridge.captured_frames.size() > 0, "应该至少有一个出站帧")
 	return _bridge.captured_frames[-1]
+
+
+# ── 断连按 close code 区分清/不清 ───────────────────────────────────
+# 回归：CLI 每条子命令都是独立连接、跑完即「干净关闭」（close frame，code
+# 1000）。干净关闭不能 release_all，否则 `hold <dur>` 定时器没倒计时就被清掉
+# （只生效一帧），sticky `press` 也无法跨命令存活。只有「异常掉线」（崩溃 /
+# kill / 网络断，get_close_code() == -1）才 release_all 兜底卡死键。
+# handle_hold 是真实逻辑（桩未 override），用它验证 held 状态。
+# 用足够长的 duration，避免测试期间 _process 的 advance_timers 提前释放。
+
+func test_clean_disconnect_preserves_inputs() -> void:
+	var hold_action := "__test_clean_disc__"
+	if not InputMap.has_action(hold_action):
+		InputMap.add_action(hold_action)
+	_input.handle_hold({"action": hold_action, "duration": 999.0})
+	assert_true(hold_action in _input.get_pressed_actions(), "前置：hold 应在持有列表")
+
+	# 1000 = 正常 WebSocket close frame（CLI 命令跑完）
+	_bridge._handle_disconnect(1000)
+
+	assert_eq(_input.release_all_calls, 0, "干净关闭不应调用 release_all（hold/press 须跨命令存活）")
+	assert_true(hold_action in _input.get_pressed_actions(), "干净关闭后 hold 应仍存活")
+	assert_eq(_bridge._active_peer, null, "断连应清掉 _active_peer")
+
+	_input.release_all()
+	InputMap.erase_action(hold_action)
+
+
+func test_abnormal_disconnect_releases_inputs() -> void:
+	var hold_action := "__test_abnormal_disc__"
+	if not InputMap.has_action(hold_action):
+		InputMap.add_action(hold_action)
+	_input.handle_hold({"action": hold_action, "duration": 999.0})
+	assert_true(hold_action in _input.get_pressed_actions(), "前置：hold 应在持有列表")
+
+	# -1 = 异常掉线（无 close frame：崩溃 / kill / 网络断）
+	_bridge._handle_disconnect(-1)
+
+	assert_eq(_input.release_all_calls, 1, "异常掉线应调用 release_all 兜底卡死键")
+	assert_false(hold_action in _input.get_pressed_actions(), "异常掉线后 hold 应被释放")
+	assert_eq(_bridge._active_peer, null, "断连应清掉 _active_peer")
+
+	InputMap.erase_action(hold_action)
 
 
 # ── JSON / 协议层校验：-32600 ──────────────────────────────────────

--- a/addons/godot_cli_control/tests/gut/test_input_simulation_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_input_simulation_api.gd
@@ -83,6 +83,22 @@ func test_hold_unknown_action_returns_1003() -> void:
 	assert_false(_api.has_active_holds())
 
 
+func test_hold_zero_duration_returns_invalid_params() -> void:
+	# duration <= 0 是无意义的「按住 0 秒」；防御纵深拦在服务端（CLI preflight 也拦）。
+	var result: Dictionary = _api.handle_hold({"action": "a", "duration": 0.0})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602, "duration=0 应回 INVALID_PARAMS(-32602)")
+	assert_false(_api.has_active_holds(), "非法 duration 不应进 held 列表")
+	assert_false("a" in _api.get_pressed_actions())
+
+
+func test_hold_negative_duration_returns_invalid_params() -> void:
+	var result: Dictionary = _api.handle_hold({"action": "a", "duration": -1.5})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+	assert_false(_api.has_active_holds())
+
+
 func test_combo_unknown_action_aborts_with_1003() -> void:
 	# combo step 引用未注册 action：必须 abort 整盘并通过 request_id 回 1003，
 	# 否则 _combo_active 卡 true 后续全 1004。

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -175,6 +175,22 @@ def _resolve_args_for_call(ns: argparse.Namespace) -> list:
     return [_parse_json_arg(a) for a in raw_args]
 
 
+def _preflight_hold(ns: argparse.Namespace) -> None:
+    """连 daemon 前校验 hold 的 duration：必须是 > 0 的数字。
+
+    duration <= 0 会让动作下一帧就释放（只生效一帧），是无意义用法；
+    要无限按住应该用 ``press``。preflight 拦住，避免 agent 干等连接重试。
+    """
+    try:
+        duration = float(ns.duration)
+    except (TypeError, ValueError):
+        raise ValueError(f"hold: duration 必须是数字，收到 {ns.duration!r}")
+    if duration <= 0:
+        raise ValueError(
+            f"hold: duration 必须 > 0（秒），收到 {duration}；要无限按住请用 `press`"
+        )
+
+
 def _preflight_combo(ns: argparse.Namespace) -> None:
     """连 daemon 前用同一份解析逻辑校验 combo 输入；抛 ValueError 即用法错。
 
@@ -549,9 +565,10 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
         description="按住动作指定时长（秒），到点自动释放。",
         positionals=(
             Positional("action", None, "InputMap 动作名"),
-            Positional("duration", None, "按住时长（秒）"),
+            Positional("duration", None, "按住时长（秒，必须 > 0）"),
         ),
         example="hold jump 1.5",
+        preflight=_preflight_hold,
         text_formatter=lambda r: f"holding: {r}",
     ),
     RpcSpec(

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -120,7 +120,7 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 |---|---|
 | `-32600` | Malformed request (missing / non-string `method`). Bug in client; should never reach an agent. |
 | `-32601` | Unknown method name. Bug; means client + plugin versions drifted. |
-| `-32602` | Invalid params: missing required field, blocked property/method (security blacklist), out-of-range value, value-type mismatch on `set` (e.g. `Vector2` property given an array of wrong length / non-numeric elements), or node-isn't-clickable (e.g. you `click`'d a `Node2D`). Don't retry; the request shape is wrong. |
+| `-32602` | Invalid params: missing required field, blocked property/method (security blacklist), out-of-range value, value-type mismatch on `set` (e.g. `Vector2` property given an array of wrong length / non-numeric elements), node-isn't-clickable (e.g. you `click`'d a `Node2D`), or `hold` given `duration ≤ 0` (use `press` for an indefinite hold). Don't retry; the request shape is wrong. |
 
 **Client-side (CLI / GameClient) — `-1xxx`:**
 
@@ -155,7 +155,7 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 **Input simulation:**
 - `press <action>` / `release <action>` — sticky press
 - `tap <action> [duration]` — press → wait → release
-- `hold <action> <duration>` — auto-release after N seconds
+- `hold <action> <duration>` — auto-release after N seconds (`duration` must be `> 0`; for an indefinite hold use `press`)
 - `combo --steps-json '[...]'` (or `combo file.json` / `combo -` for stdin) — sequence
 - `combo-cancel` — abort running combo
 - `release-all` — release everything
@@ -389,6 +389,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **Daemon won't start** — check `.cli_control/godot_bin` exists and points at a real Godot 4 binary, or `export GODOT_BIN=/path/to/godot`. See `godot-cli-control init -h` for the full lookup chain.
 - **Output flags work in any position** — `--json` / `--text` / `--no-json` are accepted both before and after subcommands as of this fix. `--port N` is still top-level only; pass it before the subcommand.
 - **`combo` rejects everything with `1004`** — a combo is already running. Call `combo-cancel` (or `release-all`) to abort.
+- **`hold` / `press` persist after the command returns** — by design. Each CLI command is its own short-lived connection that closes *cleanly*, and a clean close does **not** release inputs. `hold <action> <dur>` auto-releases after `<dur>` seconds (its timer keeps running in the daemon); a sticky `press <action>` stays held until you call `release <action>` / `release-all` (or the daemon's idle-timeout shuts it down). If a character looks stuck moving, you probably left a `press` dangling — run `release-all`. (An *abnormal* drop — your client crashing or being killed mid-session — does trigger a safety `release-all`, so stuck keys can't outlive a dead client.)
 - **`tree` returns `1005 "scene tree too large"`** — your scene has more than 5000 visible nodes (a Grid / spawned-bullets situation). Pass `--max-nodes 200` to cap, or `children <path>` for one specific subtree.
 - **`set` with a string that *looks* like JSON** — value parser parses JSON first. To force a literal `"42"` string, pass `'"42"'`; to set a literal hash sign or array text, JSON-encode it.
 - **`daemon start` opens a window when I expected headless** — your stdout is a TTY (interactive terminal). Pass `--headless` explicitly, or shell out from a context where stdout is piped.

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1140,6 +1140,47 @@ def test_combo_preflight_rejects_no_steps_before_connecting(
     assert "必须提供" in payload["error"]["message"]
 
 
+@pytest.mark.parametrize("bad_duration", ["0", "-1.5", "abc"])
+def test_hold_preflight_rejects_bad_duration_before_connecting(
+    bad_duration: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``hold`` 的 duration <= 0 或非数字必须在连 daemon **之前**报 EXIT_USAGE。
+
+    duration<=0 会让动作下一帧就释放（只生效一帧）；无限按住该用 ``press``。
+    见 issue #71。"""
+    import json as _json
+
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    class _ShouldNotConnect:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            raise AssertionError("preflight 失效：hold duration 非法时不应连 daemon")
+
+    import godot_cli_control.cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "GameClient", _ShouldNotConnect)
+    monkeypatch.setattr(sys, "argv", ["godot-cli-control", "hold", "jump", bad_duration])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == EXIT_USAGE
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload["ok"] is False
+    assert "duration" in payload["error"]["message"]
+
+
+def test_hold_preflight_accepts_positive_duration() -> None:
+    """合法 duration > 0 不应被 preflight 拦下（让它进到连接环节）。"""
+    import argparse
+
+    from godot_cli_control.cli import _preflight_hold
+
+    ns = argparse.Namespace(duration="1.5")
+    _preflight_hold(ns)  # 不抛即通过
+
+
 def test_combo_preflight_caches_steps_to_avoid_stdin_double_read(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/python/tests/test_e2e_input.py
+++ b/python/tests/test_e2e_input.py
@@ -1,0 +1,175 @@
+"""端到端回归：真实 Godot daemon 下的输入持续性（issue #70）。
+
+拦的回归：CLI 每条子命令都是独立连接、跑完即「干净关闭」。曾经 GameBridge
+在断连时无条件 release_all，导致 ``hold`` 的定时器没倒计时就被清掉（只生效
+一帧）、sticky ``press`` 也无法跨命令存活。这个 bug 当时 GUT（mock socket）
+和 pytest（mock subprocess）都没逮到 —— 只有真实 daemon 端到端能复现。
+
+覆盖三条链路：
+  1. 干净关闭后 ``hold`` 仍持续，duration 到点由定时器自动释放（不是断连释放）。
+  2. sticky ``press`` 跨命令存活，直到 ``release-all``。
+  3. 异常掉线（无 WebSocket close frame，close_code == -1）触发 release_all 兜底。
+
+需要真实 Godot 4：设置 ``GODOT_BIN`` 指向可执行文件，否则整文件 skip。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_GODOT_BIN = os.environ.get("GODOT_BIN")
+_ADDON_SRC = Path(__file__).resolve().parents[2] / "addons" / "godot_cli_control"
+
+pytestmark = pytest.mark.skipif(
+    not _GODOT_BIN or not Path(_GODOT_BIN).exists(),
+    reason="需要真实 Godot 4：设置 GODOT_BIN 指向可执行文件",
+)
+
+# 用 `python -m godot_cli_control` 调 CLI：与 PATH 无关，always 命中当前环境。
+_CLI = [sys.executable, "-m", "godot_cli_control"]
+
+_PROJECT_GODOT = """\
+config_version=5
+
+[application]
+config/name="gcc_e2e"
+run/main_scene="res://main.tscn"
+
+[autoload]
+GameBridgeNode="*res://addons/godot_cli_control/bridge/game_bridge.gd"
+
+[debug]
+settings/stdout/print_fps=false
+
+[editor_plugins]
+enabled=PackedStringArray("res://addons/godot_cli_control/plugin.cfg")
+
+[input]
+move_right={"deadzone":0.5,"events":[]}
+jump={"deadzone":0.5,"events":[]}
+"""
+
+_MAIN_TSCN = """\
+[gd_scene format=3]
+
+[node name="Main" type="Node"]
+"""
+
+
+def _run_cli(project: Path, *args: str, timeout: float = 60.0) -> dict[str, Any]:
+    """跑一条 CLI 子命令（独立进程 = 独立连接），解析最后一行 JSON 信封。"""
+    proc = subprocess.run(
+        _CLI + list(args),
+        cwd=project,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    # 信封是 stdout 单行 JSON；daemon start 等可能先打 stderr 进度，取最后的 JSON 行。
+    json_lines = [ln for ln in proc.stdout.splitlines() if ln.strip().startswith("{")]
+    assert json_lines, f"无 JSON 输出：args={args} stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    return json.loads(json_lines[-1])
+
+
+def _pressed(project: Path) -> list[str]:
+    payload = _run_cli(project, "pressed")
+    assert payload["ok"] is True, payload
+    return payload["result"]
+
+
+@pytest.fixture(scope="module")
+def godot_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """搭一个最小真实 Godot 工程（addon + autoload + 两个 InputMap 动作）并导入一次。"""
+    proj = tmp_path_factory.mktemp("gcc_e2e")
+    (proj / "addons").mkdir()
+    shutil.copytree(_ADDON_SRC, proj / "addons" / "godot_cli_control")
+    (proj / "project.godot").write_text(_PROJECT_GODOT)
+    (proj / "main.tscn").write_text(_MAIN_TSCN)
+
+    # 先跑一次编辑器导入，注册全局 class（CliControlErrorCodes）+ 资源 .import。
+    imp = subprocess.run(
+        [_GODOT_BIN, "--headless", "--editor", "--quit", "--path", str(proj)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert imp.returncode == 0, f"Godot 导入失败：{imp.stdout}\n{imp.stderr}"
+    return proj
+
+
+@pytest.fixture
+def daemon(godot_project: Path) -> Any:
+    """每个用例起/停一个真实 headless daemon；teardown 兜底 release-all + stop。"""
+    start = _run_cli(godot_project, "daemon", "start", "--headless", timeout=90)
+    assert start["ok"] is True and start["result"]["started"], start
+    port = start["result"]["port"]
+    try:
+        yield godot_project, port
+    finally:
+        _run_cli(godot_project, "release-all")
+        _run_cli(godot_project, "daemon", "stop", timeout=30)
+
+
+def test_hold_persists_across_clean_disconnect_then_auto_releases(daemon: Any) -> None:
+    project, _ = daemon
+    # hold 1s：命令拿到响应后干净关闭连接 —— 断连不应清掉它。
+    held = _run_cli(project, "hold", "move_right", "1.0")
+    assert held["ok"] is True, held
+
+    # 紧跟一条独立命令：若断连清了，这里就空了（旧 bug：只生效一帧）。
+    assert "move_right" in _pressed(project), "干净关闭后 hold 应跨命令存活"
+
+    # 等过 duration：应由 advance_timers 定时器自动释放（不是断连释放）。
+    time.sleep(2.0)
+    assert _pressed(project) == [], "duration 到点后 hold 应被定时器自动释放"
+
+
+def test_press_persists_until_release_all(daemon: Any) -> None:
+    project, _ = daemon
+    pressed = _run_cli(project, "press", "jump")
+    assert pressed["ok"] is True, pressed
+
+    # sticky press 没有定时器：跨多条独立命令仍应保持按下。
+    assert "jump" in _pressed(project), "sticky press 应跨命令存活"
+    time.sleep(1.0)
+    assert "jump" in _pressed(project), "press 不该自己释放"
+
+    rel = _run_cli(project, "release-all")
+    assert rel["ok"] is True, rel
+    assert _pressed(project) == [], "release-all 后应清空"
+
+
+def test_abnormal_disconnect_releases_held_inputs(daemon: Any) -> None:
+    project, port = daemon
+    # 子进程：连上 → 发 hold → 硬退出（不发 close frame）→ daemon 侧 close_code = -1。
+    drop_script = (
+        "import asyncio, json, os, websockets\n"
+        "async def main():\n"
+        f"    ws = await websockets.connect('ws://127.0.0.1:{port}')\n"
+        "    await ws.send(json.dumps({'id':'1','method':'input_hold',"
+        "'params':{'action':'move_right','duration':30.0}}))\n"
+        "    await ws.recv()\n"
+        "    os._exit(0)\n"
+        "asyncio.run(main())\n"
+    )
+    drop = subprocess.run(
+        [sys.executable, "-c", drop_script], capture_output=True, text=True, timeout=30
+    )
+    assert drop.returncode == 0, f"abrupt-drop 客户端异常：{drop.stderr}"
+
+    # 异常掉线应触发 release_all 兜底（即便 hold 还剩 ~30s）。给 daemon 几帧检测断连。
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        if _pressed(project) == []:
+            break
+        time.sleep(0.2)
+    assert _pressed(project) == [], "异常掉线应触发 release_all 清掉持有输入"


### PR DESCRIPTION
## 背景

用户报「godot-cli-control 输入模拟无法持续按键」。系统化排查后定位根因，并连带修了两个相关 issue。

## 根因

CLI 每条子命令都是**独立进程 / 独立连接，跑完即断**。而 GameBridge 在客户端断开时**无条件 `release_all()`**（自初始抽取从 godot-2d-skeleton 继承的「持久会话连接」假设）。于是 `hold move_right 1.0` 一拿到响应、socket 一关，daemon 立刻把刚按下的键释放了 —— 1.0s 定时器根本没机会倒计时，表现为「只生效一帧」。sticky `press` 同理无法跨命令存活。

取证（隔离复现 vs 真实 daemon + delta 日志）确认：addon 定时器逻辑本身正确，释放是**断连触发**的，不是定时器到点。

## 改动

### 1. 断连按 close code 区分（核心修复）
`_handle_disconnect(close_code)`：
- **干净关闭**（WebSocket close frame，code 1000 —— CLI 命令正常结束）：**不** release，hold/tap/combo 靠定时器自然收尾，sticky press 持续到显式 release / release-all。
- **异常掉线**（崩溃 / kill / 网络断，无 close frame，`close_code < 0`）：`release_all` 兜底，避免卡死键 + 跨会话脏状态。

实测：CLI 客户端（`client.py` 走 `await ws.close()`）每条命令稳定 code 1000；硬退出无 close 帧 → -1。两全：既保住命令级持续输入，又保留崩溃兜底。

### 2. `hold` duration ≤ 0 校验（修复 #71）
- 服务端 `handle_hold`：`duration <= 0` → `-32602 INVALID_PARAMS`（防御纵深，挡直连 RPC）。
- CLI `_preflight_hold`：连 daemon 前拦下非数字 / ≤0，给 `EXIT_USAGE`。无限按住请用 `press`。

### 3. 真实 daemon e2e 回归（修复 #70）
新增 `python/tests/test_e2e_input.py`（gated on `GODOT_BIN`）：起真实 headless daemon、用 `python -m godot_cli_control` 子进程驱动，覆盖
- hold 跨断连存活 → 定时自动释放
- press 持续到 release-all
- 异常掉线触发释放

补上了此前 GUT（mock socket）/ pytest（mock subprocess）都覆盖不到、让原 bug 漏网的盲区。

### 4. 文档
SKILL.md / README 错误码表 + hold 描述 + 断连行为 pitfall 对齐。

## 验证

- GUT：96 passing（含 clean/abnormal disconnect + hold duration 单测）
- pytest 完整套件：**336 passed / 0 failed / 0 skipped**，覆盖率 **84%**（> 80 门槛）
- 三个 e2e 真起 daemon 跑过（非 skip）

Closes #70
Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)
