### PR TITLE
chore: AI 友好性体检收尾（契约/e2e/deprecation/文档/lint）

### DIFF
--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -104,6 +104,8 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 | `get_pressed()` | `await client.get_pressed()` |
 | `list_input_actions(include_builtin=False)` | `await client.list_input_actions()` |
 
+> **CLI note**: as a shell subcommand, `screenshot` **requires an output path** — `godot-cli-control screenshot /tmp/shot.png` — and writes the PNG to that file. Returning base64 over stdout is intentionally unsupported, to keep large binary payloads out of an automating agent's context window.
+
 ### Error codes
 
 Three numeric ranges share `error.code`; they never overlap, so a single field is unambiguous.
@@ -112,7 +114,7 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 |---|---|---|
 | `1001` | server | Node not found at the given path |
 | `1002` | server | Property not found / shape mismatch |
-| `1003` | server | Method not found on the node (schema error, don't retry) |
+| `1003` | server | Method not found on the node, **or** unknown InputMap action passed to `press`/`release`/`tap`/`hold`/`combo` (`"Unknown action: <name>"`). Schema error — don't retry; run `actions` (or `actions --all`) to list valid actions |
 | `1004` | server | Combo already in progress (call `combo-cancel` to retry) |
 | `1005` | server | Scene tree too large (lower `depth` or pass `--max-nodes`) |
 | `1006` | server | Resource transiently unavailable (e.g. screenshot during scene transition). Rare under normal use — GameBridge waits for viewport first-frame before listening, and `screenshot` retries internally. Safe to retry if you do hit it. |
@@ -127,6 +129,31 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `-1099` | client | Internal CLI bug — please file an issue |
 
 For full retry guidance see the SKILL.md shipped by `godot-cli-control init` (`.claude/skills/godot-cli-control/SKILL.md` in the target project).
+
+## Daemon commands
+
+The daemon is the long-lived Godot process the CLI talks to (one per project root). The CLI auto-starts it where needed; manage it explicitly with:
+
+| Command | What it does |
+|---|---|
+| `daemon start [--headless\|--gui] [--record]` | Launch Godot with the bridge listening. Headless vs GUI is auto-detected from the TTY; `--record` forces GUI (Movie Maker needs a real renderer) and is **rejected with `--headless`** (exit 2). |
+| `daemon stop` | Stop this project's daemon. Exit 2 if it stopped cleanly but the `.avi`→`.mp4` ffmpeg transcode failed (raw `.avi` kept; see `.cli_control/ffmpeg.log`). |
+| `daemon stop --all` | Stop every registered daemon across all projects. **Exit 3** if at least one failed; per-record `rc` (and an `error` field on failures) is in `result.stopped[]`. |
+| `daemon stop --project <path>` | Stop the daemon for one specific project root. |
+| `daemon status` | Exit 0 = running, 1 = stopped. When stopped, the payload may carry `last_log` / `last_exit_code` to diagnose a crash. |
+| `daemon ls` | List every registered daemon (project root, pid, port). |
+
+## Exit codes
+
+Semantic exit codes so `if godot-cli-control exists /root/Foo; then …` works in shell:
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (or boolean true for `exists` / `visible`, node found for `wait-node`) |
+| 1 | RPC error; also `exists`/`visible`=false, `wait-node` timeout, `daemon status`=stopped |
+| 2 | Connection / IO error, or `daemon stop` ffmpeg-transcode failure |
+| 3 | `daemon stop --all` partial failure (≥1 daemon failed to stop) |
+| 64 | Usage error — bad argparse args, or a pre-flight reject like `combo` with no steps / malformed `--steps-json` (envelope carries client code `-1003`) |
 
 ## Activation Modes
 
@@ -151,7 +178,7 @@ If none triggered, the plugin prints `[Godot CLI Control] inactive — ...` to c
 ## Known Limitations
 
 1. **Headless + Movie Maker is broken** (Godot upstream): `--write-movie` produces empty MP4 in headless mode (no framebuffer). Use GUI mode for recording.
-2. **Godot binary detection** falls back to `GODOT_BIN` env var. `init` writes `.cli_control/godot_bin` after autodetect; daemon reads that file before scanning. Detection covers macOS `/Applications/Godot*.app`, `PATH` (`godot`/`godot4`), and Windows `Program Files\Godot*`.
+2. **Godot binary detection** order: `GODOT_BIN` env var → macOS `/Applications/Godot*.app` → `PATH` (`godot4`/`godot`) → Windows `Program Files\Godot*`. `init` writes the detected path to `.cli_control/godot_bin`; the daemon reads that file before re-scanning. The pytest e2e suite uses this same detection, so a `godot` on `PATH` is enough to run it.
 3. **Python ≥ 3.10** required (websockets>=14 dependency).
 4. **Single-client mode**: only one WebSocket client at a time; second connection rejected.
 5. **Headless plugin auto-register**: in headless mode, `--editor --quit` may not trigger `plugin._enter_tree` to write the autoload. `init` handles this automatically by patching `project.godot` directly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,12 @@ godot-cli-control = "godot_cli_control.cli:main"
 godot-cli-control = "godot_cli_control.pytest_plugin"
 
 [tool.pytest.ini_options]
+# pytest-asyncio：显式钉死 async fixture 的 loop scope 为 function（= 未来版本默认值），
+# 消除 "asyncio_default_fixture_loop_scope is unset" 的 deprecation warning。改这行前
+# 先确认没有 module/session-scope 的 async fixture 依赖跨用例共享 loop。
+asyncio_default_fixture_loop_scope = "function"
 # gui：需要真实显示（开窗）才能跑的端到端测试。普通 unit / headless e2e 不带此
-# marker。本地默认随 GODOT_BIN / GCC_GUI_E2E 未设而 skip；CI 专档（Linux 套
+# marker。本地默认随 godot 检测 / GCC_GUI_E2E 未设而 skip；CI 专档（Linux 套
 # xvfb 或 macOS runner）设 GCC_GUI_E2E=1 开启。注册在此避免 unknown-marker 警告，
 # 也让 `pytest -m "not gui"` 能稳定剔除。
 markers = [

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -44,9 +44,9 @@ godot-cli-control daemon stop
 |---|---|
 | 0 | Success (or, for `exists` / `visible` / `wait-node`, the boolean was true / found) |
 | 1 | RPC error (server returned `{"error":...}`); also `exists`/`visible`=false, `wait-node`=timeout, `daemon status`=stopped |
-| 2 | Connection / IO / usage error (daemon not running, malformed `combo` input, script path not found). Also: **`daemon stop` returns 2** when the daemon stopped cleanly but `ffmpeg` transcode of the recorded `.avi`→`.mp4` failed — the raw `.avi` is kept and `.cli_control/ffmpeg.log` has the details. `run <script>` propagates this: a successful script + failed transcode still exits 2. |
+| 2 | Connection / IO / usage error (daemon not running, script path not found). Also: **`daemon stop` returns 2** when the daemon stopped cleanly but `ffmpeg` transcode of the recorded `.avi`→`.mp4` failed — the raw `.avi` is kept and `.cli_control/ffmpeg.log` has the details. `run <script>` propagates this: a successful script + failed transcode still exits 2. |
 | 3 | `daemon stop --all` partial failure: at least one daemon in the registry failed to stop. Per-record `rc` is in the JSON `result.stopped[]`. |
-| 64 | Argparse usage error |
+| 64 | Argparse usage error, **or a pre-flight usage error caught before connecting** — e.g. `combo` with no steps / malformed `--steps-json` / `combo -` from a TTY, or `hold` with a non-positive duration. The error envelope carries client code `-1003`. |
 
 Shell-`if` works:
 

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -398,7 +398,7 @@ def test_exec_user_script_json_redirects_script_stdout_to_stderr(
     rc = _exec_user_script(script, port=9999, output_format="json")
     captured = capsys.readouterr()
     assert rc == 0
-    out_lines = [l for l in captured.out.splitlines() if l.strip()]
+    out_lines = [line for line in captured.out.splitlines() if line.strip()]
     assert len(out_lines) == 1, f"stdout 不是单行 envelope：{captured.out!r}"
     payload = _json.loads(out_lines[0])
     assert payload["ok"] is True
@@ -425,7 +425,7 @@ def test_exec_user_script_json_error_on_runtime_exception(
     rc = _exec_user_script(script, port=9999, output_format="json")
     captured = capsys.readouterr()
     assert rc == 1
-    out_lines = [l for l in captured.out.splitlines() if l.strip()]
+    out_lines = [line for line in captured.out.splitlines() if line.strip()]
     assert len(out_lines) == 1
     payload = _json.loads(out_lines[0])
     assert payload["ok"] is False
@@ -571,7 +571,7 @@ def test_exec_user_script_json_top_level_print_does_not_leak(
     rc = _exec_user_script(script, port=9999, output_format="json")
     captured = capsys.readouterr()
     assert rc == 0
-    out_lines = [l for l in captured.out.splitlines() if l.strip()]
+    out_lines = [line for line in captured.out.splitlines() if line.strip()]
     assert len(out_lines) == 1, (
         f"stdout 不是单行 envelope（顶层 print 漏了？）：{captured.out!r}"
     )
@@ -1119,7 +1119,7 @@ def test_combo_preflight_rejects_no_steps_before_connecting(
     避免 agent 等 30s 连接 retry 才看到错误。"""
     import json as _json
 
-    from godot_cli_control.cli import EXIT_USAGE, build_parser, main
+    from godot_cli_control.cli import EXIT_USAGE, main
 
     # 把 GameClient 替成会爆的桩 —— 如果 preflight 没生效、跑到连接环节就立刻看见。
     class _ShouldNotConnect:
@@ -1188,7 +1188,7 @@ def test_combo_preflight_caches_steps_to_avoid_stdin_double_read(
     """stdin 流不能读两次：preflight 必须把解析结果缓存到 ns，handler 复用。"""
     import io
 
-    from godot_cli_control.cli import _preflight_combo, _read_combo_steps, build_parser
+    from godot_cli_control.cli import _preflight_combo, build_parser
 
     monkeypatch.setattr(sys, "stdin", io.StringIO('[{"action":"jump"}]'))
     ns = build_parser().parse_args(["combo", "-"])
@@ -1559,7 +1559,8 @@ def test_daemon_ls_lists_active_daemon(
     import os
     from godot_cli_control import registry
     monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
-    proj = tmp_path / "p"; proj.mkdir()
+    proj = tmp_path / "p"
+    proj.mkdir()
     registry.register(
         proj, pid=os.getpid(), port=12345, godot_bin="x", log_path="y"
     )
@@ -1592,8 +1593,10 @@ def test_daemon_stop_all_invokes_terminate(
     from godot_cli_control import registry
     monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
 
-    proj1 = tmp_path / "a"; proj1.mkdir()
-    proj2 = tmp_path / "b"; proj2.mkdir()
+    proj1 = tmp_path / "a"
+    proj1.mkdir()
+    proj2 = tmp_path / "b"
+    proj2.mkdir()
     import os
     registry.register(proj1, pid=os.getpid(), port=1, godot_bin="x", log_path="y")
     registry.register(proj2, pid=os.getpid(), port=2, godot_bin="x", log_path="y")
@@ -1621,8 +1624,10 @@ def test_daemon_stop_all_returns_partial_when_one_fails(
     from godot_cli_control.daemon import DaemonError
     monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
 
-    proj1 = tmp_path / "ok"; proj1.mkdir()
-    proj2 = tmp_path / "bad"; proj2.mkdir()
+    proj1 = tmp_path / "ok"
+    proj1.mkdir()
+    proj2 = tmp_path / "bad"
+    proj2.mkdir()
     import os
     registry.register(proj1, pid=os.getpid(), port=1, godot_bin="x", log_path="y")
     registry.register(proj2, pid=os.getpid(), port=2, godot_bin="x", log_path="y")
@@ -1648,7 +1653,8 @@ def test_daemon_stop_all_ffmpeg_rc2_does_not_promote_to_partial(
     """单条 stop 返回 2（ffmpeg 转码失败但 daemon 已停）不算 --all 失败 —— rc 应为 0。"""
     from godot_cli_control import registry
     monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "reg")
-    proj = tmp_path / "p"; proj.mkdir()
+    proj = tmp_path / "p"
+    proj.mkdir()
     import os
     registry.register(proj, pid=os.getpid(), port=1, godot_bin="x", log_path="y")
 
@@ -1666,7 +1672,8 @@ def test_daemon_stop_project_flag(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """--project <path> 应对该项目调 Daemon(...).stop()，与 cwd 无关。"""
-    target = tmp_path / "p"; target.mkdir()
+    target = tmp_path / "p"
+    target.mkdir()
     seen: list[Path] = []
     import godot_cli_control.daemon as daemon_mod
     monkeypatch.setattr(daemon_mod.Daemon, "stop",

--- a/python/tests/test_cli_helpers.py
+++ b/python/tests/test_cli_helpers.py
@@ -15,7 +15,6 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock
 
-import pytest
 
 from godot_cli_control import cli
 

--- a/python/tests/test_e2e_input.py
+++ b/python/tests/test_e2e_input.py
@@ -10,13 +10,12 @@
   2. sticky ``press`` 跨命令存活，直到 ``release-all``。
   3. 异常掉线（无 WebSocket close frame，close_code == -1）触发 release_all 兜底。
 
-需要真实 Godot 4：设置 ``GODOT_BIN`` 指向可执行文件，否则整文件 skip。
+需要真实 Godot 4：PATH 里有 ``godot``（或设 ``GODOT_BIN``），否则整文件 skip。
 """
 
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -26,12 +25,16 @@ from typing import Any
 
 import pytest
 
-_GODOT_BIN = os.environ.get("GODOT_BIN")
+from godot_cli_control.daemon import find_godot_binary
+
+# 与生产 daemon 用同一套 godot 检测（GODOT_BIN > macOS .app > PATH > Windows），
+# 不再硬依赖 GODOT_BIN env：本机装了 godot 即自动跑这条 e2e。
+_GODOT_BIN = find_godot_binary()
 _ADDON_SRC = Path(__file__).resolve().parents[2] / "addons" / "godot_cli_control"
 
 pytestmark = pytest.mark.skipif(
-    not _GODOT_BIN or not Path(_GODOT_BIN).exists(),
-    reason="需要真实 Godot 4：设置 GODOT_BIN 指向可执行文件",
+    not _GODOT_BIN,
+    reason="需要真实 Godot 4：把 godot 装进 PATH 或设 GODOT_BIN，否则整文件 skip",
 )
 
 # 用 `python -m godot_cli_control` 调 CLI：与 PATH 无关，always 命中当前环境。

--- a/python/tests/test_e2e_screenshot_gui.py
+++ b/python/tests/test_e2e_screenshot_gui.py
@@ -13,7 +13,7 @@ screenshot 回归）的产物。
   3. 连续重复 N 次（覆盖动态 transient 兜底，验证不是只有第一帧侥幸成功）。
 
 需要真实 Godot 4 **且真实显示**：
-  - ``GODOT_BIN`` 指向可执行文件；
+  - PATH 里有 ``godot``（或设 ``GODOT_BIN``）；
   - ``GCC_GUI_E2E=1`` 显式开启（本地默认 skip —— 多数开发机 / 无头 CI 没显示，
     误跑会卡在开窗或拿不到 RenderingDevice）。CI 专档在 Linux 套 xvfb 或用
     macOS runner，并设 ``GCC_GUI_E2E=1``。
@@ -35,7 +35,11 @@ from typing import Any
 
 import pytest
 
-_GODOT_BIN = os.environ.get("GODOT_BIN")
+from godot_cli_control.daemon import find_godot_binary
+
+# 与生产 daemon 用同一套 godot 检测（GODOT_BIN > macOS .app > PATH > Windows），
+# 不再硬依赖 GODOT_BIN env。注意本文件还有第二层 GCC_GUI_E2E gate（需真实显示）。
+_GODOT_BIN = find_godot_binary()
 _ADDON_SRC = Path(__file__).resolve().parents[2] / "addons" / "godot_cli_control"
 
 # RESOURCE_UNAVAILABLE：screenshot 时 viewport texture 暂不可用的 transient 码。
@@ -48,8 +52,8 @@ _REPEAT = 5
 pytestmark = [
     pytest.mark.gui,
     pytest.mark.skipif(
-        not _GODOT_BIN or not Path(_GODOT_BIN).exists(),
-        reason="需要真实 Godot 4：设置 GODOT_BIN 指向可执行文件",
+        not _GODOT_BIN,
+        reason="需要真实 Godot 4：把 godot 装进 PATH 或设 GODOT_BIN",
     ),
     pytest.mark.skipif(
         os.environ.get("GCC_GUI_E2E") != "1",

--- a/python/tests/test_pytest_plugin.py
+++ b/python/tests/test_pytest_plugin.py
@@ -11,6 +11,21 @@ import pytest
 pytest_plugins = ["pytester"]
 
 
+@pytest.fixture(autouse=True)
+def _pin_asyncio_loop_scope(pytester: pytest.Pytester) -> None:
+    """pytester 子实例不继承主 pyproject 的 ``[tool.pytest.ini_options]``，而
+    pytest-asyncio 是已安装插件，每次子 ``runpytest`` 都会因
+    ``asyncio_default_fixture_loop_scope`` 未设发 deprecation warning（同进程下冒泡到
+    主 summary）。这些子测试只验证同步 fixture，给每个临时项目写一份最小 ini 钉死该值，
+    消除噪音；与主 pyproject 的同名配置保持一致。"""
+    pytester.makeini(
+        """
+        [pytest]
+        asyncio_default_fixture_loop_scope = function
+        """
+    )
+
+
 def test_options_registered_in_help(pytester: pytest.Pytester) -> None:
     """--help 输出含我们的 CLI 选项 group。"""
     result = pytester.runpytest("--help")

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -44,7 +44,8 @@ def test_register_creates_record(reg_dir: Path, tmp_path: Path) -> None:
 
 
 def test_unregister_removes_record(reg_dir: Path, tmp_path: Path) -> None:
-    proj = tmp_path / "p1"; proj.mkdir()
+    proj = tmp_path / "p1"
+    proj.mkdir()
     registry.register(proj, pid=os.getpid(), port=1, godot_bin="x", log_path="x")
     registry.unregister(proj)
     assert registry.list_all() == []
@@ -53,7 +54,8 @@ def test_unregister_removes_record(reg_dir: Path, tmp_path: Path) -> None:
 def test_list_all_prunes_dead_pids(
     reg_dir: Path, tmp_path: Path, dead_pid: int
 ) -> None:
-    proj = tmp_path / "p1"; proj.mkdir()
+    proj = tmp_path / "p1"
+    proj.mkdir()
     # 用一个已 reap 的子进程 PID —— 100% 死、跨平台稳
     registry.register(proj, pid=dead_pid, port=1, godot_bin="x", log_path="x")
     assert registry.list_all() == []  # 探活后死记录被清掉
@@ -64,7 +66,8 @@ def test_list_all_prunes_dead_pids(
 def test_list_all_also_cleans_project_state_for_dead(
     reg_dir: Path, tmp_path: Path, dead_pid: int
 ) -> None:
-    proj = tmp_path / "p1"; proj.mkdir()
+    proj = tmp_path / "p1"
+    proj.mkdir()
     ctrl = proj / ".cli_control"
     ctrl.mkdir()
     (ctrl / "godot.pid").write_text(str(dead_pid))
@@ -77,7 +80,8 @@ def test_list_all_also_cleans_project_state_for_dead(
 
 
 def test_project_hash_stable(tmp_path: Path) -> None:
-    p = tmp_path / "p"; p.mkdir()
+    p = tmp_path / "p"
+    p.mkdir()
     h1 = registry.project_hash(p)
     h2 = registry.project_hash(p)
     assert h1 == h2 and len(h1) == 12

--- a/python/tests/test_runner.py
+++ b/python/tests/test_runner.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 

--- a/python/tests/test_skills_install.py
+++ b/python/tests/test_skills_install.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 
 
 # ── render_skill ──


### PR DESCRIPTION
## 背景

一次「项目有没有问题」的健康检查：整体很健康（测试 362 passed / 覆盖率 85% / 错误码无撞码 / SKILL.md 与 CLI 同步良好），问题集中在文档与实现的细微漂移。本 PR 修掉发现的项，无法当场修的开成 issue（#81–#84）。

## 改动

**🟠 契约 bug（唯一影响 AI agent 的）**
- `SKILL.md` 退出码表：combo/hold 用法错从误标的 exit 2 改正为 **64**（实际走 preflight→`EXIT_USAGE`，envelope 带 `-1003`），否则 agent 的 shell `if` 判断会错。

**e2e godot 检测（按需求：不再硬依赖 GODOT_BIN）**
- `test_e2e_input.py` / `test_e2e_screenshot_gui.py` 改用生产 daemon 同一套 `find_godot_binary()`（`GODOT_BIN` > macOS .app > PATH godot），装了 godot 即自动跑。验证：headless 的 `test_e2e_input` 从 skip 变 3/3 PASS；GUI 文件保留第二层 `GCC_GUI_E2E` gate。

**工程卫生**
- 消除 pytest-asyncio `asyncio_default_fixture_loop_scope` deprecation（主 run 配置 + pytester 子运行 autouse 注入），warning 10→0。
- addon `README.md` 补 4 处滞后：`daemon ls`、`daemon stop --all/--project`、退出码表（含 exit 3、combo→64）、screenshot CLI 用法、1003 的 unknown InputMap action 语义。
- `python/tests/` 19 条 ruff lint 清理（F401/E702/E741），纯风格零逻辑。

## 验证

362 passed / 1 skipped（GUI e2e 需 `GCC_GUI_E2E`）/ 0 failed；覆盖率 85%；ruff `All checks passed`；SKILL.md 渲染正常；init 注入测试全过。

## 关联遗留 issue

- #81 client.py 仍 68%（e2e 走 subprocess，coverage 不计子进程）
- #82 `-1003` 在 preflight=64 / `_run_rpc`=2 退出码歧义
- #83 ruff 纳入 pyproject+CI+dev 依赖
- #84 CI pytest job 装 godot 跑 headless e2e

## 取舍

e2e 的 godot 检测保留 `GODOT_BIN` 作最高优先级 override（fallback 到 PATH godot），而非完全无视——这样和生产 daemon 用同一函数（真端到端），且不破坏 CI 用 `GODOT_BIN` 选版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)