### PR TITLE
fix(daemon): 拒绝 record+headless 防 Movie Maker headless SIGSEGV（CultivationWorld #180）

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -97,7 +97,8 @@ The CLI is the canonical surface — every `GameClient` method has a one-line eq
 ```bash
 # Lifecycle
 godot-cli-control init [--path DIR] [--force]
-godot-cli-control daemon start [--headless --record --movie-path X --fps N --port N --idle-timeout 30m]
+godot-cli-control daemon start [--headless | --gui] [--port N --idle-timeout 30m]
+godot-cli-control daemon start --record --movie-path X [--fps N]   # 录制需真实渲染器，不能与 --headless 同用
 godot-cli-control daemon stop [--all | --project PATH]
 godot-cli-control daemon status
 godot-cli-control daemon ls                  # list running daemons across all projects

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -73,10 +73,17 @@ def _resolve_headless(
     True，让没显式指定 ``--headless`` / ``--gui`` 的非 TTY 场景（subagent / pipe）
     自动改走 GUI —— headless 下 dummy renderer 拿不到 viewport texture，screenshot
     永远 1006 fail（issue #65）。
+
+    ``--record`` 同理且更狠：Movie Maker 的 ``add_frame()`` 读的也是 viewport
+    texture，headless 下拿到 null 直接 SIGSEGV（CultivationWorld #180）。所以没显式
+    ``--headless`` 时一律翻成 GUI；显式 ``--headless`` 仍返回 True，由
+    ``daemon.start`` 的 preflight 拒绝（明确用法错，不静默改写用户意图）。
     """
     if getattr(ns, "headless", False):
         return True
     if getattr(ns, "gui", False):
+        return False
+    if getattr(ns, "record", False):
         return False
     if force_gui_hint:
         return False
@@ -1356,7 +1363,8 @@ def _add_daemon_flags(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--record",
         action="store_true",
-        help="启动后录制 demo（写到 .cli_control/movie_path）",
+        help="启动后录制 demo（写到 .cli_control/movie_path）。需真实渲染器，"
+        "不能与 --headless 同用；没指定时会自动开窗（即使非 TTY）。",
     )
     p.add_argument(
         "--movie-path",
@@ -1367,7 +1375,8 @@ def _add_daemon_flags(p: argparse.ArgumentParser) -> None:
     headless_grp.add_argument(
         "--headless",
         action="store_true",
-        help="无窗口模式。默认值：stdout 非 TTY 时自动 headless（CI / pipe / agent）。",
+        help="无窗口模式。默认值：stdout 非 TTY 时自动 headless（CI / pipe / agent）。"
+        "与 --record 互斥（录制需真实渲染器）。",
     )
     headless_grp.add_argument(
         "--gui",

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -93,6 +93,17 @@ class Daemon:
             )
         if record and not movie_path:
             raise DaemonError("--record requires --movie-path")
+        # 录制无法在 headless 下跑：Godot Movie Maker 的 add_frame() 读 viewport
+        # texture，headless dummy renderer 拿到 null 直接 SIGSEGV（首帧崩，
+        # CultivationWorld #180）。CLI 侧 _resolve_headless 已把「没显式 --headless
+        # 的 record」翻成 GUI，所以走到这里还 headless=True 的只可能是用户显式
+        # --headless —— 这是用法矛盾，spawn 前拒绝，别让 Godot 段错误。
+        if record and headless:
+            raise DaemonError(
+                "录制与 --headless 冲突：Godot Movie Maker 需要真实渲染器，"
+                "headless dummy renderer 拿不到 viewport texture，add_frame() 会"
+                " SIGSEGV。去掉 --headless（默认/非 TTY 会自动开窗）或显式 --gui。"
+            )
 
         bin_path = (
             godot_bin

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -274,7 +274,7 @@ Or `{"steps": [...]}` wrapper form is also accepted. Steps run strictly serially
 The daemon can drive Godot's [Movie Maker](https://docs.godotengine.org/en/stable/tutorials/animation/creating_movies.html) (`--write-movie`) so input you script through this skill is captured to disk. Pipeline: Godot writes raw `.avi`, `daemon stop` shells out to `ffmpeg` to transcode that into `.mp4` next to the original.
 
 ```bash
-godot-cli-control daemon start --record --movie-path out.avi --headless --fps 60
+godot-cli-control daemon start --record --movie-path out.avi --fps 60
 godot-cli-control click /root/Main/StartButton
 godot-cli-control tap jump 0.3
 godot-cli-control daemon stop          # → produces out.mp4
@@ -283,6 +283,7 @@ godot-cli-control daemon stop          # → produces out.mp4
 Key constraints:
 
 - `--record` **requires** `--movie-path` (daemon refuses to start otherwise).
+- `--record` needs a **real renderer**, so it cannot run with `--headless`: Godot Movie Maker's `add_frame()` reads the viewport texture, which the headless dummy renderer leaves null → SIGSEGV on the first frame. The daemon therefore **rejects `--record --headless` with exit code 2** before launching Godot. You don't need to pass `--gui`: when `--record` is set the daemon auto-opens a window even in a non-TTY (subagent / pipe / CI) shell that would otherwise default to headless.
 - The `.mp4` is produced **only when `daemon stop` runs**; `kill -9` leaves the raw `.avi` behind.
 - `ffmpeg` must be on `PATH` for transcoding. If transcoding fails, the raw `.avi` is kept and `daemon stop` exits with code `2` (transcode log at `.cli_control/ffmpeg.log`).
 - `--fps` controls the **fixed simulation framerate** Godot runs at while recording — set it to your target video framerate.

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1258,6 +1258,47 @@ def test_daemon_start_text_mode_keeps_silent_success(
     assert capsys.readouterr().out == ""
 
 
+def test_daemon_start_rejects_record_with_explicit_headless(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``daemon start --record --movie-path x --headless`` → ok:false 信封 +
+    EXIT_INFRA_ERROR(2)，且 message 点名 headless（CultivationWorld #180）。
+
+    显式 --headless 经 _resolve_headless 仍是 True，被 daemon.start 的 preflight
+    拒绝。find_godot_binary mock 成 None 确保 RED 时不会真去 spawn Godot。"""
+    import json as _json
+
+    (tmp_path / "project.godot").write_text("", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: None
+    )
+
+    from godot_cli_control.cli import (
+        EXIT_INFRA_ERROR,
+        OUTPUT_JSON,
+        cmd_daemon_start,
+    )
+
+    ns = __import__("argparse").Namespace(
+        record=True,
+        movie_path=str(tmp_path / "demo.avi"),
+        headless=True,
+        gui=False,
+        fps=30,
+        port=0,
+        idle_timeout="0",
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_daemon_start(ns)
+    assert rc == EXIT_INFRA_ERROR
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload["ok"] is False
+    assert "headless" in payload["error"]["message"]
+
+
 def test_daemon_stop_emits_json_envelope(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -1795,6 +1836,30 @@ class TestDaemonHeadlessAutodetect:
         monkeypatch.setattr("sys.stdout.isatty", lambda: False)
         ns = type("NS", (), {"headless": True, "gui": False})()
         assert _resolve_headless(ns, force_gui_hint=True) is True
+
+    def test_record_flips_pipe_to_gui(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--record 没显式 --headless 时强制开窗 —— Movie Maker 需真实渲染器，
+        headless dummy renderer 拿不到 viewport texture 会 SIGSEGV
+        （CultivationWorld #180，同 screenshot/#65）。非 TTY 默认 headless
+        的 subagent/pipe/CI 场景下，--record 也应自动翻成 GUI。"""
+        from godot_cli_control.cli import _resolve_headless
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        ns = type("NS", (), {"headless": False, "gui": False, "record": True})()
+        assert _resolve_headless(ns) is False
+
+    def test_explicit_headless_wins_over_record_flip(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """显式 --headless + --record 仍返回 True —— 不静默改写用户意图，
+        而是把矛盾交给 daemon.start 的 preflight 拒绝（给明确用法错）。"""
+        from godot_cli_control.cli import _resolve_headless
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        ns = type("NS", (), {"headless": True, "gui": False, "record": True})()
+        assert _resolve_headless(ns) is True
 
 
 class TestScriptLikelyUsesScreenshot:

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -80,6 +80,26 @@ def test_start_rejects_record_without_movie_path(tmp_path: Path) -> None:
         daemon.start(record=True, movie_path=None)
 
 
+def test_start_rejects_record_with_headless(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """record + headless 必须在 spawn 前拒绝。
+
+    Godot Movie Maker 在 headless dummy renderer 下拿不到 viewport texture，
+    add_frame() 收到 null 纹理直接 SIGSEGV（CultivationWorld #180，同 #65 截图）。
+    这是用法矛盾 —— preflight 报错，别让 Godot 段错误吓人。检查必须在 Godot
+    binary 查找/spawn 之前，所以即使 find_godot_binary 被 mock 成 None 也应先命中
+    headless 报错。"""
+    _touch_godot_project(tmp_path)
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: None
+    )
+    daemon = Daemon(tmp_path)
+    movie = tmp_path / "rec.avi"
+    with pytest.raises(DaemonError, match="headless"):
+        daemon.start(record=True, movie_path=str(movie), headless=True)
+
+
 def test_start_rejects_when_godot_bin_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## 背景

下游 CultivationWorld#180 报告：`godot-cli-control run --record --movie-path ... --headless --fps 30 <script>` 启动到 Movie Maker 首帧即崩，日志 `ERROR: Parameter "t" is null.` → `MovieWriter::add_frame()` signal 11。

## 根因

Godot Movie Maker 的 `add_frame()` 读 viewport texture，`--headless` 下用 dummy renderer 拿不到纹理 → null → SIGSEGV。这与 #65（headless 截图 1006）同源。而本工具：

- `daemon.py:start` 把 `--headless` 与 `--write-movie` **各自**拼进命令行，**无互斥**——`--record --headless` 一起传就生成会崩的组合。
- `cli.py:_resolve_headless` 之前只为 screenshot(#65) 翻转 GUI，**没管 record**，非 TTY（subagent/pipe/CI）默认 headless 时 `--record` 必崩。
- SKILL.md 模板 / README **反而推荐**了 `--headless --record` 这个会崩的组合。

## 改动

**行为（双保险）**
- `_resolve_headless` 加 record 分支：没显式 `--headless` 时自动翻 GUI（subagent/pipe/CI 下 `--record` 直接可用）。
- `daemon.start` 加 preflight：显式 `--headless`+`--record` 在 spawn 前抛 `DaemonError` → 退出码 2，给明确用法错而非段错误；同时兜住绕过 CLI 直接调 `daemon.start` 的调用方。

**文档**
- SKILL.md 模板录屏示例去掉 `--headless` + 补 constraint（说明会被拒、record 自动开窗）。
- README synopsis 把 record 与 headless 拆开。
- `--record` / `--headless` 的 argparse help 注明互斥。

## 测试

- `test_daemon.py`：`daemon.start(record, headless)` 抛 DaemonError。
- `test_cli.py`：`_resolve_headless` record 自动翻 GUI、显式 headless 优先（交给 preflight 拒绝）、CLI `daemon start --record --headless` → 退出码 2 + ok:false 信封且 message 点名 headless。
- 全量：342 passed / 4 skipped / 覆盖率 94%，未碰坏现存测试；`format_full_help()` 渲染 exit=0。

## 注意（跨仓库）

下游 CultivationWorld 的 `.codex/.../SKILL.md` 是 `init` 渲染的副本，需本仓**发新版 + 下游重跑 `init`** 才会吃到文档修复；代码层面下游升级新版 CLI 后即不再崩。

## 关联

- Fixes 下游 CultivationWorld#180（待发版 + 下游升级后生效）
- 收尾 issue #78：补真实录屏 e2e smoke（当前录屏仅 mock 级覆盖）
- 同源：#65（headless 截图）

🤖 Generated with [Claude Code](https://claude.com/claude-code)