### PR TITLE
test: 测试覆盖补强（#40/#41/#42/#64/#36 + e2e 进 CI）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,9 +171,91 @@ jobs:
         # GODOT_BIN 由前面 Resolve Godot exe path step 写到 $GITHUB_ENV
         run: python addons/godot_cli_control/tests/test_init_walkthrough.py
 
-      # ---- GUT unit tests (Linux only —— GUT cmdln 在 headless 下输出最稳定) ----
-      - name: Run GUT unit tests (Linux only)
+      # ---- GUT unit tests (跨平台 Python runner run_gut.py, issue #36) ----
+      # run_gut.py 是纯 stdlib（不 import godot_cli_control），只需 python + git，
+      # 无需 pip install。macOS 格的 GUT 在 gui-screenshot-e2e job 里跑（复用那边
+      # 已下载的 macOS Godot，免重复下载）。
+      - name: Run GUT unit tests (Linux)
         if: matrix.os == 'ubuntu-latest'
         env:
           GODOT_BIN: /home/runner/godot-bin/godot
-        run: ./addons/godot_cli_control/tests/run_gut.sh
+        run: python addons/godot_cli_control/tests/run_gut.py
+
+      - name: Run GUT unit tests (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        # GODOT_BIN 由前面 Resolve Godot exe path step 写到 $GITHUB_ENV
+        run: python addons/godot_cli_control/tests/run_gut.py
+
+  # windowed screenshot e2e（issue #64）：GUT / 普通 e2e 全跑 --headless，dummy
+  # renderer 拿不到 viewport texture，frame_post_draw 这条「真实用户用 screenshot」
+  # 的分支长期零覆盖（#61 即此类 silent regression）。这里用 macOS runner（真 GPU /
+  # 能开窗，无需 xvfb 赌软渲染）真起 GUI daemon、立刻截图，覆盖 windowed 路径。
+  gui-screenshot-e2e:
+    name: macOS e2e — windowed screenshot + GUT (Godot ${{ matrix.godot-version }})
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        godot-version: ['4.6.2-stable']
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install package + test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Cache Godot (macOS)
+        id: godot-cache-macos
+        uses: actions/cache@v5
+        with:
+          path: ~/godot-bin
+          key: godot-${{ matrix.godot-version }}-macos-universal
+
+      - name: Download Godot (macOS)
+        if: steps.godot-cache-macos.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/godot-bin
+          VER="${{ matrix.godot-version }}"
+          URL="https://github.com/godotengine/godot/releases/download/${VER}/Godot_v${VER}_macos.universal.zip"
+          echo "Downloading $URL"
+          curl -fsSL -o /tmp/godot.zip "$URL"
+          unzip -q /tmp/godot.zip -d ~/godot-bin
+
+      - name: Resolve Godot binary (macOS)
+        run: |
+          BIN="$HOME/godot-bin/Godot.app/Contents/MacOS/Godot"
+          if [ ! -x "$BIN" ]; then
+            echo "找不到 Godot 可执行：$BIN"; ls -R ~/godot-bin; exit 1
+          fi
+          echo "GODOT_BIN=$BIN" >> "$GITHUB_ENV"
+
+      - name: Verify Godot (macOS)
+        run: |
+          "$GODOT_BIN" --version
+
+      # GCC_GUI_E2E=1 解锁 test_e2e_screenshot_gui.py 的默认 skip；--gui daemon
+      # 在 macOS runner 的窗口会话里真开窗。
+      - name: Run windowed screenshot e2e
+        env:
+          GCC_GUI_E2E: '1'
+        run: python -m pytest python/tests/test_e2e_screenshot_gui.py -v
+
+      # macOS 格的 GUT 在此跑（issue #36 三平台覆盖的第三格），复用上面下载的
+      # macOS Godot，免在 walkthrough job 再加一套 macOS Godot 下载步骤。
+      - name: Run GUT unit tests (macOS)
+        run: python addons/godot_cli_control/tests/run_gut.py
+
+      # 输入持续性 e2e（#70）：起真 headless daemon，过去因没有任何 CI job 同时
+      # 备齐 GODOT_BIN + 已装包 + pytest 而从未在 CI 真跑过（python-unit 不设
+      # GODOT_BIN ⇒ skip；walkthrough 不跑 pytest）。本 job 三者齐全，顺手让它
+      # 首次进 CI。headless，无需开窗。
+      - name: Run input-persistence e2e (headless)
+        run: python -m pytest python/tests/test_e2e_input.py -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ release.sh                  # 发版脚本
 
 - 测试不能用 `pytest --cov` 跑，必须 `coverage run -m pytest`。原因写在 `pyproject.toml` 的注释里：pytest11 entry-point 在 pytest 启动时 import 包，pytest-cov 上得太晚会 miss 掉 import-time 语句。
 - 跑测试遵循全局规则：**用 subagent 委托执行（指定 `model: "sonnet"`），主会话只接收精简结论**，避免大量 pytest 输出污染上下文。
-- GDScript 那侧的单测走 `./addons/godot_cli_control/tests/run_gut.sh`，需要 `GODOT_BIN`。
+- GDScript 那侧的单测走 `./addons/godot_cli_control/tests/run_gut.sh`（bash，Linux/macOS）或跨平台的 `python addons/godot_cli_control/tests/run_gut.py`（CI 用这个，三平台通吃），都需要 `GODOT_BIN`。改其中一个记得对齐另一个。
 
 ## 发版 / CI
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Tracked in [issues](https://github.com/ClaymanTwinkle/godot-cli-control/issues).
 
 ## Contributing
 
-Issues and PRs welcome. The plugin's GUT unit tests run via `./addons/godot_cli_control/tests/run_gut.sh` (requires `GODOT_BIN`). The Python package's tests run via `pytest` from `python/`. CI matrix covers Linux, macOS, and Windows.
+Issues and PRs welcome. The plugin's GUT unit tests run via `./addons/godot_cli_control/tests/run_gut.sh` (bash) or the cross-platform `python addons/godot_cli_control/tests/run_gut.py` (what CI uses) — both require `GODOT_BIN`. The Python package's tests run via `pytest` from `python/`. CI matrix covers Linux, macOS, and Windows.
 
 ## License
 

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -65,7 +65,11 @@ Compatibility shims are also kept at `addons/godot_cli_control/bin/run_cli_contr
 ## Running the GUT unit tests
 
 ```bash
+# Linux / macOS (bash):
 GODOT_BIN=/path/to/godot ./addons/godot_cli_control/tests/run_gut.sh
+
+# Cross-platform (Linux / macOS / Windows) — this is what CI runs:
+GODOT_BIN=/path/to/godot python addons/godot_cli_control/tests/run_gut.py
 ```
 
 The runner builds a throwaway Godot project, `git clone`s a pinned [GUT](https://github.com/bitwes/Gut) release into `addons/gut/`, copies this plugin in, and runs the test files under `addons/godot_cli_control/tests/gut/`. Coverage today is `LowLevelApi` handler boundaries (blacklist, missing-property, node-not-found) and `InputSimulationApi` state machine (combo / press / release / tap / release_all).

--- a/addons/godot_cli_control/tests/run_gut.py
+++ b/addons/godot_cli_control/tests/run_gut.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""跨平台 GUT runner —— run_gut.sh 的 Python 等价物（issue #36）。
+
+run_gut.sh 是 bash，Windows runner 用不了；macOS 上 GUT cmdln 的 stdout buffering
+历史上偶发丢字。改用 Python stdlib（tempfile / shutil / subprocess）抹平
+mktemp / cp -r / 路径分隔符这些平台差异，让 CI 能在 ubuntu / macOS / windows
+三格统一跑 GDScript 单测。
+
+逻辑与 run_gut.sh 一致：
+  1. 找 Godot 二进制（GODOT_BIN > macOS 默认 .app > PATH 中的 godot[.exe]）。
+  2. 临时目录搭最小 Godot 工程 + 复制本 plugin。
+  3. clone GUT 固定 tag，搬运 addons/gut。
+  4. headless 预热 import（填 .godot/ 缓存）。
+  5. headless 跑 gut_cmdln.gd，实时透传输出并缓冲。
+  6. 断言 GUT 的 "All tests passed!" marker（cmdln 加载失败时 Godot 仍可能 exit 0，
+     所以不能只看 returncode）。
+
+用法：
+    GODOT_BIN=/path/to/godot python3 run_gut.py
+    python3 run_gut.py            # 未设 GODOT_BIN 时尝试 macOS 默认 / PATH
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+GUT_REF = "v9.4.0"  # bumping：检查 https://github.com/bitwes/Gut/releases
+
+# 仓库根：本脚本在 addons/godot_cli_control/tests/，往上 3 级。
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_PROJECT_GODOT = """\
+config_version=5
+
+[application]
+config/name="gut-tests"
+config/features=PackedStringArray("4.4", "GL Compatibility")
+
+[rendering]
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"
+"""
+
+_SUCCESS_MARKER = "All tests passed!"
+
+
+def _log(msg: str) -> None:
+    print(f"==> {msg}", flush=True)
+
+
+def _fail(msg: str) -> "None":
+    print(f"FAIL: {msg}", file=sys.stderr, flush=True)
+    raise SystemExit(1)
+
+
+def _find_godot() -> str:
+    """GODOT_BIN > macOS 默认 .app > PATH 中的 godot/godot.exe。"""
+    env_bin = os.environ.get("GODOT_BIN")
+    if env_bin:
+        if not (Path(env_bin).is_file() and os.access(env_bin, os.X_OK)):
+            _fail(f"GODOT_BIN 指向的不是可执行文件：{env_bin}")
+        return env_bin
+
+    mac_default = Path("/Applications/Godot.app/Contents/MacOS/Godot")
+    if mac_default.is_file() and os.access(mac_default, os.X_OK):
+        return str(mac_default)
+
+    for name in ("godot", "godot.exe", "Godot"):
+        found = shutil.which(name)
+        if found:
+            return found
+
+    _fail("找不到 Godot 二进制（设置 GODOT_BIN 或加入 PATH）")
+    raise AssertionError("unreachable")  # 给类型检查器：_fail 永远 raise
+
+
+def _run_godot(godot: str, *args: str, capture: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [godot, *args],
+        capture_output=capture,
+        text=True,
+    )
+
+
+def _clone_gut(dest_parent: Path) -> Path:
+    """clone GUT 到临时目录，返回其 addons/gut 路径。"""
+    _log(f"下载 GUT {GUT_REF}")
+    gut_src = dest_parent / "gut-src"
+    res = subprocess.run(
+        [
+            "git", "clone", "--depth", "1", "--branch", GUT_REF,
+            "https://github.com/bitwes/Gut.git", str(gut_src),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode != 0:
+        _fail(f"git clone GUT 失败：\n{res.stderr}")
+    gut_addon = gut_src / "addons" / "gut"
+    if not (gut_addon / "gut_cmdln.gd").is_file():
+        _fail(f"GUT {GUT_REF} 内未找到 addons/gut/gut_cmdln.gd（GUT 目录结构变了？）")
+    return gut_addon
+
+
+def _run_gut_cmdln(godot: str, proj: Path) -> str:
+    """实时透传 gut_cmdln 输出并缓冲返回（等价 bash 的 `| tee`）。"""
+    _log("跑 GUT")
+    proc = subprocess.Popen(
+        [
+            godot, "--headless", "--path", str(proj),
+            "-s", "res://addons/gut/gut_cmdln.gd",
+            "-gdir=res://addons/godot_cli_control/tests/gut",
+            "-gexit",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    buf: list[str] = []
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        buf.append(line)
+    proc.wait()
+    return "".join(buf)
+
+
+def main() -> int:
+    godot = _find_godot()
+    _log(f"使用 Godot: {godot}")
+    _run_godot(godot, "--version")
+
+    # 一个临时父目录装 工程 + GUT clone；with 块退出自动清理（跨平台、无 trap）。
+    with tempfile.TemporaryDirectory(prefix="godot-cli-control-gut-") as tmp:
+        tmp_path = Path(tmp)
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _log(f"临时项目: {proj}")
+
+        # 1) 最小 Godot 工程
+        (proj / "project.godot").write_text(_PROJECT_GODOT, encoding="utf-8")
+
+        # 2) 被测 plugin
+        (proj / "addons").mkdir()
+        shutil.copytree(
+            REPO_ROOT / "addons" / "godot_cli_control",
+            proj / "addons" / "godot_cli_control",
+        )
+
+        # 3) GUT
+        gut_addon = _clone_gut(tmp_path)
+        shutil.copytree(gut_addon, proj / "addons" / "gut")
+
+        # 4) headless 预热 import（失败不致命，与 .sh 一致：用 || true 语义）
+        _log("import 资源")
+        _run_godot(godot, "--headless", "--path", str(proj), "--editor", "--quit",
+                   capture=True)
+
+        # 5) 跑 GUT
+        output = _run_gut_cmdln(godot, proj)
+
+    # 6) Godot 在 cmdln 脚本加载失败时仍可能 exit 0 —— 额外断言 GUT 成功 marker。
+    if _SUCCESS_MARKER in output:
+        _log("GUT PASS")
+        return 0
+    _fail(f"没看到 GUT 的 '{_SUCCESS_MARKER}' marker —— 看上面输出排查")
+    return 1  # unreachable（_fail raise）
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/addons/godot_cli_control/tests/run_gut.sh
+++ b/addons/godot_cli_control/tests/run_gut.sh
@@ -4,6 +4,10 @@
 # 没有把 GUT vendor 进仓库（它是开发依赖，不该跟 plugin 一起发布到 PyPI/AssetLib）；
 # 临时项目从头建，避免污染仓库的 .godot/ import 缓存。
 #
+# 跨平台：CI（ubuntu / macOS / windows 三格）跑的是同目录的 run_gut.py
+# （bash 在 Windows 用不了）。本 .sh 保留给 Linux / macOS 本地开发者方便用；
+# 两者逻辑等价，改一个记得对齐另一个。
+#
 # 用法：
 #   GODOT_BIN=/path/to/godot ./run_gut.sh
 #   （未设置 GODOT_BIN 时尝试 macOS 默认路径或 PATH 中的 godot）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,15 @@ godot-cli-control = "godot_cli_control.cli:main"
 [project.entry-points.pytest11]
 godot-cli-control = "godot_cli_control.pytest_plugin"
 
+[tool.pytest.ini_options]
+# gui：需要真实显示（开窗）才能跑的端到端测试。普通 unit / headless e2e 不带此
+# marker。本地默认随 GODOT_BIN / GCC_GUI_E2E 未设而 skip；CI 专档（Linux 套
+# xvfb 或 macOS runner）设 GCC_GUI_E2E=1 开启。注册在此避免 unknown-marker 警告，
+# 也让 `pytest -m "not gui"` 能稳定剔除。
+markers = [
+    "gui: 需要真实显示的 windowed e2e（screenshot frame_post_draw 路径，issue #64）",
+]
+
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/python/README.md
+++ b/python/README.md
@@ -159,7 +159,10 @@ coverage run -m pytest python/tests/
 coverage report
 
 # GUT tests for the Godot plugin (needs GODOT_BIN env var)
+# bash (Linux/macOS):
 GODOT_BIN=/path/to/godot ./addons/godot_cli_control/tests/run_gut.sh
+# cross-platform (Linux/macOS/Windows) — what CI runs:
+GODOT_BIN=/path/to/godot python addons/godot_cli_control/tests/run_gut.py
 ```
 
 ## Documentation

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -19,6 +19,18 @@ from godot_cli_control.daemon import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """统一把全局注册表重定向到 tmp_path/reg，覆盖整个模块。
+
+    成功路径的 start() 会写 ~/.local/state/godot-cli-control/daemons/；
+    autouse 后任何新写的成功路径测试都自动隔离，无需再手动 monkeypatch
+    （漏写会静默污染开发者 / CI 的真实注册表，失败模式不可见）。
+    """
+    from godot_cli_control import registry as _reg
+    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
+
+
 def test_is_running_false_when_no_pid_file(tmp_path: Path) -> None:
     daemon = Daemon(tmp_path)
     assert daemon.is_running() is False
@@ -225,10 +237,6 @@ def test_start_detaches_subprocess_signal_group(
     monkeypatch.setattr(
         "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
     )
-    # 隔离全局注册表
-    from godot_cli_control import registry as _reg
-    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
-
     daemon.start(port=29998)
 
     if _sys.platform == "win32":
@@ -316,8 +324,9 @@ def _setup_start_env(
 ) -> tuple[Daemon, Path]:
     """返回 (daemon, fake_bin)。已 patch find_godot_binary、_ensure_imported、Popen、sleep、_wait_port_ready。
 
-    同时把 registry._REGISTRY_DIR 重定向到 tmp_path/reg，避免成功 start()
-    的测试污染真实 ~/.local/state/godot-cli-control/daemons/。
+    registry._REGISTRY_DIR 的隔离由模块级 autouse fixture _isolate_registry
+    统一负责（重定向到 tmp_path/reg），避免成功 start() 污染真实
+    ~/.local/state/godot-cli-control/daemons/。
     """
     _touch_godot_project(tmp_path)
     fake_bin = tmp_path / "fake_godot"
@@ -345,9 +354,7 @@ def _setup_start_env(
         "godot_cli_control.daemon._wait_port_ready",
         lambda *a, **k: port_ready,
     )
-    # 隔离全局注册表：把写入重定向到临时目录，避免污染 ~/.local/state/…
-    from godot_cli_control import registry as _reg
-    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
+    # 全局注册表隔离由模块级 autouse fixture _isolate_registry 负责。
     return Daemon(tmp_path), fake_bin
 
 
@@ -606,10 +613,6 @@ def test_start_record_writes_movie_path_file_and_args(
     monkeypatch.setattr(
         "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
     )
-    # 隔离全局注册表
-    from godot_cli_control import registry as _reg
-    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
-
     daemon = Daemon(tmp_path)
     movie = tmp_path / "rec.avi"
     daemon.start(record=True, movie_path=str(movie), fps=60, port=29994)
@@ -887,10 +890,6 @@ def test_start_redirects_godot_output_to_log_file(
     monkeypatch.setattr(
         "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
     )
-    # 隔离全局注册表
-    from godot_cli_control import registry as _reg
-    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
-
     daemon = Daemon(tmp_path)
     daemon.start(port=29900)
 
@@ -1176,6 +1175,56 @@ def test_start_with_port_zero_writes_actual_port(
     assert 1024 < written < 65536
 
 
+def test_start_passes_actual_port_to_popen_argv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """port=0 时传给 Godot Popen 的 --game-bridge-port 必须是落盘的实际端口。
+
+    防回归：上面的 test 只验了 port 文件内容，没验同一端口确实通过
+    --game-bridge-port=<N> 传给了 Popen。若未来重构把"写文件"和"传 argv"
+    两条路径分裂（如误传 port=0 而非 actual_port），单测才能抓到。
+    """
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "fake_godot"
+    fake_bin.write_text("")
+    fake_bin.chmod(0o755)
+
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        pid = 999_999_020
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+    def _record_popen(args: list[str], **kwargs: Any) -> _FakeProc:
+        captured["args"] = args
+        return _FakeProc()
+
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: str(fake_bin)
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._ensure_imported", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.subprocess.Popen", _record_popen
+    )
+    monkeypatch.setattr("godot_cli_control.daemon.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
+    )
+
+    daemon = Daemon(tmp_path)
+    daemon.start(port=0)
+
+    written = int(daemon.port_file.read_text().strip())
+    expected = f"--game-bridge-port={written}"
+    assert any(a == expected for a in captured["args"]), \
+        f"Popen argv 必须含 {expected}（实际：{captured['args']}）"
+
+
 def test_start_passes_idle_timeout_to_popen(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1211,9 +1260,6 @@ def test_start_passes_idle_timeout_to_popen(
     monkeypatch.setattr(
         "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
     )
-    from godot_cli_control import registry as _reg
-    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
-
     daemon = Daemon(tmp_path)
     daemon.start(port=0, idle_timeout=10)
     assert any(a == "--game-bridge-idle-timeout=10" for a in captured["args"])
@@ -1254,9 +1300,6 @@ def test_start_omits_idle_timeout_when_zero(
     monkeypatch.setattr(
         "godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True
     )
-    from godot_cli_control import registry as _reg
-    monkeypatch.setattr(_reg, "_REGISTRY_DIR", tmp_path / "reg")
-
     daemon = Daemon(tmp_path)
     daemon.start(port=0)  # 不传 idle_timeout 用默认
     assert not any(a.startswith("--game-bridge-idle-timeout=") for a in captured["args"])
@@ -1272,7 +1315,7 @@ def test_start_registers_in_global_registry(
     """
     from godot_cli_control import registry
 
-    monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
+    # 注册表隔离由 autouse fixture _isolate_registry 统一重定向到 tmp_path/reg。
     daemon, _ = _setup_start_env(tmp_path, monkeypatch)
     record_file = tmp_path / "reg" / f"{registry.project_hash(tmp_path)}.json"
 

--- a/python/tests/test_e2e_screenshot_gui.py
+++ b/python/tests/test_e2e_screenshot_gui.py
@@ -1,0 +1,180 @@
+"""端到端回归：GUI（windowed）模式下的 screenshot 路径（issue #64）。
+
+GUT 套件全跑在 ``--headless`` 下，``RenderingServer.get_rendering_device() ==
+null``，所有 screenshot 用例都走 dummy 渲染路径。``frame_post_draw`` 这条
+windowed 分支 —— 也就是真实用户用 screenshot 的路径 —— 长期没有任何自动化覆盖：
+issue #61 本身就是这种 silent regression（GUT 全绿 + pytest 全绿，但 GUI 模式
+screenshot 回归）的产物。
+
+本测试真起一个 **GUI**（``--gui``，非 headless）daemon，**立刻**截图（不加任何
+``wait(...)`` 魔法 —— #61 的 H + D 启动 gate 应保证首帧 viewport ready），断言：
+  1. 返回 ``ok=true`` 且不报 1006（RESOURCE_UNAVAILABLE transient）。
+  2. 落盘是非空、带 PNG magic 的真 PNG。
+  3. 连续重复 N 次（覆盖动态 transient 兜底，验证不是只有第一帧侥幸成功）。
+
+需要真实 Godot 4 **且真实显示**：
+  - ``GODOT_BIN`` 指向可执行文件；
+  - ``GCC_GUI_E2E=1`` 显式开启（本地默认 skip —— 多数开发机 / 无头 CI 没显示，
+    误跑会卡在开窗或拿不到 RenderingDevice）。CI 专档在 Linux 套 xvfb 或用
+    macOS runner，并设 ``GCC_GUI_E2E=1``。
+
+设计讨论（issue #64 内）：是否给 ``client.screenshot`` 加 1006 retry 兜底走
+「数据驱动」—— 先用本测试收集 windowed 路径是否真撞 1006，撞了再加 client retry
+并把次数/间隔做成可配。本测试就是那个数据采集点。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_GODOT_BIN = os.environ.get("GODOT_BIN")
+_ADDON_SRC = Path(__file__).resolve().parents[2] / "addons" / "godot_cli_control"
+
+# RESOURCE_UNAVAILABLE：screenshot 时 viewport texture 暂不可用的 transient 码。
+# 见 addons/godot_cli_control/bridge/error_codes.gd。
+_RESOURCE_UNAVAILABLE = 1006
+
+# 重复次数：> 1 才能区分「首帧侥幸」与「稳定可用」。
+_REPEAT = 5
+
+pytestmark = [
+    pytest.mark.gui,
+    pytest.mark.skipif(
+        not _GODOT_BIN or not Path(_GODOT_BIN).exists(),
+        reason="需要真实 Godot 4：设置 GODOT_BIN 指向可执行文件",
+    ),
+    pytest.mark.skipif(
+        os.environ.get("GCC_GUI_E2E") != "1",
+        reason="GUI e2e 默认 skip（需真实显示 / xvfb）；CI 专档设 GCC_GUI_E2E=1 开启",
+    ),
+]
+
+# 用 `python -m godot_cli_control` 调 CLI：与 PATH 无关，always 命中当前环境。
+_CLI = [sys.executable, "-m", "godot_cli_control"]
+
+# main 场景给个有尺寸的 ColorRect，让窗口真有可渲染内容（空 Node 也能截，但有内容
+# 更贴近真实用法、也更容易暴露 viewport-not-ready 类问题）。
+_PROJECT_GODOT = """\
+config_version=5
+
+[application]
+config/name="gcc_e2e_screenshot"
+run/main_scene="res://main.tscn"
+config/features=PackedStringArray("4.2")
+
+[autoload]
+GameBridgeNode="*res://addons/godot_cli_control/bridge/game_bridge.gd"
+
+[debug]
+settings/stdout/print_fps=false
+
+[display]
+window/size/viewport_width=320
+window/size/viewport_height=240
+
+[editor_plugins]
+enabled=PackedStringArray("res://addons/godot_cli_control/plugin.cfg")
+"""
+
+_MAIN_TSCN = """\
+[gd_scene format=3 uid="uid://gccscreenshot"]
+
+[node name="Main" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+
+[node name="Bg" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+color = Color(0.2, 0.4, 0.8, 1)
+"""
+
+
+def _run_cli(project: Path, *args: str, timeout: float = 90.0) -> dict[str, Any]:
+    """跑一条 CLI 子命令（独立进程 = 独立连接），解析最后一行 JSON 信封。"""
+    proc = subprocess.run(
+        _CLI + list(args),
+        cwd=project,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    json_lines = [ln for ln in proc.stdout.splitlines() if ln.strip().startswith("{")]
+    assert json_lines, (
+        f"无 JSON 输出：args={args} stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+    return json.loads(json_lines[-1])
+
+
+@pytest.fixture(scope="module")
+def godot_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """搭一个最小真实 Godot 工程（addon + autoload + 有内容的 main 场景）并导入一次。"""
+    proj = tmp_path_factory.mktemp("gcc_e2e_screenshot")
+    (proj / "addons").mkdir()
+    shutil.copytree(_ADDON_SRC, proj / "addons" / "godot_cli_control")
+    (proj / "project.godot").write_text(_PROJECT_GODOT)
+    (proj / "main.tscn").write_text(_MAIN_TSCN)
+
+    # 先跑一次编辑器导入，注册全局 class + 资源 .import（headless 导入即可）。
+    imp = subprocess.run(
+        [_GODOT_BIN, "--headless", "--editor", "--quit", "--path", str(proj)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert imp.returncode == 0, f"Godot 导入失败：{imp.stdout}\n{imp.stderr}"
+    return proj
+
+
+@pytest.fixture
+def gui_daemon(godot_project: Path) -> Any:
+    """起/停一个真实 **GUI**（开窗）daemon；teardown 兜底 stop。
+
+    用 ``--gui`` 强制开窗，绕过 isatty 自动判 —— 必须开窗才会走 windowed
+    ``frame_post_draw`` 渲染分支（这正是本测试要覆盖的路径）。
+    """
+    start = _run_cli(godot_project, "daemon", "start", "--gui", timeout=120)
+    assert start["ok"] is True and start["result"]["started"], start
+    try:
+        yield godot_project
+    finally:
+        _run_cli(godot_project, "daemon", "stop", timeout=30)
+
+
+def test_windowed_screenshot_returns_png_without_wait(
+    gui_daemon: Any, tmp_path: Path
+) -> None:
+    """GUI 模式立刻截图（无 wait 魔法）应稳定拿到非空 PNG，且不撞 1006。"""
+    project = gui_daemon
+
+    for i in range(_REPEAT):
+        out = tmp_path / f"shot_{i}.png"
+        payload = _run_cli(project, "screenshot", str(out))
+
+        # 不应撞 transient 1006：H + D 启动 gate 之后 windowed 路径应已稳定。
+        # 若真撞到，这里给出明确信号 —— 即 issue #64 里「数据驱动决定是否加
+        # client retry」的触发条件。
+        if not payload["ok"]:
+            assert payload["error"]["code"] != _RESOURCE_UNAVAILABLE, (
+                f"第 {i} 次 windowed screenshot 撞到 1006 transient —— "
+                f"H+D 兜底未覆盖此 case，应据此加 client retry：{payload}"
+            )
+            pytest.fail(f"第 {i} 次 screenshot 失败：{payload}")
+
+        assert out.exists(), f"第 {i} 次 screenshot 未落盘：{payload}"
+        raw = out.read_bytes()
+        assert raw, f"第 {i} 次 screenshot PNG 为空"
+        assert raw.startswith(b"\x89PNG\r\n\x1a\n"), (
+            f"第 {i} 次 screenshot 不是合法 PNG（magic 不符）：{raw[:8]!r}"
+        )
+        assert payload["result"]["bytes"] == len(raw), (
+            f"第 {i} 次 信封 bytes 与落盘大小不一致：{payload}"
+        )

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -13,6 +15,19 @@ from godot_cli_control import registry
 def reg_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "registry")
     return tmp_path / "registry"
+
+
+@pytest.fixture
+def dead_pid() -> int:
+    """一个 100% 已死、跨平台稳定的 PID。
+
+    起一个立即退出的子进程并 reap（wait）掉，其 PID 此后保证不存活——
+    比硬编码 magic PID（如 2_000_000）稳：后者依赖 OS 的 PID 上限，
+    Linux pid_max=4194304 下长跑系统理论上可能真有进程占到该 PID 而 flaky。
+    """
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait()
+    return proc.pid
 
 
 def test_register_creates_record(reg_dir: Path, tmp_path: Path) -> None:
@@ -35,24 +50,26 @@ def test_unregister_removes_record(reg_dir: Path, tmp_path: Path) -> None:
     assert registry.list_all() == []
 
 
-def test_list_all_prunes_dead_pids(reg_dir: Path, tmp_path: Path) -> None:
+def test_list_all_prunes_dead_pids(
+    reg_dir: Path, tmp_path: Path, dead_pid: int
+) -> None:
     proj = tmp_path / "p1"; proj.mkdir()
-    # PID 1 几乎不会是当前用户的 Godot；用一个肯定死的高位 PID
-    registry.register(proj, pid=2_000_000, port=1, godot_bin="x", log_path="x")
+    # 用一个已 reap 的子进程 PID —— 100% 死、跨平台稳
+    registry.register(proj, pid=dead_pid, port=1, godot_bin="x", log_path="x")
     assert registry.list_all() == []  # 探活后死记录被清掉
     # 注册表文件也应被删
     assert not list(reg_dir.glob("*.json"))
 
 
 def test_list_all_also_cleans_project_state_for_dead(
-    reg_dir: Path, tmp_path: Path
+    reg_dir: Path, tmp_path: Path, dead_pid: int
 ) -> None:
     proj = tmp_path / "p1"; proj.mkdir()
     ctrl = proj / ".cli_control"
     ctrl.mkdir()
-    (ctrl / "godot.pid").write_text("2000000")
+    (ctrl / "godot.pid").write_text(str(dead_pid))
     (ctrl / "port").write_text("12345")
-    registry.register(proj, pid=2_000_000, port=12345, godot_bin="x",
+    registry.register(proj, pid=dead_pid, port=12345, godot_bin="x",
                       log_path=str(ctrl / "godot.log"))
     registry.list_all()
     assert not (ctrl / "godot.pid").exists()
@@ -66,9 +83,9 @@ def test_project_hash_stable(tmp_path: Path) -> None:
     assert h1 == h2 and len(h1) == 12
 
 
-def test_process_alive_branches() -> None:
+def test_process_alive_branches(dead_pid: int) -> None:
     """直接覆盖 _process_alive 四个分支，避免未来 'simplify' 误改 PermissionError 含义。"""
     assert registry._process_alive(0) is False
     assert registry._process_alive(-1) is False
     assert registry._process_alive(os.getpid()) is True
-    assert registry._process_alive(2_000_000) is False
+    assert registry._process_alive(dead_pid) is False


### PR DESCRIPTION
解决 5 个测试覆盖 issue，外加把已有的输入持续性 e2e 接进 CI。

## A 档 — 纯 pytest（本地全套件 337 passed / coverage 84%）
- **#40** `test_daemon.py` 加 module 级 autouse fixture `_isolate_registry`，删掉 7 处 inline `_REGISTRY_DIR` monkeypatch（issue 说 4 处，实际已增到 7）。新写的成功路径测试漏 monkeypatch 不再静默污染真实注册表目录。
- **#41** `test_registry.py` 加 `dead_pid` fixture —— `subprocess.Popen([sys.executable, "-c", ""])` reap 掉拿一个 100% 死、跨平台稳的 PID，替换 3 处 magic `2_000_000`（依赖 OS pid 上限，理论 flaky）。用 `sys.executable` 而非 `true`，Windows 也能跑。
- **#42** 新增 `test_start_passes_actual_port_to_popen_argv`：断言 `port=0` 时落盘端口确实通过 `--game-bridge-port=<N>` 传给 Popen，防"写文件 / 传 argv"两条路径分裂。

## #64 — windowed screenshot e2e
GUT 全跑 `--headless`，dummy renderer 拿不到 viewport texture，`frame_post_draw` 这条用户主用法路径长期零覆盖（#61 即此类 silent regression）。
- 新增 `test_e2e_screenshot_gui.py`：`--gui` 真窗 daemon 立刻截图 ×5，断言非空 PNG（magic 校验）+ 不撞 1006。
- `pyproject.toml` 注册 `gui` marker，默认 skip（需 `GODOT_BIN` + `GCC_GUI_E2E=1`）。
- CI 加 macOS runner job（真 GPU 开窗，不赌 xvfb 软渲染）。
- **本地 macOS 真跑：5/5 截图成功、0 次 1006** → 数据驱动结论：当前无需给 client 加 1006 retry（回答了 issue 内的设计讨论）。

## #36 — 跨平台 GUT
- 新增 `run_gut.py`：`run_gut.sh` 的 stdlib 等价物，抹平 mktemp / cp / 路径分隔符差异。CI 三平台跑 GUT（ubuntu + windows 在 walkthrough job，macOS 复用新 job 已下载的 Godot，零新增下载）。
- 保留 `run_gut.sh` 给本地开发者（按 issue 要求）；README×3 + CLAUDE.md + `.sh` 头注释标注两者并存、CI 用 `.py`。
- **本地 macOS 真跑：exit 0，96/96 GUT 全绿，临时目录自动清理**。

## 顺手
`test_e2e_input.py`（#70 输入持续性 e2e）此前因为没有任何 CI job 同时备齐 `GODOT_BIN` + 已装包 + pytest 而**从未在 CI 真跑过**（python-unit 不设 GODOT_BIN ⇒ skip；walkthrough 不跑 pytest）。新 macOS job 三者齐全，顺手接进 CI（本地 3 passed / 20s）。

## ⚠️ 验证边界（诚实说明）
macOS 那一格（GUI 截图 / GUT / 输入 e2e）全部**本地真跑验证过绿**。Windows GUT（`run_gut.py` 在 pwsh + Windows 路径）与 CI job 编排的运行时行为，靠本 PR 的 CI 跑出来验证 —— 这是唯一能证明跨平台绿的方式。

Closes #40, #41, #42, #64, #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)