### PR TITLE
refactor(gdscript): _build_tree 两个 LIMIT 常量改名消歧义（#48）

### DIFF
--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -60,7 +60,7 @@
 - **Error code 1004 collision**: `low_level_api.gd` 的 scene tree 超限改用新业务码 `1005 "scene tree too large"`，与 input_simulation `1004 "combo in progress"` 解耦。新增 `error_codes.gd` 集中常量。
 - **pytest fixture default port**: `--godot-cli-port` 默认从 9877 改为 0（OS-assigned），与 `daemon start` 默认对齐；多项目并行测试不再撞端口。
 - **Addon README error-code table**: 之前只列到 1003，补全 1004 / 1005 / 客户端 -1xxx 段。
-- **Scene tree hard limit bypass (DoS fix)**: `handle_get_scene_tree` 入口现在把 `max_nodes` clamp 到硬墙 `_BUILD_TREE_NODE_LIMIT` (5000)。修复前客户端传 `max_nodes=999999` 会让服务端先把整棵超大树构造成 Dictionary 再被 1005 错误丢弃（内存浪费 / OOM 路径）。
+- **Scene tree hard limit bypass (DoS fix)**: `handle_get_scene_tree` 入口现在把 `max_nodes` clamp 到硬墙 `_BUILD_TREE_MAX_NODES` (5000)。修复前客户端传 `max_nodes=999999` 会让服务端先把整棵超大树构造成 Dictionary 再被 1005 错误丢弃（内存浪费 / OOM 路径）。
 - **Error code 1003 semantic split**: screenshot 在 viewport texture 为 null 时不再借用 `1003 METHOD_NOT_FOUND`，改用新业务码 `1006 RESOURCE_UNAVAILABLE`。1003 现在是纯 schema 错（不应 retry），1006 是 transient 错（短重试可能成功），agent 据此分别处置。
 
 #### Added

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -7,11 +7,12 @@ extends Node
 ## 若冷启动或 GUT 跑前遇到 "Class 'CliControlErrorCodes' not found"，先跑一次
 ## 完整 import（`godot --editor --quit --path .`）让 .godot/global_script_class_cache.cfg 建立。
 
-const _BUILD_TREE_HARD_LIMIT: int = 50
+# depth=0（"无限深度"）时的递归深度兜底，防无限递归 / 病态深树。
+const _BUILD_TREE_DEFAULT_MAX_DEPTH: int = 50
 # 总节点数上限：宽场景（1000+ 子项的 Grid/Container）会构造极大 JSON，
 # 超 outbound buffer（默认 10 MB）后客户端拿到截断包 → STATE_CLOSED 断连。
 # 5000 节点对应 ~500 KB JSON，留足余量。
-const _BUILD_TREE_NODE_LIMIT: int = 5000
+const _BUILD_TREE_MAX_NODES: int = 5000
 # wait_game_time_async 防呆上限：防止误传 1e9 之类的数值挂死 session
 const _MAX_WAIT_SECONDS: float = 3600.0
 # take_screenshot_async 循环上限：常态下 GameBridge 启动 gate 已保证 viewport
@@ -370,14 +371,14 @@ func handle_get_children(params: Dictionary) -> Dictionary:
 func handle_get_scene_tree(params: Dictionary) -> Dictionary:
 	var max_depth: int = params.get("depth", 5) as int
 	# max_nodes 是客户端控制的软上限。**入口处 clamp 到硬墙
-	# _BUILD_TREE_NODE_LIMIT (5000)**：防止恶意 / 失误调用传 max_nodes=999999
+	# _BUILD_TREE_MAX_NODES (5000)**：防止恶意 / 失误调用传 max_nodes=999999
 	# 时让 _build_tree 真把整棵超大树构造成 Dictionary 后才被外层错误返回丢弃
 	# （DoS / OOM 路径）。clamp 后 _build_tree 内部的短路单一来源，
 	# 同时承担软上限（agent truncated 信号）与硬墙（防爆 outbound buffer）。
 	# 不传时也用硬墙做默认，兼容旧客户端。
-	var max_nodes: int = params.get("max_nodes", _BUILD_TREE_NODE_LIMIT) as int
-	if max_nodes <= 0 or max_nodes > _BUILD_TREE_NODE_LIMIT:
-		max_nodes = _BUILD_TREE_NODE_LIMIT
+	var max_nodes: int = params.get("max_nodes", _BUILD_TREE_MAX_NODES) as int
+	if max_nodes <= 0 or max_nodes > _BUILD_TREE_MAX_NODES:
+		max_nodes = _BUILD_TREE_MAX_NODES
 	var root: Node = get_tree().current_scene
 	if root == null:
 		root = get_tree().root
@@ -389,10 +390,10 @@ func handle_get_scene_tree(params: Dictionary) -> Dictionary:
 	# 因为 max_nodes 已 clamp 到 ≤ LIMIT，counter 最多比 LIMIT 多 ~1，
 	# 所以这条分支只在 max_nodes==LIMIT（客户端没传或传了 ≥LIMIT）时被触发。
 	# max_nodes < LIMIT 的客户端永远走 truncated 软信号路径，不会撞 1005。
-	if counter[0] > _BUILD_TREE_NODE_LIMIT:
+	if counter[0] > _BUILD_TREE_MAX_NODES:
 		return _err(
 			CliControlErrorCodes.SCENE_TREE_TOO_LARGE,
-			"scene tree too large (>%d nodes); lower 'depth' or query a subtree" % _BUILD_TREE_NODE_LIMIT,
+			"scene tree too large (>%d nodes); lower 'depth' or query a subtree" % _BUILD_TREE_MAX_NODES,
 		)
 	# 软上限：硬墙内但超过 max_nodes 时附加 truncated 信号让 agent 决定分子树。
 	var response: Dictionary = {"tree": tree}
@@ -479,10 +480,10 @@ func _has_property(node: Node, property: String) -> bool:
 	return false
 
 
-## depth=0 表示"无限深度"，使用硬限制 _BUILD_TREE_HARD_LIMIT (50) 防止无限递归。
+## depth=0 表示"无限深度"，使用硬限制 _BUILD_TREE_DEFAULT_MAX_DEPTH (50) 防止无限递归。
 ## counter 是 by-ref 计数器：超过 max_nodes 时短路（不再递归子节点），
 ## 调用方读 counter[0] > max_nodes 决定是否附加 truncated 信号，
-## 读 counter[0] > _BUILD_TREE_NODE_LIMIT 决定是否走 1005 (SCENE_TREE_TOO_LARGE) 错误路径。
+## 读 counter[0] > _BUILD_TREE_MAX_NODES 决定是否走 1005 (SCENE_TREE_TOO_LARGE) 错误路径。
 func _build_tree(node: Node, max_depth: int, current_depth: int, counter: Array[int], max_nodes: int) -> Dictionary:
 	counter[0] += 1
 	var entry: Dictionary = {
@@ -497,7 +498,7 @@ func _build_tree(node: Node, max_depth: int, current_depth: int, counter: Array[
 	if counter[0] > max_nodes:
 		# 超软上限：不再下递归，但当前 entry 已计入；调用方附加 truncated 信号
 		return entry
-	var effective_max: int = _BUILD_TREE_HARD_LIMIT if max_depth == 0 else max_depth
+	var effective_max: int = _BUILD_TREE_DEFAULT_MAX_DEPTH if max_depth == 0 else max_depth
 	if current_depth < effective_max:
 		var children: Array[Dictionary] = []
 		for child: Node in node.get_children():

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -631,11 +631,11 @@ func test_build_tree_short_circuits_above_node_limit() -> void:
 	var leaf: Node = Node.new()
 	leaf.name = "Leaf"
 	add_child_autofree(leaf)
-	var counter: Array[int] = [LowLevelApiScript._BUILD_TREE_NODE_LIMIT]
+	var counter: Array[int] = [LowLevelApiScript._BUILD_TREE_MAX_NODES]
 	# 第 5 参数 max_nodes = LIMIT（5000）；leaf 计入后 counter == LIMIT+1 > max_nodes，触发短路
-	var entry: Dictionary = _api._build_tree(leaf, 5, 0, counter, LowLevelApiScript._BUILD_TREE_NODE_LIMIT)
+	var entry: Dictionary = _api._build_tree(leaf, 5, 0, counter, LowLevelApiScript._BUILD_TREE_MAX_NODES)
 	# leaf 自身被计入 → counter 变成 LIMIT+1
-	assert_eq(int(counter[0]), LowLevelApiScript._BUILD_TREE_NODE_LIMIT + 1)
+	assert_eq(int(counter[0]), LowLevelApiScript._BUILD_TREE_MAX_NODES + 1)
 	# 超 limit 后立刻 return，不下递归 children
 	assert_does_not_have(entry, "children")
 
@@ -650,14 +650,14 @@ func test_build_tree_under_limit_includes_children() -> void:
 	parent.add_child(c1)
 	var counter: Array[int] = [0]
 	# 第 5 参数 max_nodes 给硬墙 5000，远超 2 个节点，不会触发软截断
-	var entry: Dictionary = _api._build_tree(parent, 5, 0, counter, LowLevelApiScript._BUILD_TREE_NODE_LIMIT)
+	var entry: Dictionary = _api._build_tree(parent, 5, 0, counter, LowLevelApiScript._BUILD_TREE_MAX_NODES)
 	assert_has(entry, "children")
 	assert_eq((entry.children as Array).size(), 1)
 
 
 func test_handle_get_scene_tree_clamps_oversized_max_nodes() -> void:
 	# P1 回归：恶意/失误客户端传 max_nodes=999999 时，
-	# 入口必须 clamp 到 _BUILD_TREE_NODE_LIMIT，
+	# 入口必须 clamp 到 _BUILD_TREE_MAX_NODES，
 	# 否则 _build_tree 会构造完整大字典再被外层 1005 丢弃（DoS 风险）。
 	# 这里 happy path 验证 clamp 不破坏正常调用——简单场景下无 1005 报错、无 truncated 信号。
 	var result: Dictionary = _api.handle_get_scene_tree({


### PR DESCRIPTION
PR #46 final review (Minor #7) 提的命名易混问题。

`low_level_api.gd` 两个常量都含 `LIMIT`，语义却不同，易看反：
- `_BUILD_TREE_HARD_LIMIT` (50) 其实是**深度**兜底 → 改 `_BUILD_TREE_DEFAULT_MAX_DEPTH`
- `_BUILD_TREE_NODE_LIMIT` (5000) 其实是**节点数**硬墙（触发 1005）→ 改 `_BUILD_TREE_MAX_NODES`

纯重构：外部 API / 错误码 / 行为零变化。顺手给深度常量补一行注释；同步 GUT 测试引用 + CHANGELOG 常量名。docs/ 下历史 plan 是冻结设计快照，保留不动。

## 验证
GUT **96/96 全绿**（含 test_build_tree_* 与 clamp 用例），exit 0。

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)