### PR TITLE
fix(daemon/registry): 消除 run 收尾 SIGTERM 噪音(#67) + Windows 注册表目录(#43)

### DIFF
--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -910,7 +910,8 @@ def cmd_daemon_status(ns: argparse.Namespace) -> int:
 def cmd_daemon_ls(ns: argparse.Namespace) -> int:
     """跨项目列出运行中的 daemon。
 
-    扫全局注册表 ~/.local/state/godot-cli-control/daemons/，对每条记录探活。
+    扫全局注册表（POSIX `~/.local/state/godot-cli-control/daemons/`；Windows
+    `%LOCALAPPDATA%\\godot-cli-control\\daemons\\`），对每条记录探活。
     死记录会被 list_all 自动清理（连同对应项目的 .cli_control/godot.pid 与 port）。
     JSON 模式：{"ok": true, "result": {"daemons": [...]}}（信封一致）。
     Text 模式：每条一行 `<pid>\t<port>\t<project_root>\t<started_at>`；空时 (no running daemons)。
@@ -1511,7 +1512,8 @@ def build_parser() -> argparse.ArgumentParser:
         "ls",
         help="列出所有正在运行的 daemon（跨项目）",
         description=(
-            "扫描全局注册表 ~/.local/state/godot-cli-control/daemons/，"
+            "扫描全局注册表（POSIX ~/.local/state/godot-cli-control/daemons/；"
+            "Windows %LOCALAPPDATA%\\godot-cli-control\\daemons\\），"
             "列出所有探活通过的 daemon。死记录会被自动清理。"
         ),
     )

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -328,14 +328,20 @@ class Daemon:
         return f"{header}\n{body}"
 
     def _terminate(self, pid: int, timeout: float = 10.0) -> None:
-        """SIGTERM → wait → SIGKILL。"""
+        """SIGTERM → wait → SIGKILL。
+
+        探活用 ``_reap_if_dead`` 而非 ``_process_alive``：``run`` 自起的 daemon 中
+        Godot 是本进程的子进程，SIGTERM 后会变 zombie，``os.kill(pid, 0)`` 对
+        zombie 仍成功，必须 ``waitpid`` 回收才能正确判定其已退出 —— 否则空等满
+        timeout 才放弃，每次 ``run`` 收尾都打印 "SIGTERM 超时" 噪音（#67）。
+        """
         try:
             os.kill(pid, signal.SIGTERM)
         except (ProcessLookupError, OSError):
             return
         deadline = time.time() + timeout
         while time.time() < deadline:
-            if not _process_alive(pid):
+            if _reap_if_dead(pid):
                 return
             time.sleep(0.5)
         print("SIGTERM 超时，强制终止", file=sys.stderr)
@@ -343,6 +349,7 @@ class Daemon:
             os.kill(pid, _force_kill_signal())
         except (ProcessLookupError, OSError):
             pass
+        _reap_if_dead(pid)  # 回收被 SIGKILL 的 zombie 子进程（若它是本进程的孩子）
 
 
 # ── Godot 二进制发现 ──
@@ -423,6 +430,34 @@ def _process_alive(pid: int) -> bool:
     except OSError:
         return False
     return True
+
+
+def _reap_if_dead(pid: int) -> bool:
+    """Return True when ``pid`` is no longer a *running* process.
+
+    处理 ``_process_alive`` 单独搞不定的 zombie 场景：当 ``pid`` 是本进程已退出但
+    尚未被 wait 的子进程时，它以 zombie 形式滞留进程表，``os.kill(pid, 0)`` 持续
+    成功 —— ``_process_alive`` 会无限误报其存活。这正是 ``run`` 每次都打印
+    "SIGTERM 超时" 的根因（#67）：``run`` 是 daemon 的父进程，它 SIGTERM 掉的
+    Godot 变成无人回收的 zombie。
+
+    ``os.waitpid(pid, WNOHANG)`` 会回收这种子进程并报告其退出。对于不是本进程
+    子进程的 pid（如独立的 ``daemon stop``，其 Godot 已被 init 回收），waitpid 抛
+    ChildProcessError，回落到通用探活。
+    """
+    if sys.platform != "win32":
+        try:
+            reaped_pid, _ = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            pass  # 不是本进程的子进程 —— 交给下面的通用探活
+        except OSError:
+            pass
+        else:
+            if reaped_pid == pid:
+                return True  # 子进程已退出并被回收
+            if reaped_pid == 0:
+                return False  # 子进程仍在运行
+    return not _process_alive(pid)
 
 
 def _process_is_godot(pid: int) -> bool:

--- a/python/godot_cli_control/registry.py
+++ b/python/godot_cli_control/registry.py
@@ -1,4 +1,4 @@
-"""Global cross-project daemon registry under ~/.local/state/godot-cli-control/daemons/.
+"""Global cross-project daemon registry，目录按平台惯例选址（见 ``_user_state_dir``）。
 
 每个守护进程一份 ``<project_hash>.json``，记录 PID / 端口 / 项目路径 / 启动时刻。
 ``list_all()`` 顺手探活并清理死记录。无文件锁 —— 每条记录文件名以 project_hash
@@ -14,7 +14,21 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-_REGISTRY_DIR = Path.home() / ".local" / "state" / "godot-cli-control" / "daemons"
+def _user_state_dir() -> Path:
+    """守护进程注册表的根目录，按平台惯例选址（#43）。
+
+    - Windows：``%LOCALAPPDATA%\\godot-cli-control``（回落 ``~/AppData/Local``）。
+      ``~/.local/state`` 是 XDG 约定，不是 Windows 用户会去找的位置。
+    - Linux / macOS：保持既有 XDG state 风格 ``~/.local/state/godot-cli-control``
+      （字节不变，避免已有用户的注册表搬家）。
+    """
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        return Path(base) / "godot-cli-control"
+    return Path.home() / ".local" / "state" / "godot-cli-control"
+
+
+_REGISTRY_DIR = _user_state_dir() / "daemons"
 
 
 @dataclass(frozen=True)

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -434,6 +435,33 @@ def test_terminate_returns_early_when_process_already_gone(
 
     Daemon(tmp_path)._terminate(pid=123, timeout=1.0)
     assert len(sent) == 1, "进程已不存在时不应再尝试第二次 kill"
+
+
+def test_terminate_reaps_zombie_child_without_timeout(tmp_path: Path) -> None:
+    """#67 根因：`run` 自起的 daemon 中 Godot 是本进程的子进程，SIGTERM 后变
+    zombie；`os.kill(pid, 0)` 对 zombie 仍成功 → 旧实现误判存活、空等满 timeout
+    才放弃，每次 `run` 收尾都打印 "SIGTERM 超时" 噪音。`_terminate` 必须
+    waitpid 回收自己的 zombie 子进程并立即返回，不空等。"""
+    if sys.platform == "win32":
+        pytest.skip("zombie / waitpid 语义是 POSIX-only")
+
+    # 立即退出的子进程；不调用 proc.wait()/poll() → 成为本进程的 zombie 子进程。
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    try:
+        time.sleep(0.5)  # 等它退出（python -c "" 近即时），此刻起它是 zombie
+        start = time.monotonic()
+        Daemon(tmp_path)._terminate(pid=proc.pid, timeout=8.0)
+        elapsed = time.monotonic() - start
+        assert elapsed < 4.0, (
+            f"_terminate 应 reap zombie 子进程后立即返回，实际空等 {elapsed:.1f}s"
+            "（把 zombie 误判成存活 = #67 噪音根因）"
+        )
+    finally:
+        # 兜底回收：若 _terminate 已 reap，这里 ECHILD，忽略即可。
+        try:
+            os.waitpid(proc.pid, os.WNOHANG)
+        except (ChildProcessError, OSError):
+            pass
 
 
 # ── _process_is_godot 多平台矩阵 ──

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -89,3 +89,36 @@ def test_process_alive_branches(dead_pid: int) -> None:
     assert registry._process_alive(-1) is False
     assert registry._process_alive(os.getpid()) is True
     assert registry._process_alive(dead_pid) is False
+
+
+# ── _user_state_dir 平台选址（#43）──
+
+
+def test_user_state_dir_windows_uses_localappdata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows 上落到 %LOCALAPPDATA%\\godot-cli-control，而非 XDG 的 ~/.local/state。"""
+    monkeypatch.setattr(registry.sys, "platform", "win32")
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\tester\AppData\Local")
+    d = registry._user_state_dir()
+    assert d == Path(r"C:\Users\tester\AppData\Local") / "godot-cli-control"
+
+
+def test_user_state_dir_windows_falls_back_without_localappdata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LOCALAPPDATA 缺失时回落到 ~/AppData/Local，不会误用 XDG 路径。"""
+    monkeypatch.setattr(registry.sys, "platform", "win32")
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    d = registry._user_state_dir()
+    assert d == Path.home() / "AppData" / "Local" / "godot-cli-control"
+
+
+def test_user_state_dir_posix_keeps_xdg_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Linux / macOS 维持既有 ~/.local/state 选址（不给已有用户搬家）。"""
+    monkeypatch.setattr(registry.sys, "platform", "linux")
+    assert registry._user_state_dir() == Path.home() / ".local" / "state" / "godot-cli-control"
+    monkeypatch.setattr(registry.sys, "platform", "darwin")
+    assert registry._user_state_dir() == Path.home() / ".local" / "state" / "godot-cli-control"


### PR DESCRIPTION
两个独立 bug，分两个 commit（可 bisect）。

## #67 — `run` 收尾每次打印「SIGTERM 超时，强制终止」

**根因（实测定位）**：issue 推测是 grace period 太短（1-2s），实测它已是 10s——推测不成立。真因是 **zombie 进程**：`run` 自起的 daemon 中 Godot 是 run 进程的子进程，stop 发 SIGTERM 后 Godot ~200ms 就正常退出，但父进程（run）从不 `waitpid` 回收 → Godot 变 zombie 滞留进程表 → `_process_alive` 的 `os.kill(pid,0)` 对 zombie 仍返回成功 → 误判存活、空等满 10s → 噪音 + 无效 SIGKILL。单独 `daemon stop` 不触发（那时 Godot 已被 init 收养即时回收）。

**修复**：`_terminate` 探活改用新 helper `_reap_if_dead()` —— `os.waitpid(pid, WNOHANG)` 回收自己的 zombie 子进程后再判定退出；非本进程子进程抛 `ChildProcessError`，回落到原 `_process_alive`。

**验证**：
- 单测 `test_terminate_reaps_zombie_child_without_timeout`：修复前空等 8s FAIL，修复后立即返回 PASS
- 端到端真 `run` ×3：噪音 **0/3**（修复前 3/3），收尾 ~1.8s
- SIGKILL 升级路径既有测试不受影响

## #43 — Windows 注册表目录不符平台惯例

`_REGISTRY_DIR` 写死 `~/.local/state/...`（XDG 风格），Windows 用户不会去那找。抽出 `_user_state_dir()`，Windows 用 `%LOCALAPPDATA%\godot-cli-control`（回落 `~/AppData/Local`），**Linux/macOS 保持 `~/.local/state` 字节不变**（不给已有用户搬家）。不引入新依赖。同步两处 agent 可见的 CLI help。

测试：`test_user_state_dir_*` 三条覆盖 win(有/无 LOCALAPPDATA)+posix。

## 整体验证
全量 `coverage run -m pytest`：**341 passed, 1 skipped, 84% 覆盖率**（>80 门槛）。

Closes #67
Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)