### PR TITLE
fix(test): run_gut.py 强制 UTF-8 stdout/stderr（修复 #36 Windows GUT）

### DIFF
--- a/addons/godot_cli_control/tests/run_gut.py
+++ b/addons/godot_cli_control/tests/run_gut.py
@@ -29,6 +29,15 @@ import sys
 import tempfile
 from pathlib import Path
 
+# Windows 默认 stdout/stderr 编码是 cp1252，编不了中文日志或 Godot 输出里的非 ASCII
+# 字符（issue #36：Windows CI 格曾因 `_log("使用 Godot…")` 在第一行就 UnicodeEncodeError
+# 崩掉，GUT 根本没跑起来）。强制 UTF-8，macOS/Linux 本就默认 UTF-8 不受影响。
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+    except (AttributeError, ValueError):  # 非 TextIOWrapper（被重定向）时静默跳过
+        pass
+
 GUT_REF = "v9.4.0"  # bumping：检查 https://github.com/bitwes/Gut/releases
 
 # 仓库根：本脚本在 addons/godot_cli_control/tests/，往上 3 级。


### PR DESCRIPTION
## 背景

`62ea8e6`（#36 跨平台 GUT）引入的 `run_gut.py` 在 **Windows CI 第一行就崩**：

\`\`\`
File ".../run_gut.py", line 53, in _log
UnicodeEncodeError: 'charmap' codec can't encode characters in position 4-5
\`\`\`

`_log("使用 Godot…")` 撞 Windows Python 默认 `cp1252` 编码，GUT 根本没跑起来。macOS/Linux 默认 UTF-8 所以本地手测没暴露——#36 当时"Windows GUT 靠 CI 验证"那句被 CI 打脸，**#36 实际未达成**。

## 修法

模块加载时把 `sys.stdout/stderr` `reconfigure(encoding="utf-8")`（非 TextIOWrapper 时静默跳过）。

## 验证

- 本地以 cp1252 wrapper 模拟 Windows 自检：`_log` 中文不再崩、`encoding=utf-8` ✓
- Windows 真验证靠本 PR 的 CI（windows-latest 的 `Run GUT unit tests (Windows)` 该格转绿即 #36 真正达成）

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)