### PR TITLE
fix: 批量修复 10 个 issue（端口 auto-discover、退出码统一、--wait、ruff 门禁等）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,38 @@ on:
   workflow_dispatch:
 
 jobs:
+  # lint 门禁（issue #83）：规则集 + line-length 锁在 pyproject [tool.ruff]，CI 只负责
+  # 跑。独立 job 而非塞进 python-unit 矩阵——lint 与 OS/Python 版本无关，跑一次即可。
+  lint:
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install "ruff>=0.6"
+
+      - name: ruff check
+        run: ruff check .
+
   python-unit:
     name: pytest (Python ${{ matrix.python-version }} / ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      GODOT_VERSION: '4.6.2-stable'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
         include:
-          # 跨平台 daemon / pathing 验证：Windows + macOS 跑一份 3.12 即可，
+          # 跨平台 daemon / pathing 验证：Windows + macOS 跑一份 3.12 即可,
           # 不再扩成全 python × 全 os 的 12 格 matrix。
           - os: windows-latest
             python-version: '3.12'
@@ -38,6 +60,38 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[test]"
+
+      # ---- Godot for headless e2e (issue #84) -----------------------------
+      # 仅 ubuntu+3.12（覆盖率门禁所在格）下装 Godot，让 headless e2e
+      # （test_e2e_input / test_e2e_example / test_e2e_client_direct）在 CI 真跑
+      # 并计入覆盖率。装了 godot ⇒ find_godot_binary() 命中 ⇒ 这些文件不再 skip。
+      # 其余 python 版本格仍走纯 unit（无 GODOT_BIN ⇒ e2e 自动 skip），不重复下载。
+      # 复用 walkthrough job 的下载逻辑；headless 不需要 display，普通 runner 即可。
+      - name: Cache Godot (Linux, e2e)
+        id: godot-cache-e2e
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: actions/cache@v5
+        with:
+          path: ~/godot-bin
+          key: godot-${{ env.GODOT_VERSION }}-linux-x86_64
+
+      - name: Download Godot (Linux, e2e)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && steps.godot-cache-e2e.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/godot-bin
+          VER="${GODOT_VERSION}"
+          URL="https://github.com/godotengine/godot/releases/download/${VER}/Godot_v${VER}_linux.x86_64.zip"
+          echo "Downloading $URL"
+          curl -fsSL -o /tmp/godot.zip "$URL"
+          unzip -q /tmp/godot.zip -d ~/godot-bin
+          mv ~/godot-bin/Godot_v${VER}_linux.x86_64 ~/godot-bin/godot
+          chmod +x ~/godot-bin/godot
+
+      - name: Expose GODOT_BIN for e2e (Linux)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        run: |
+          ~/godot-bin/godot --version
+          echo "GODOT_BIN=$HOME/godot-bin/godot" >> "$GITHUB_ENV"
 
       # 用 `coverage run` 而非 `pytest --cov`：pytest 启动时
       # pytest11 entry-point 会自动加载 godot_cli_control.pytest_plugin，
@@ -266,3 +320,14 @@ jobs:
       # 属性名一旦回归，这一步立刻红 —— 仓库自带 demo 不许悄悄腐烂。
       - name: Run example demo e2e (headless)
         run: python -m pytest python/tests/test_e2e_example.py -v
+
+      # 录屏 e2e（#78）：本 job 是唯一同时备齐「真实显示 + GODOT_BIN + ffmpeg」的格，
+      # 录制必须开窗（headless dummy renderer 写帧 SIGSEGV，正是 #180 根因），
+      # 所以只能在这里跑。先确保 ffmpeg/ffprobe 在 PATH（缺则 test 自身 skip 并打印原因）。
+      - name: Ensure ffmpeg (macOS)
+        run: ffmpeg -version >/dev/null 2>&1 && ffprobe -version >/dev/null 2>&1 || brew install ffmpeg
+
+      - name: Run record e2e (windowed --record → mp4)
+        env:
+          GCC_GUI_E2E: '1'
+        run: python -m pytest python/tests/test_e2e_record.py -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,8 @@
 3. **退出码语义化**
    - 0 = 成功 / 布尔 true / 节点存在 / wait 命中
    - 1 = RPC 错（含 `exists`/`visible`=false、`wait-node` timeout、`daemon status` stopped）
-   - 2 = 连接 / IO / 用法错（agent 应该 retry 或修参数，而不是把它当 RPC 失败）
-   - 64 = argparse 用法错
+   - 2 = 连接 / IO 错，或 `run`/`daemon` 前置失败（脚本路径不存在、daemon 起不来；这些仍带 `-1003`）
+   - 64 = 用法错：argparse + RPC 子命令的 preflight / 运行期参数解析失败，统一携带 `-1003`（issue #82：RPC 子命令的 `-1003` 恒等于 64，不再有 2/64 歧义）
    - 3 = `daemon stop --all` 部分失败（专用，避免与 2 撞）
    - shell `if godot-cli-control exists /root/Foo; then …` 必须能用。
 

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -106,6 +106,10 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 
 > **CLI note**: as a shell subcommand, `screenshot` **requires an output path** — `godot-cli-control screenshot /tmp/shot.png` — and writes the PNG to that file. Returning base64 over stdout is intentionally unsupported, to keep large binary payloads out of an automating agent's context window.
 
+> **`--wait`**: `tap` / `hold` / `combo` return as soon as the input is armed, *before* the motion finishes. Add `--wait` (e.g. `hold run 1.5 --wait`) to block until the action's duration elapses (game-time) so the next read sees the settled state — equivalent to following the command with `wait-time <duration>` on the same connection.
+
+> **No-arg `GameClient()` / `GameBridge()`**: with no `port` argument they auto-discover the daemon's port from `.cli_control/port` (falling back to `9877`), so a single-connection script connects to a running daemon without hardcoding a port.
+
 ### Error codes
 
 Three numeric ranges share `error.code`; they never overlap, so a single field is unambiguous.
@@ -123,7 +127,7 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements, or `hold` given `duration ≤ 0` — use `press` for an indefinite hold) |
 | `-1001` | client | Connection failure (daemon not running, port wrong, proxy hijacking localhost) |
 | `-1002` | client | Timeout waiting for response |
-| `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, …) |
+| `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, a non-numeric `tap`/`wait-time` arg, a `set`/`call` value that fails JSON parsing, …). From an RPC subcommand this always exits **64** (#82); top-level `run`/`daemon` precondition failures also use `-1003` but exit 2. |
 | `-1004` | client | Local file IO error (e.g. screenshot can't write the destination) |
 | `-1005` | client | `run <script>` user script raised an uncaught exception — fix the script |
 | `-1099` | client | Internal CLI bug — please file an issue |
@@ -143,6 +147,8 @@ The daemon is the long-lived Godot process the CLI talks to (one per project roo
 | `daemon status` | Exit 0 = running, 1 = stopped. When stopped, the payload may carry `last_log` / `last_exit_code` to diagnose a crash. |
 | `daemon ls` | List every registered daemon (project root, pid, port). |
 
+**Project-level defaults**: drop a `.cli_control/config.json` with `{"idle_timeout": "30m"}` to give `daemon start` / `run` a default idle-timeout without passing `--idle-timeout` each time. It's consulted only when the flag is omitted (default `0`); an explicit `--idle-timeout` always wins. A long-running `wait-time` / `combo` / recording is bounded client-side by a 600s wall-time fail-safe — override it for legitimately long operations with `GODOT_CLI_LONG_OP_TIMEOUT=<seconds>`.
+
 ## Exit codes
 
 Semantic exit codes so `if godot-cli-control exists /root/Foo; then …` works in shell:
@@ -153,7 +159,7 @@ Semantic exit codes so `if godot-cli-control exists /root/Foo; then …` works i
 | 1 | RPC error; also `exists`/`visible`=false, `wait-node` timeout, `daemon status`=stopped |
 | 2 | Connection / IO error, or `daemon stop` ffmpeg-transcode failure |
 | 3 | `daemon stop --all` partial failure (≥1 daemon failed to stop) |
-| 64 | Usage error — bad argparse args, or a pre-flight reject like `combo` with no steps / malformed `--steps-json` (envelope carries client code `-1003`) |
+| 64 | Usage error on an RPC subcommand — bad argparse args, a pre-flight reject (`combo` with no steps / malformed `--steps-json`), a non-numeric `tap`/`wait-time` arg, or a `set`/`call` value that fails JSON parsing. These all carry client code `-1003` and now consistently exit 64 (#82; a few previously exited 2). |
 
 ## Activation Modes
 

--- a/examples/platformer-demo/.gitignore
+++ b/examples/platformer-demo/.gitignore
@@ -8,5 +8,15 @@
 # godot-cli-control daemon runtime (PID + port files).
 /.cli_control/
 
+# Skill files written by `godot-cli-control init` into the consuming project.
+/.claude/
+/.codex/
+
+# Godot per-script UID sidecars, generated on first import. The repo-root addons/
+# commits its .uid (stable cross-references matter there); this demo ships
+# deliberately un-imported (run `init` to materialize), so its script UIDs are
+# per-machine import artifacts — don't commit them.
+*.gd.uid
+
 # Screenshots produced by drive.sh.
 *.png

--- a/examples/platformer-demo/drive.sh
+++ b/examples/platformer-demo/drive.sh
@@ -12,8 +12,12 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 # 0) One-time: install the control surface into this project (copies the addon,
-#    patches project.godot, detects the Godot binary). addons/, .godot/ and
-#    .cli_control/ are all gitignored, so this never dirties the repo. Idempotent.
+#    patches project.godot to wire the autoload + plugin, detects the Godot
+#    binary, writes .claude/.codex skill files). Idempotent. The vendored copies
+#    — addons/, .godot/, .cli_control/, .claude/, .codex/, *.gd.uid — are all
+#    gitignored. project.godot IS tracked and this demo ships without the bridge
+#    sections (left for init), so the one change `git status` shows after a run is
+#    that patch; `git checkout examples/platformer-demo/project.godot` reverts it.
 godot-cli-control init
 
 # 1) Start the daemon with a window (GUI mode — screenshots need a real renderer).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ dependencies = [
 
 [project.optional-dependencies]
 pytest = ["pytest>=7"]
-# 全套测试依赖 —— 仅 CI / 开发者本地测试用，包含 pytest-cov 与 pytest-asyncio。
-# 普通用户用 `[pytest]` 已够；不要把 cov 拖到默认安装路径。
-test = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov>=4"]
+# 全套测试依赖 —— 仅 CI / 开发者本地测试用，包含 pytest-cov、pytest-asyncio 与
+# ruff（lint 门禁，issue #83）。普通用户用 `[pytest]` 已够；不要把这些拖到默认安装路径。
+test = ["pytest>=7", "pytest-asyncio>=0.21", "pytest-cov>=4", "ruff>=0.6"]
 
 [project.scripts]
 godot-cli-control = "godot_cli_control.cli:main"
@@ -34,6 +34,21 @@ asyncio_default_fixture_loop_scope = "function"
 markers = [
     "gui: 需要真实显示的 windowed e2e（screenshot frame_post_draw 路径，issue #64）",
 ]
+
+# ── lint（ruff）─────────────────────────────────────────────────────────
+# issue #83：把 lint 从「开发者本机全局 ruff」收编成 CI 门禁 + dev 依赖，趁全仓
+# 基线为 0 锁定收益。规则集刻意只钉 ruff 默认的 pyflakes(F) + pycodestyle 子集
+# (E4/E7/E9)——这正是当前 0-error 基线对应的集合；扩到 E501/I/UP/B 会一次性炸出
+# 几十条历史报错，与「锁定基线、零噪音引入门禁」的目标相悖。要加规则请单开 PR、
+# 连同 autofix 一起 land，别让门禁第一天就红。line-length 仅供 `ruff format`
+# 参考（E501 未纳入 select，不构成门禁）。
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+extend-exclude = ["python/godot_cli_control/_version.py"]  # hatch-vcs 生成物
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -15,13 +15,16 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
-from .client import DEFAULT_PORT, GameClient
+from .client import GameClient
 
 
 class GameBridge:
     """同步接口，内部通过事件循环调用异步 GameClient。"""
 
-    def __init__(self, port: int = DEFAULT_PORT) -> None:
+    def __init__(self, port: int | None = None) -> None:
+        # port=None → GameClient 从 .cli_control/port auto-discover（issue #91）。
+        # daemon 默认 OS 自动分配端口，所以 ``GameBridge()`` 无参数也能连上正在
+        # 跑的 daemon，与 README 的单连接脚本示例一致。
         self._loop = asyncio.new_event_loop()
         self._client = GameClient(port=port)
         self._loop.run_until_complete(

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -243,6 +243,39 @@ def _read_combo_steps(ns: argparse.Namespace) -> list[dict]:
     return parsed
 
 
+def _combo_total_duration(steps: list[dict]) -> float:
+    """combo 全部 step 的累计 game-time（给 ``--wait`` 算阻塞时长，issue #90）。
+
+    step schema 与服务端一致：``{"action": ..., "duration": <默认 0.1>}`` 串行
+    按下/释放，``{"wait": <秒>}`` 纯等待。非数字 / 缺字段按默认 0.1 兜底，绝不
+    抛错——``--wait`` 是体验增强，估时偏差远好过让命令崩掉。
+    """
+    total = 0.0
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        raw = step.get("wait", step.get("duration", 0.1))
+        try:
+            total += float(raw)
+        except (TypeError, ValueError):
+            total += 0.1
+    return total
+
+
+async def _maybe_block_for_duration(
+    client: GameClient, ns: argparse.Namespace, duration: float
+) -> None:
+    """``--wait``：输入命令发出后，阻塞 ``duration`` 的 game-time 再返回（issue #90）。
+
+    把 SKILL.md 推荐的「读动作完成后状态前先 wait-time <时长>」折叠进同一条命令、
+    复用同一连接：需要同步的 agent 一步到位拿到结算后状态。默认（不传 ``--wait``）
+    保持异步立即返回，sticky + timer 模型不变。``wait_game_time`` 在 ≤0 时本就短路，
+    这里也提前挡掉，省一次 RPC 往返。
+    """
+    if getattr(ns, "wait", False) and duration > 0:
+        await client.wait_game_time(duration)
+
+
 # ── 现有 RPC 命令 handler（迁移到 ns 签名 + 返回数据） ──
 
 
@@ -279,11 +312,16 @@ async def cmd_release(client: GameClient, ns: argparse.Namespace) -> dict:
 
 async def cmd_tap(client: GameClient, ns: argparse.Namespace) -> dict:
     duration = float(ns.duration) if ns.duration else 0.1
-    return await client.action_tap(ns.action, duration)
+    result = await client.action_tap(ns.action, duration)
+    await _maybe_block_for_duration(client, ns, duration)
+    return result
 
 
 async def cmd_hold(client: GameClient, ns: argparse.Namespace) -> dict:
-    return await client.hold(ns.action, float(ns.duration))
+    duration = float(ns.duration)
+    result = await client.hold(ns.action, duration)
+    await _maybe_block_for_duration(client, ns, duration)
+    return result
 
 
 async def cmd_combo(client: GameClient, ns: argparse.Namespace) -> dict:
@@ -291,7 +329,9 @@ async def cmd_combo(client: GameClient, ns: argparse.Namespace) -> dict:
     steps = getattr(ns, "_combo_steps", None)
     if steps is None:
         steps = _read_combo_steps(ns)
-    return await client.combo(steps)
+    result = await client.combo(steps)
+    await _maybe_block_for_duration(client, ns, _combo_total_duration(steps))
+    return result
 
 
 async def cmd_release_all(client: GameClient, ns: argparse.Namespace) -> dict:
@@ -424,8 +464,18 @@ def _exit_from_wait_node(r: dict) -> int:
 # ── extra_args registrators ──
 
 
+def _register_wait_flag(p: argparse.ArgumentParser) -> None:
+    """``--wait``：输入命令阻塞到动作时长（game-time）结束再返回（issue #90）。"""
+    p.add_argument(
+        "--wait",
+        action="store_true",
+        help="阻塞到动作时长（game-time）结束再返回，再读状态即结算后值；"
+        "默认异步立即返回。等价于命令后再跑一次 wait-time <时长>，但复用同一连接。",
+    )
+
+
 def _register_combo_args(p: argparse.ArgumentParser) -> None:
-    """combo 的 args：``json_file`` 位置可选，加 ``--steps-json``。
+    """combo 的 args：``json_file`` 位置可选，加 ``--steps-json`` / ``--wait``。
     互斥校验在 ``_read_combo_steps`` 里做（argparse 里不能同时加 dest 冲突的
     位置参数和可选参数到 mutually_exclusive_group）。"""
     p.add_argument(
@@ -439,6 +489,7 @@ def _register_combo_args(p: argparse.ArgumentParser) -> None:
         default=None,
         help="直接传 JSON 字符串，不需要文件（与位置参数互斥）",
     )
+    _register_wait_flag(p)
 
 
 def _register_tree_args(p: argparse.ArgumentParser) -> None:
@@ -558,23 +609,25 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
     RpcSpec(
         name="tap",
         handler=cmd_tap,
-        description="短按动作（press → 等待 → release）。",
+        description="短按动作（press → 等待 → release）。默认异步立即返回；加 --wait 阻塞到时长结束。",
         positionals=(
             Positional("action", None, "InputMap 动作名"),
             Positional("duration", "?", "按下时长（秒），默认 0.1"),
         ),
         example="tap jump 0.2",
+        extra_args=_register_wait_flag,
         text_formatter=lambda r: f"tapped: {r}",
     ),
     RpcSpec(
         name="hold",
         handler=cmd_hold,
-        description="按住动作指定时长（秒），到点自动释放。",
+        description="按住动作指定时长（秒），到点自动释放。默认命令立即返回（动作在游戏里持续该时长）；要读动作完成后的状态请加 --wait（或命令后先 wait-time <时长>）。",
         positionals=(
             Positional("action", None, "InputMap 动作名"),
             Positional("duration", None, "按住时长（秒，必须 > 0）"),
         ),
         example="hold jump 1.5",
+        extra_args=_register_wait_flag,
         preflight=_preflight_hold,
         text_formatter=lambda r: f"holding: {r}",
     ),
@@ -762,12 +815,37 @@ RPC_BY_NAME: dict[str, RpcSpec] = {s.name: s for s in RPC_SPECS}
 # ── Daemon / run / init 子命令 ──
 
 
-def cmd_daemon_start(ns: argparse.Namespace) -> int:
-    from .daemon import Daemon, DaemonError
+def _resolve_idle_timeout(ns: argparse.Namespace) -> int:
+    """解析 idle-timeout 秒数：显式 ``--idle-timeout`` > 项目级 config > 0（关闭）。
+
+    issue #44：默认值 ``"0"`` 时回退读 ``.cli_control/config.json`` 的 ``idle_timeout``，
+    省得喜欢自动收尾的用户每次手敲 ``--idle-timeout``。config 也没设则仍是 0（关闭）。
+    注意：显式 ``--idle-timeout 0`` 与默认 ``"0"`` 不可区分，两者都会回退 config——
+    config 设了又想单次强制关闭，临时 `unset` 配置即可（YAGNI，未做 opt-out flag）。
+    非法 duration（CLI 或 config 任一）抛 ``ValueError``，由调用方转 EXIT_USAGE。
+    """
     from ._duration import parse_duration
 
+    raw = getattr(ns, "idle_timeout", "0")
+    if raw == "0":
+        from .daemon import read_project_config
+
+        cfg_val = read_project_config().get("idle_timeout")
+        if cfg_val is not None:
+            try:
+                return parse_duration(str(cfg_val))
+            except ValueError as e:
+                raise ValueError(
+                    f".cli_control/config.json 的 idle_timeout 非法：{e}"
+                ) from e
+    return parse_duration(raw)
+
+
+def cmd_daemon_start(ns: argparse.Namespace) -> int:
+    from .daemon import Daemon, DaemonError
+
     try:
-        idle_seconds = parse_duration(getattr(ns, "idle_timeout", "0"))
+        idle_seconds = _resolve_idle_timeout(ns)
     except ValueError as e:
         _emit_top_error(ns, code=CLIENT_CODE_USAGE, message=str(e))
         return EXIT_USAGE
@@ -965,7 +1043,6 @@ def cmd_run(ns: argparse.Namespace) -> int:
       64 argparse 用法错（idle_timeout 解析失败等"明显参数写错"）
     """
     from .daemon import Daemon, DaemonError
-    from ._duration import parse_duration
 
     fmt = _output_format(ns)
 
@@ -985,7 +1062,7 @@ def cmd_run(ns: argparse.Namespace) -> int:
             return EXIT_INFRA_ERROR
 
         try:
-            idle_seconds = parse_duration(getattr(ns, "idle_timeout", "0"))
+            idle_seconds = _resolve_idle_timeout(ns)
         except ValueError as e:
             if fmt == OUTPUT_JSON:
                 _emit_error_payload(CLIENT_CODE_USAGE, str(e))
@@ -1395,7 +1472,8 @@ def _add_daemon_flags(p: argparse.ArgumentParser) -> None:
         "--idle-timeout",
         type=str,
         default="0",
-        help="空闲超时（如 30m / 2h / 90s / 0=关闭，默认关）。开启后 Godot 端 Timer 自动 quit。",
+        help="空闲超时（如 30m / 2h / 90s / 0=关闭，默认关）。开启后 Godot 端 Timer 自动 quit。"
+        "不传时回退读 .cli_control/config.json 的 idle_timeout（issue #44），省得每次手敲。",
     )
 
 
@@ -1748,9 +1826,12 @@ async def _run_rpc(
         _emit_envelope_error(fmt, code, msg)
         return EXIT_INFRA_ERROR
     except (ValueError, json.JSONDecodeError) as e:
-        # 用法错误：combo 没文件没 inline、set value 解析失败……
+        # 用法错误：set/call 的 value JSON 解析失败等（这些命令无 preflight）。
+        # 统一退 EXIT_USAGE(64)，与 preflight 路径（combo/hold）一致 —— 同一客户端
+        # 码 -1003 必须恒等于 exit 64，否则 agent 拿到 -1003 无法据此推断退出码
+        # （issue #82，破坏「单 code 字段无歧义」契约）。
         _emit_envelope_error(fmt, CLIENT_CODE_USAGE, str(e))
-        return EXIT_INFRA_ERROR
+        return EXIT_USAGE
     except Exception as e:  # noqa: BLE001
         # 兜底：客户端内部 bug（AttributeError、KeyError、协议解析意外等）
         # 也要落进信封，否则 ``--json`` 契约对 AI agent 不再可信。把异常类
@@ -1805,9 +1886,10 @@ def main() -> None:
 
         port = ns.port
         if port is None:
-            from .daemon import Daemon
+            # 与 GameClient()/GameBridge() 共用同一发现入口（issue #91）。
+            from .daemon import discover_port
 
-            port = Daemon(Path.cwd()).current_port() or DEFAULT_PORT
+            port = discover_port() or DEFAULT_PORT
 
         rc = asyncio.run(_run_rpc(spec, ns, port, fmt))
         sys.exit(rc)

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import uuid
 from typing import Any
 
@@ -23,7 +24,39 @@ DEFAULT_PORT: int = 9877
 # 改用固定大值后：正常完成时 server 自然回包；server 真死循环时由 600s 兜底
 # （而不是 55s 把还活着的录像炸掉）；死连接由 websockets 库的 ping/pong 心跳
 # 在 ~40s 内独立检测，与本上限无关。
-LONG_OP_CLIENT_TIMEOUT: float = 600.0
+LONG_OP_DEFAULT_TIMEOUT: float = 600.0
+
+
+def _resolve_long_op_timeout() -> float:
+    """长操作生死线，可被 ``GODOT_CLI_LONG_OP_TIMEOUT`` env 覆盖（issue #69）。
+
+    默认 ``LONG_OP_DEFAULT_TIMEOUT``（600s）。合法录像 > 10min 等少数长操作可
+    设环境变量调高（如 ``GODOT_CLI_LONG_OP_TIMEOUT=1800``）。非正数 / 非数字一律
+    忽略并回退默认——这是个兜底生死线，绝不能因 env 写错被设成 0 把正常操作秒杀。
+    """
+    raw = os.environ.get("GODOT_CLI_LONG_OP_TIMEOUT")
+    if not raw:
+        return LONG_OP_DEFAULT_TIMEOUT
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "GODOT_CLI_LONG_OP_TIMEOUT=%r 不是数字，回退默认 %.0fs",
+            raw, LONG_OP_DEFAULT_TIMEOUT,
+        )
+        return LONG_OP_DEFAULT_TIMEOUT
+    if value <= 0:
+        logger.warning(
+            "GODOT_CLI_LONG_OP_TIMEOUT=%r 必须 > 0，回退默认 %.0fs",
+            raw, LONG_OP_DEFAULT_TIMEOUT,
+        )
+        return LONG_OP_DEFAULT_TIMEOUT
+    return value
+
+
+# 模块级解析一次：进程生命周期内 env 不变；测试需要时改 env 后调
+# ``_resolve_long_op_timeout()`` 拿新值，或直接给 request() 传 timeout。
+LONG_OP_CLIENT_TIMEOUT: float = _resolve_long_op_timeout()
 
 
 class RpcError(RuntimeError):
@@ -43,7 +76,17 @@ class RpcError(RuntimeError):
 class GameClient:
     """WebSocket client that connects to Godot's GameBridge service."""
 
-    def __init__(self, port: int = DEFAULT_PORT) -> None:
+    def __init__(self, port: int | None = None) -> None:
+        # port=None（无显式端口）→ 从 .cli_control/port auto-discover，找不到再回退
+        # DEFAULT_PORT。daemon 默认 OS 自动分配端口，所以照 README 写
+        # ``GameClient()`` 单连接脚本的用户/agent 必须经由这条发现路径才能连上
+        # （issue #91）。发现逻辑收敛在 daemon.discover_port，CLI 走同一入口。
+        # 延迟 import 避免 client 在 package import 时拉起 daemon→registry 这条
+        # 较重的依赖链。
+        if port is None:
+            from .daemon import discover_port
+
+            port = discover_port() or DEFAULT_PORT
         self._port = port
         self._ws: ClientConnection | None = None
         self._pending: dict[str, asyncio.Future[dict]] = {}
@@ -279,17 +322,18 @@ class GameClient:
     async def wait_game_time(self, seconds: float) -> dict:
         """按 Godot game time 等待 N 秒。
 
-        客户端用固定 ``LONG_OP_CLIENT_TIMEOUT`` 生死线（issue #45）：game-time
-        与 wall-time 比值受录像模式 / 分辨率 / 盘速 / fps 影响不可预测，任何
-        seconds-scaled 公式都会在某个组合下假超时。死连接由 ws ping/pong 兜底。
-        seconds <= 0 时客户端短路返回，不发 RPC。
+        客户端用固定的长操作生死线（issue #45）：game-time 与 wall-time 比值受
+        录像模式 / 分辨率 / 盘速 / fps 影响不可预测，任何 seconds-scaled 公式都会
+        在某个组合下假超时。死连接由 ws ping/pong 兜底。生死线默认 600s，可被
+        ``GODOT_CLI_LONG_OP_TIMEOUT`` env 覆盖（issue #69）——每次调用现取，
+        让 env 改动即时生效。seconds <= 0 时客户端短路返回，不发 RPC。
         """
         if seconds <= 0:
             return {"success": True}
         return await self.request(
             "wait_game_time",
             {"seconds": seconds},
-            timeout=LONG_OP_CLIENT_TIMEOUT,
+            timeout=_resolve_long_op_timeout(),
         )
 
     # ---- Input simulation API ----
@@ -311,10 +355,11 @@ class GameClient:
         )
 
     async def combo(self, steps: list[dict]) -> dict:
-        # 客户端用固定 LONG_OP_CLIENT_TIMEOUT 生死线（issue #45）：见
-        # wait_game_time 注释——同样的 game-time / wall-time 不对齐问题。
+        # 长操作生死线（issue #45）：见 wait_game_time 注释——同样的 game-time /
+        # wall-time 不对齐问题。默认 600s，可被 GODOT_CLI_LONG_OP_TIMEOUT 覆盖
+        # （issue #69），每次调用现取。
         return await self.request(
-            "input_combo", {"steps": steps}, timeout=LONG_OP_CLIENT_TIMEOUT
+            "input_combo", {"steps": steps}, timeout=_resolve_long_op_timeout()
         )
 
     async def combo_cancel(self) -> dict:

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import signal
@@ -361,6 +362,46 @@ class Daemon:
         except (ProcessLookupError, OSError):
             pass
         _reap_if_dead(pid)  # 回收被 SIGKILL 的 zombie 子进程（若它是本进程的孩子）
+
+
+# ── 项目级配置 ──
+
+
+def read_project_config(project_root: Path | None = None) -> dict:
+    """读取项目级 ``<project_root>/.cli_control/config.json``（issue #44）。
+
+    存放无需每次手敲的默认值，目前支持 ``idle_timeout``（如 ``{"idle_timeout":"30m"}``）。
+    ``project_root`` 默认 ``Path.cwd()``。缺文件 / 非法 JSON / 顶层非对象一律返回
+    ``{}``——配置坏掉绝不能让 daemon 起不来，缺省即回到「无配置」行为。
+    """
+    root = Path(project_root) if project_root is not None else Path.cwd()
+    path = root / ".cli_control" / "config.json"
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+# ── 端口发现 ──
+
+
+def discover_port(project_root: Path | None = None) -> int | None:
+    """从 ``<project_root>/.cli_control/port`` 读取 daemon 当前监听端口。
+
+    daemon 默认以 OS 自动分配端口启动（写入 ``.cli_control/port``），所以"无显式
+    端口"的连接方都得先来这里发现实际端口，再回退 ``DEFAULT_PORT``。这是 CLI RPC
+    子命令、``GameClient()`` 与 ``GameBridge()`` 三处无显式 port 时的**唯一共用**
+    发现入口（issue #91）——与 README 承诺的 "auto-discover from ``.cli_control/port``"
+    对齐。
+
+    ``project_root`` 默认 ``Path.cwd()``（与 CLI 的工作目录约定一致）。无 port 文件
+    或解析失败时返回 ``None``，由调用方决定回退值。
+    """
+    root = Path(project_root) if project_root is not None else Path.cwd()
+    return Daemon(root).current_port()
 
 
 # ── Godot 二进制发现 ──

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -14,7 +14,7 @@ WebSocket bridge for headless / scripted control of Godot 4 scenes. A daemon pro
 **Output is JSON by default.** Every RPC subcommand prints a single-line envelope on stdout:
 
 - success: `{"ok": true, "result": <data>}` — exit 0 (or per-command exit code, see *Exit codes* below)
-- error:   `{"ok": false, "error": {"code": <int>, "message": "..."}}` — exit 1 (RPC error) / 2 (connection, timeout, usage)
+- error:   `{"ok": false, "error": {"code": <int>, "message": "..."}}` — exit 1 (RPC error) / 2 (connection, timeout) / 64 (usage)
 
 Pipe straight into `jq` or `json.loads`. Add `--text` (or `--no-json`) to switch back to the legacy human-readable strings if you really want them.
 
@@ -44,9 +44,9 @@ godot-cli-control daemon stop
 |---|---|
 | 0 | Success (or, for `exists` / `visible` / `wait-node`, the boolean was true / found) |
 | 1 | RPC error (server returned `{"error":...}`); also `exists`/`visible`=false, `wait-node`=timeout, `daemon status`=stopped |
-| 2 | Connection / IO / usage error (daemon not running, script path not found). Also: **`daemon stop` returns 2** when the daemon stopped cleanly but `ffmpeg` transcode of the recorded `.avi`→`.mp4` failed — the raw `.avi` is kept and `.cli_control/ffmpeg.log` has the details. `run <script>` propagates this: a successful script + failed transcode still exits 2. |
+| 2 | Connection / IO error (daemon not running, script path not found). Also: **`daemon stop` returns 2** when the daemon stopped cleanly but `ffmpeg` transcode of the recorded `.avi`→`.mp4` failed — the raw `.avi` is kept and `.cli_control/ffmpeg.log` has the details. `run <script>` propagates this: a successful script + failed transcode still exits 2. |
 | 3 | `daemon stop --all` partial failure: at least one daemon in the registry failed to stop. Per-record `rc` is in the JSON `result.stopped[]`. |
-| 64 | Argparse usage error, **or a pre-flight usage error caught before connecting** — e.g. `combo` with no steps / malformed `--steps-json` / `combo -` from a TTY, or `hold` with a non-positive duration. The error envelope carries client code `-1003`. |
+| 64 | Usage error on an **RPC subcommand** — argparse, a pre-flight reject caught before connecting (`combo` with no steps / malformed `--steps-json` / `combo -` from a TTY, `hold` with a non-positive duration), **and** a bad runtime argument (`tap` / `wait-time` given a non-number, a `set`/`call` value that fails JSON parsing). For RPC subcommands these all carry client code `-1003` and now consistently exit 64 (a few previously exited 2 — fixed in #82). |
 
 Shell-`if` works:
 
@@ -128,7 +128,7 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 |---|---|
 | `-1001` | Connection failure (daemon not running, port wrong, proxy hijacking localhost). Run `daemon status`. |
 | `-1002` | Timeout waiting for a response. Daemon may be hung mid-frame; check Godot stderr. |
-| `-1003` | Usage error (e.g. `combo` got no steps, malformed `--steps-json`, `combo -` from a TTY). Fix the invocation. |
+| `-1003` | Usage error (`combo` got no steps, malformed `--steps-json`, `combo -` from a TTY, a non-numeric `tap`/`wait-time` arg, **or** a `set`/`call` value that fails JSON parsing). From an RPC subcommand this always exits **64**. (Top-level `run`/`daemon` precondition failures — e.g. script path not found, daemon failed to start — also surface `-1003` but exit **2**.) Fix the invocation. |
 | `-1004` | Local file IO error (e.g. `screenshot` can't write the destination — bad path, no write permission). **Not** a daemon problem. |
 | `-1005` | `run <script>` user script raised an uncaught exception. The error message has the exception type + last-line summary; full traceback is on stderr. Fix the script, not the CLI. |
 | `-1099` | Internal client error (unforeseen exception). Bug in this CLI; please file an issue. Stderr has the full traceback. |
@@ -154,11 +154,13 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 
 **Input simulation:**
 - `press <action>` / `release <action>` — sticky press
-- `tap <action> [duration]` — press → wait → release
-- `hold <action> <duration>` — auto-release after N seconds (`duration` must be `> 0`; for an indefinite hold use `press`)
-- `combo --steps-json '[...]'` (or `combo file.json` / `combo -` for stdin) — sequence
+- `tap <action> [duration] [--wait]` — press → wait → release
+- `hold <action> <duration> [--wait]` — auto-release after N seconds (`duration` must be `> 0`; for an indefinite hold use `press`)
+- `combo --steps-json '[...]' [--wait]` (or `combo file.json` / `combo -` for stdin) — sequence
 - `combo-cancel` — abort running combo
 - `release-all` — release everything
+
+`tap` / `hold` / `combo` are **async by default** — they return as soon as the input is armed, *before* the in-game motion finishes (see *Common pitfalls*). Add **`--wait`** to block until the action's duration elapses (game-time) so the next `get` reads the settled state — it folds an implicit `wait-time <duration>` into the same command/connection.
 
 **Wait:**
 - `wait-node <path> [timeout]` — block until node appears (exit 0=found, 1=timeout)
@@ -288,6 +290,9 @@ Key constraints:
 - `ffmpeg` must be on `PATH` for transcoding. If transcoding fails, the raw `.avi` is kept and `daemon stop` exits with code `2` (transcode log at `.cli_control/ffmpeg.log`).
 - `--fps` controls the **fixed simulation framerate** Godot runs at while recording — set it to your target video framerate.
 - Output path is relative to cwd; use absolute paths if your script changes cwd.
+- Long `wait-time` / `combo` / recording ops are bounded client-side by a fixed **600s** wall-time fail-safe (not a per-call timeout — game-time vs wall-time can't be predicted). A genuinely long operation (e.g. a > 10-minute recording) that trips it can raise the ceiling via `GODOT_CLI_LONG_OP_TIMEOUT=<seconds>` (e.g. `1800`); a non-positive / non-numeric value is ignored and falls back to 600s.
+
+**Project-level defaults** (`.cli_control/config.json`, optional): set `{"idle_timeout": "30m"}` so `daemon start` / `run` auto-quit after idle without re-typing `--idle-timeout` every time. It's read only when you don't pass `--idle-timeout` (default `0`); an explicit flag wins. Bad JSON / a malformed duration there surfaces as a `-1003` usage error (exit 64).
 
 ## CLI reference
 
@@ -299,7 +304,7 @@ Key constraints:
 
 ## Python `GameClient` API
 
-`from godot_cli_control.client import GameClient` — async WebSocket client; use as `async with GameClient(port=...) as client:`. **Every method below has a 1-line CLI equivalent above; only reach for Python when you need to keep a client open across many steps without the connection-per-call overhead.**
+`from godot_cli_control.client import GameClient` — async WebSocket client; use as `async with GameClient() as client:`. **With no `port` argument it auto-discovers from `.cli_control/port`** (the same file the daemon writes and the CLI reads), falling back to `9877` if absent — so a no-arg `GameClient()` connects to a running daemon out of the box. Pass `GameClient(port=N)` only to override. (`GameBridge()` in `run` scripts auto-discovers identically.) **Every method below has a 1-line CLI equivalent above; only reach for Python when you need to keep a client open across many steps without the connection-per-call overhead.**
 
 Errors raise `RpcError(code, message)` (a `RuntimeError` subclass) that preserves the server's error code — useful for retrying `1004 "combo in progress"`.
 
@@ -394,6 +399,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
   - `daemon start --port N`: the port the daemon itself listens on. This is a local flag of `start`, so — like any other `daemon` flag — its position doesn't matter.
 - **`combo` rejects everything with `1004`** — a combo is already running. Call `combo-cancel` (or `release-all`) to abort.
 - **`hold` / `press` persist after the command returns** — by design. Each CLI command is its own short-lived connection that closes *cleanly*, and a clean close does **not** release inputs. `hold <action> <dur>` auto-releases after `<dur>` seconds (its timer keeps running in the daemon); a sticky `press <action>` stays held until you call `release <action>` / `release-all` (or the daemon's idle-timeout shuts it down). If a character looks stuck moving, you probably left a `press` dangling — run `release-all`. (An *abnormal* drop — your client crashing or being killed mid-session — does trigger a safety `release-all`, so stuck keys can't outlive a dead client.)
+- **`hold` / `tap` / `combo` return *before* the motion finishes — use `--wait` (or `wait-time`) before reading state.** These input commands are asynchronous: `hold move_right 1.0` returns in ~0.4s (it just arms a release-timer in the daemon), but the character keeps moving for the full `1.0` in-game second. If you `get position` immediately you read a *mid-motion* value (e.g. `x=415` instead of the settled `x=540`). Two fixes: ① pass **`--wait`** (`hold move_right 1.0 --wait` blocks until the duration elapses, then `get … position` reads the settled value) — one command, one connection; ② or do it explicitly: `hold move_right 1.0` → `wait-time 1.0` → `get … position`. `--wait` works on `tap` (default `0.1`s) and `combo` (waits the summed step durations) too. Either way, also account for any physics/animation that plays out over extra frames after the input lands.
 - **`tree` returns `1005 "scene tree too large"`** — your scene has more than 5000 visible nodes (a Grid / spawned-bullets situation). Pass `--max-nodes 200` to cap, or `children <path>` for one specific subtree.
 - **`set` with a string that *looks* like JSON** — value parser parses JSON first. To force a literal `"42"` string, pass `'"42"'`; to set a literal hash sign or array text, JSON-encode it.
 - **`daemon start` opens a window when I expected headless** — your stdout is a TTY (interactive terminal). Pass `--headless` explicitly, or shell out from a context where stdout is piped.

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -109,7 +109,7 @@ async def test_listen_clears_pending_on_disconnect() -> None:
     async def fake_iter():
         # iterator 立即结束（模拟连接关闭）
         return
-        yield  # noqa: unreachable
+        yield  # 让函数成为 async generator；return 在前，这行永远到不了
 
     fake_ws.__aiter__ = lambda self: fake_iter()
     fake_ws.close = AsyncMock()
@@ -148,7 +148,7 @@ async def test_request_timeout_cleans_pending() -> None:
         # async iterator 永久挂起：不会 yield 也不会结束，
         # 模拟"连接活着但不回响应"——request() 必定走 timeout 路径。
         await asyncio.Event().wait()
-        yield  # noqa: unreachable
+        yield  # 让函数成为 async generator；return 在前，这行永远到不了
 
     fake_ws.__aiter__ = lambda self: hang_iter()
     fake_ws.send = AsyncMock()
@@ -285,7 +285,7 @@ async def test_request_raises_rpc_error_with_code() -> None:
     async def hang_iter():
         # 让 listen task 保持活着 —— 我们手动通过 _pending 注入响应。
         await asyncio.Event().wait()
-        yield  # noqa: unreachable
+        yield  # 让函数成为 async generator；return 在前，这行永远到不了
 
     fake_ws.__aiter__ = lambda self: hang_iter()
     fake_ws.send = AsyncMock()
@@ -335,7 +335,7 @@ async def test_get_pressed_unwraps_actions_field() -> None:
     async def hang_iter():
         # 让 listen task 保持活着 —— 我们手动通过 _pending 注入响应。
         await asyncio.Event().wait()
-        yield  # noqa: unreachable
+        yield  # 让函数成为 async generator；return 在前，这行永远到不了
 
     fake_ws.__aiter__ = lambda self: hang_iter()
     fake_ws.send = AsyncMock()
@@ -378,7 +378,7 @@ async def test_list_input_actions_passes_include_builtin_param() -> None:
     async def hang_iter():
         # 让 listen task 保持活着 —— 我们手动通过 _pending 注入响应。
         await asyncio.Event().wait()
-        yield  # noqa: unreachable
+        yield  # 让函数成为 async generator；return 在前，这行永远到不了
 
     fake_ws.__aiter__ = lambda self: hang_iter()
     fake_ws.send = AsyncMock()

--- a/python/tests/test_e2e_client_direct.py
+++ b/python/tests/test_e2e_client_direct.py
@@ -1,0 +1,217 @@
+"""端到端回归：直连 ``GameClient`` 真实 daemon，覆盖 client.py 的 RPC 方法体（issue #81）。
+
+为什么单开这条：既有 e2e（``test_e2e_input`` 等）经 ``subprocess.run([python, -m
+godot_cli_control, ...])`` 调 CLI，``coverage run`` 默认不统计子进程，所以真实
+WebSocket 链路虽然跑了、``client.py`` 的 ``set_property`` / ``call_method`` /
+``get_children`` / ``wait_for_node`` 等方法体却没计入覆盖率。本文件**在 pytest 进程内**
+``async with GameClient(port=...)`` 直接 await 这些方法打真 daemon —— 方法体在被
+trace 的进程里执行，覆盖率如实计入。下游 CultivationWorld 依赖这些方法，回归不能只靠
+mock 级单测。
+
+需要真实 Godot 4：PATH 里有 ``godot``（或设 ``GODOT_BIN``），否则整文件 skip。
+截图走 GUI 路径（headless dummy renderer 拿不到 viewport texture），不在此覆盖——
+见 ``test_e2e_screenshot_gui.py``。
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from godot_cli_control.client import GameClient, RpcError
+from godot_cli_control.daemon import find_godot_binary
+
+_GODOT_BIN = find_godot_binary()
+_ADDON_SRC = Path(__file__).resolve().parents[2] / "addons" / "godot_cli_control"
+
+pytestmark = pytest.mark.skipif(
+    not _GODOT_BIN,
+    reason="需要真实 Godot 4：把 godot 装进 PATH 或设 GODOT_BIN，否则整文件 skip",
+)
+
+_CLI = [sys.executable, "-m", "godot_cli_control"]
+
+_PROJECT_GODOT = """\
+config_version=5
+
+[application]
+config/name="gcc_e2e_client"
+run/main_scene="res://main.tscn"
+
+[autoload]
+GameBridgeNode="*res://addons/godot_cli_control/bridge/game_bridge.gd"
+
+[debug]
+settings/stdout/print_fps=false
+
+[editor_plugins]
+enabled=PackedStringArray("res://addons/godot_cli_control/plugin.cfg")
+
+[input]
+move_right={"deadzone":0.5,"events":[]}
+jump={"deadzone":0.5,"events":[]}
+"""
+
+# Main 挂一个脚本暴露可读写属性 counter 与用户方法 bump —— 给 set_property /
+# call_method 一个不撞 blacklist（script/set/call 等被禁）的合法目标。
+_MAIN_GD = """\
+extends Node
+
+var counter: int = 0
+
+func bump(n: int) -> int:
+	counter += n
+	return counter
+"""
+
+_MAIN_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://main.gd" id="1"]
+
+[node name="Main" type="Node"]
+script = ExtResource("1")
+
+[node name="Title" type="Label" parent="."]
+text = "Hello"
+
+[node name="Player" type="Node2D" parent="."]
+
+[node name="Panel" type="Control" parent="."]
+"""
+
+
+def _run_cli(project: Path, *args: str, timeout: float = 60.0) -> dict[str, Any]:
+    proc = subprocess.run(
+        _CLI + list(args), cwd=project, capture_output=True, text=True, timeout=timeout
+    )
+    json_lines = [ln for ln in proc.stdout.splitlines() if ln.strip().startswith("{")]
+    assert json_lines, f"无 JSON 输出：args={args} stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    return json.loads(json_lines[-1])
+
+
+@pytest.fixture(scope="module")
+def godot_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    proj = tmp_path_factory.mktemp("gcc_e2e_client")
+    (proj / "addons").mkdir()
+    shutil.copytree(_ADDON_SRC, proj / "addons" / "godot_cli_control")
+    (proj / "project.godot").write_text(_PROJECT_GODOT)
+    (proj / "main.gd").write_text(_MAIN_GD)
+    (proj / "main.tscn").write_text(_MAIN_TSCN)
+
+    imp = subprocess.run(
+        [_GODOT_BIN, "--headless", "--editor", "--quit", "--path", str(proj)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert imp.returncode == 0, f"Godot 导入失败：{imp.stdout}\n{imp.stderr}"
+    return proj
+
+
+@pytest.fixture(scope="module")
+def daemon_port(godot_project: Path) -> Any:
+    start = _run_cli(godot_project, "daemon", "start", "--headless", timeout=90)
+    assert start["ok"] is True and start["result"]["started"], start
+    try:
+        yield godot_project, start["result"]["port"]
+    finally:
+        _run_cli(godot_project, "release-all")
+        _run_cli(godot_project, "daemon", "stop", timeout=30)
+
+
+@pytest.mark.asyncio
+async def test_client_read_methods(daemon_port: Any) -> None:
+    """读路径：node_exists / is_visible / get_text / get_property / get_children /
+    get_scene_tree / wait_for_node（命中 + 超时）—— 直连真实 daemon。"""
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        assert await client.node_exists("/root/Main") is True
+        assert await client.node_exists("/root/Main/DoesNotExist") is False
+
+        assert await client.is_visible("/root/Main/Panel") is True
+
+        assert await client.get_text("/root/Main/Title") == "Hello"
+
+        assert await client.get_property("/root/Main", "counter") == 0
+
+        children = await client.get_children("/root/Main")
+        names = {c.get("name") for c in children}
+        assert {"Title", "Player", "Panel"} <= names, children
+
+        # 类型过滤：只要 Label
+        labels = await client.get_children("/root/Main", type_filter="Label")
+        assert [c.get("name") for c in labels] == ["Title"], labels
+
+        tree = await client.get_scene_tree(depth=3)
+        assert isinstance(tree, dict) and tree, tree
+
+        assert await client.wait_for_node("/root/Main/Player", timeout=2.0) is True
+        assert await client.wait_for_node("/root/Main/Ghost", timeout=0.5) is False
+
+
+@pytest.mark.asyncio
+async def test_client_write_and_call_methods(daemon_port: Any) -> None:
+    """写路径：set_property 落值可被 get_property 读回；call_method 调用户方法拿返回值。"""
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        await client.set_property("/root/Main", "counter", 7)
+        assert await client.get_property("/root/Main", "counter") == 7
+
+        # 用户方法 bump(n) 不在 method blacklist（call/set/free 才禁）：counter 7 + 5 = 12
+        assert await client.call_method("/root/Main", "bump", [5]) == 12
+        assert await client.get_property("/root/Main", "counter") == 12
+
+        # 写非法属性（script 在 property blacklist）应抛 RpcError，错误码保留
+        with pytest.raises(RpcError):
+            await client.set_property("/root/Main", "script", "res://evil.gd")
+
+
+@pytest.mark.asyncio
+async def test_client_input_methods(daemon_port: Any) -> None:
+    """输入路径：list_input_actions / press / get_pressed / release / tap / hold /
+    combo / combo_cancel / release_all —— 全部直连真实模拟器。"""
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        try:
+            actions = await client.list_input_actions(include_builtin=False)
+            assert {"move_right", "jump"} <= set(actions), actions
+
+            await client.action_press("jump")
+            assert "jump" in await client.get_pressed()
+            await client.action_release("jump")
+            assert "jump" not in await client.get_pressed()
+
+            await client.action_tap("jump", 0.05)
+
+            await client.hold("move_right", 0.2)
+            assert "move_right" in await client.get_pressed()
+
+            # combo 串行跑完后返回；随后 combo_cancel 无 combo 在跑 → 安全 no-op success
+            combo_res = await client.combo([{"action": "jump", "duration": 0.05}])
+            assert combo_res.get("success") is True, combo_res
+            cancel_res = await client.combo_cancel()
+            assert cancel_res.get("success") is True, cancel_res
+        finally:
+            await client.release_all()
+            assert await client.get_pressed() == []
+
+
+@pytest.mark.asyncio
+async def test_client_autodiscovers_port_from_control_dir(
+    daemon_port: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """无 port 参数的 GameClient() 从 cwd 的 .cli_control/port auto-discover（issue #91）。
+
+    daemon 已写 .cli_control/port；chdir 到项目根后 GameClient()（无参）应据此连上，
+    覆盖 client.GameClient.__init__ 的 discover_port 分支。"""
+    project, _ = daemon_port
+    monkeypatch.chdir(project)
+    async with GameClient() as client:  # 无 port → auto-discover
+        assert await client.node_exists("/root/Main") is True

--- a/python/tests/test_e2e_record.py
+++ b/python/tests/test_e2e_record.py
@@ -1,0 +1,198 @@
+"""端到端 smoke：``--record`` 真起 Godot Movie Maker，产出有效 ``.mp4``（issue #78）。
+
+录屏路径此前只有 mock 级覆盖（``test_daemon`` 拦 ``subprocess.Popen`` 断言 argv 含
+``--write-movie/--fixed-fps``，没真起 Godot）。真实链路「Godot 写 ``.avi`` →
+``daemon stop`` → ffmpeg 转 ``.mp4`` → 分辨率/时长有效」从未端到端验证过。
+
+本测试在**能开窗的 runner** 上：
+  1. ``daemon start --record --movie-path <tmp>.avi --fps N``（record ⇒ 自动 GUI）
+  2. 跑几步输入 + ``wait-time`` 让画面推进若干帧
+  3. ``daemon stop`` → 触发 ffmpeg 转码
+  4. 断言 ``.mp4`` 存在且非空；``ffprobe`` 校验时长 > 0、分辨率与项目窗口一致
+
+回归这条能拦的 bug：CultivationWorld#180（``--record --headless`` Movie Maker 首帧
+SIGSEGV）的修复目前只有 mock 级保护。
+
+依赖：真实 Godot 4 + 真实显示（``GCC_GUI_E2E=1``）+ ``ffmpeg``/``ffprobe`` 在 PATH。
+**headless runner 跑不了录制（正是 #180 根因）**，故必须 gate 在有 display 的 job 上；
+缺 display / ffmpeg 时 skip 并在 reason 写明原因（不静默跳过）。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from godot_cli_control.daemon import find_godot_binary
+
+_GODOT_BIN = find_godot_binary()
+_ADDON_SRC = Path(__file__).resolve().parents[2] / "addons" / "godot_cli_control"
+
+# 项目窗口尺寸（断言录像分辨率与之一致）。
+_VIEW_W, _VIEW_H = 320, 240
+_FPS = 15
+_WAIT_SECONDS = 1.0  # 推进的 game-time → ≈ _FPS * _WAIT_SECONDS 帧
+
+pytestmark = [
+    pytest.mark.gui,
+    pytest.mark.skipif(
+        not _GODOT_BIN,
+        reason="需要真实 Godot 4：把 godot 装进 PATH 或设 GODOT_BIN",
+    ),
+    pytest.mark.skipif(
+        os.environ.get("GCC_GUI_E2E") != "1",
+        reason="录屏 e2e 默认 skip（需真实显示 / xvfb）；CI 专档设 GCC_GUI_E2E=1 开启",
+    ),
+    pytest.mark.skipif(
+        not (shutil.which("ffmpeg") and shutil.which("ffprobe")),
+        reason="需要 ffmpeg + ffprobe 在 PATH 才能转码并校验录像",
+    ),
+]
+
+_CLI = [sys.executable, "-m", "godot_cli_control"]
+
+_PROJECT_GODOT = f"""\
+config_version=5
+
+[application]
+config/name="gcc_e2e_record"
+run/main_scene="res://main.tscn"
+config/features=PackedStringArray("4.2")
+
+[autoload]
+GameBridgeNode="*res://addons/godot_cli_control/bridge/game_bridge.gd"
+
+[debug]
+settings/stdout/print_fps=false
+
+[display]
+window/size/viewport_width={_VIEW_W}
+window/size/viewport_height={_VIEW_H}
+
+[editor_plugins]
+enabled=PackedStringArray("res://addons/godot_cli_control/plugin.cfg")
+
+[input]
+jump={{"deadzone":0.5,"events":[]}}
+"""
+
+# 让 Bg 每帧平移，录像里有真实运动（而非单帧静止），更贴近「录 demo」的实际用途。
+_MAIN_GD = """\
+extends Control
+
+func _process(delta: float) -> void:
+	var bg := $Bg
+	bg.position.x = fmod(bg.position.x + 80.0 * delta, 160.0)
+"""
+
+_MAIN_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://main.gd" id="1"]
+
+[node name="Main" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+script = ExtResource("1")
+
+[node name="Bg" type="ColorRect" parent="."]
+offset_right = 80.0
+offset_bottom = 240.0
+color = Color(0.2, 0.4, 0.8, 1)
+"""
+
+
+def _run_cli(project: Path, *args: str, timeout: float = 120.0) -> dict[str, Any]:
+    proc = subprocess.run(
+        _CLI + list(args), cwd=project, capture_output=True, text=True, timeout=timeout
+    )
+    json_lines = [ln for ln in proc.stdout.splitlines() if ln.strip().startswith("{")]
+    assert json_lines, f"无 JSON 输出：args={args} stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    return json.loads(json_lines[-1])
+
+
+def _ffprobe(mp4: Path) -> dict[str, Any]:
+    out = subprocess.run(
+        [
+            "ffprobe", "-v", "error",
+            "-select_streams", "v:0",
+            "-show_entries", "stream=width,height",
+            "-show_entries", "format=duration",
+            "-of", "json", str(mp4),
+        ],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert out.returncode == 0, f"ffprobe 失败：{out.stderr}"
+    return json.loads(out.stdout)
+
+
+@pytest.fixture(scope="module")
+def godot_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    proj = tmp_path_factory.mktemp("gcc_e2e_record")
+    (proj / "addons").mkdir()
+    shutil.copytree(_ADDON_SRC, proj / "addons" / "godot_cli_control")
+    (proj / "project.godot").write_text(_PROJECT_GODOT)
+    (proj / "main.gd").write_text(_MAIN_GD)
+    (proj / "main.tscn").write_text(_MAIN_TSCN)
+
+    imp = subprocess.run(
+        [_GODOT_BIN, "--headless", "--editor", "--quit", "--path", str(proj)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert imp.returncode == 0, f"Godot 导入失败：{imp.stdout}\n{imp.stderr}"
+    return proj
+
+
+def test_record_produces_valid_mp4(godot_project: Path) -> None:
+    """--record → 推进若干帧 → daemon stop 转码 → 有效 .mp4（时长 > 0、分辨率匹配）。"""
+    project = godot_project
+    avi = project / "demo.avi"
+    mp4 = avi.with_suffix(".mp4")
+
+    # record ⇒ 自动 GUI（即便本进程非 TTY）。movie-path 用 .avi（Godot Movie Maker
+    # 内置 MJPEG-AVI 写出），stop 时 ffmpeg 转成 .mp4。
+    start = _run_cli(
+        project, "daemon", "start",
+        "--record", "--movie-path", str(avi), "--fps", str(_FPS),
+        timeout=120,
+    )
+    assert start["ok"] is True and start["result"]["started"], start
+
+    stopped_cleanly = False
+    try:
+        # 跑一步输入 + 推进 game-time，让 Movie Maker 写出若干帧。
+        _run_cli(project, "tap", "jump", "0.1")
+        wt = _run_cli(project, "wait-time", str(_WAIT_SECONDS))
+        assert wt["ok"] is True, wt
+    finally:
+        stop = _run_cli(project, "daemon", "stop", timeout=60)
+        stopped_cleanly = True
+        # rc 0 = 转码成功；rc 2 = daemon 已停但 ffmpeg 转码失败（保留 .avi）。
+        assert stop["ok"] is True, stop
+        assert stop["result"].get("rc") == 0, (
+            f"daemon stop 报转码失败 rc={stop['result'].get('rc')}；"
+            f"看 .cli_control/ffmpeg.log。原始 .avi 是否存在：{avi.exists()}"
+        )
+
+    assert stopped_cleanly
+    assert mp4.exists(), f"转码后未见 {mp4}（.avi 存在={avi.exists()}）"
+    assert mp4.stat().st_size > 0, "转码出的 .mp4 为空"
+
+    probe = _ffprobe(mp4)
+    duration = float(probe.get("format", {}).get("duration", 0.0))
+    assert duration > 0.0, f"录像时长应 > 0：{probe}"
+
+    stream = probe.get("streams", [{}])[0]
+    assert (stream.get("width"), stream.get("height")) == (_VIEW_W, _VIEW_H), (
+        f"录像分辨率应与项目窗口 {_VIEW_W}x{_VIEW_H} 一致，实际 "
+        f"{stream.get('width')}x{stream.get('height')}：{probe}"
+    )

--- a/python/tests/test_issue_fixes.py
+++ b/python/tests/test_issue_fixes.py
@@ -1,0 +1,292 @@
+"""单测：本批 issue 修复的契约锁定（无需真实 daemon）。
+
+覆盖：
+  - #82  RPC 子命令的用法错（-1003）恒退 64，不再 2
+  - #90  hold / tap / combo 的 --wait 在输入后阻塞 wait_game_time(duration)
+  - #44  项目级 .cli_control/config.json 的 idle_timeout 回退
+  - #69  GODOT_CLI_LONG_OP_TIMEOUT env 覆盖长操作生死线
+  - #91  GameClient()/discover_port 无显式 port 时从 .cli_control/port 发现
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+# ── #82：RPC 子命令用法错恒退 64 ──────────────────────────────────────────
+
+
+def test_run_rpc_value_error_exits_usage_not_infra() -> None:
+    """handler 抛 ValueError（如 wait-time 的 seconds 非数字）→ EXIT_USAGE(64) + -1003。
+
+    回归 #82：此前 _run_rpc 的 ValueError 分支退 EXIT_INFRA_ERROR(2)，与 preflight
+    路径（combo/hold 退 64）冲突，使同一 -1003 码退出码有歧义。"""
+    from godot_cli_control.cli import (
+        EXIT_USAGE,
+        OUTPUT_JSON,
+        RPC_BY_NAME,
+        _run_rpc,
+    )
+
+    spec = RPC_BY_NAME["wait-time"]
+    ns = argparse.Namespace(seconds="not-a-number")
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_JSON))
+
+    assert rc == EXIT_USAGE, f"用法错应退 64，实际 {rc}"
+
+
+def test_run_rpc_value_error_envelope_code_is_usage(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """ValueError 分支的信封 code 必须是 -1003（CLIENT_CODE_USAGE）。"""
+    from godot_cli_control.cli import (
+        CLIENT_CODE_USAGE,
+        OUTPUT_JSON,
+        RPC_BY_NAME,
+        _run_rpc,
+    )
+
+    spec = RPC_BY_NAME["wait-time"]
+    ns = argparse.Namespace(seconds="xyz")
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_JSON))
+
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == CLIENT_CODE_USAGE
+
+
+# ── #90：--wait 阻塞 ───────────────────────────────────────────────────────
+
+
+def _wait_aware_client() -> AsyncMock:
+    c = AsyncMock()
+    c.hold = AsyncMock(return_value={"success": True})
+    c.action_tap = AsyncMock(return_value={"success": True})
+    c.combo = AsyncMock(return_value={"success": True})
+    c.wait_game_time = AsyncMock(return_value={"success": True})
+    return c
+
+
+def test_hold_wait_blocks_for_duration() -> None:
+    from godot_cli_control.cli import cmd_hold
+
+    c = _wait_aware_client()
+    ns = argparse.Namespace(action="move_right", duration="1.5", wait=True)
+    asyncio.run(cmd_hold(c, ns))
+    c.hold.assert_awaited_once_with("move_right", 1.5)
+    c.wait_game_time.assert_awaited_once_with(1.5)
+
+
+def test_hold_without_wait_does_not_block() -> None:
+    from godot_cli_control.cli import cmd_hold
+
+    c = _wait_aware_client()
+    ns = argparse.Namespace(action="move_right", duration="1.5", wait=False)
+    asyncio.run(cmd_hold(c, ns))
+    c.hold.assert_awaited_once()
+    c.wait_game_time.assert_not_awaited()
+
+
+def test_hold_missing_wait_attr_defaults_async() -> None:
+    """ns 没有 wait 属性（旧调用方）时按异步处理，不崩。"""
+    from godot_cli_control.cli import cmd_hold
+
+    c = _wait_aware_client()
+    ns = argparse.Namespace(action="jump", duration="0.5")
+    asyncio.run(cmd_hold(c, ns))
+    c.wait_game_time.assert_not_awaited()
+
+
+def test_tap_wait_blocks_for_duration() -> None:
+    from godot_cli_control.cli import cmd_tap
+
+    c = _wait_aware_client()
+    ns = argparse.Namespace(action="jump", duration="0.3", wait=True)
+    asyncio.run(cmd_tap(c, ns))
+    c.action_tap.assert_awaited_once_with("jump", 0.3)
+    c.wait_game_time.assert_awaited_once_with(0.3)
+
+
+def test_tap_wait_uses_default_duration() -> None:
+    """tap 不传 duration 时默认 0.1，--wait 阻塞 0.1。"""
+    from godot_cli_control.cli import cmd_tap
+
+    c = _wait_aware_client()
+    ns = argparse.Namespace(action="jump", duration=None, wait=True)
+    asyncio.run(cmd_tap(c, ns))
+    c.wait_game_time.assert_awaited_once_with(0.1)
+
+
+def test_combo_wait_blocks_for_summed_duration() -> None:
+    from godot_cli_control.cli import cmd_combo
+
+    c = _wait_aware_client()
+    steps = [{"action": "jump", "duration": 0.2}, {"wait": 0.3}, {"action": "attack"}]
+    ns = argparse.Namespace(wait=True, _combo_steps=steps)
+    asyncio.run(cmd_combo(c, ns))
+    c.combo.assert_awaited_once_with(steps)
+    # 0.2 + 0.3 + 0.1(默认) = 0.6
+    c.wait_game_time.assert_awaited_once()
+    awaited_arg = c.wait_game_time.await_args.args[0]
+    assert abs(awaited_arg - 0.6) < 1e-9, awaited_arg
+
+
+def test_combo_total_duration_tolerates_garbage() -> None:
+    from godot_cli_control.cli import _combo_total_duration
+
+    steps = [{"action": "x", "duration": "bad"}, "not-a-dict", {"wait": 1}]
+    # 0.1(bad→默认) + 0(非 dict 跳过) + 1 = 1.1
+    assert abs(_combo_total_duration(steps) - 1.1) < 1e-9
+
+
+# ── #44：项目级 config idle_timeout 回退 ──────────────────────────────────
+
+
+def test_resolve_idle_timeout_explicit_wins(tmp_path, monkeypatch) -> None:
+    from godot_cli_control.cli import _resolve_idle_timeout
+
+    ctrl = tmp_path / ".cli_control"
+    ctrl.mkdir()
+    (ctrl / "config.json").write_text('{"idle_timeout": "30m"}')
+    monkeypatch.chdir(tmp_path)
+    # 显式 --idle-timeout 10s 压过 config
+    assert _resolve_idle_timeout(argparse.Namespace(idle_timeout="10s")) == 10
+
+
+def test_resolve_idle_timeout_falls_back_to_config(tmp_path, monkeypatch) -> None:
+    from godot_cli_control.cli import _resolve_idle_timeout
+
+    ctrl = tmp_path / ".cli_control"
+    ctrl.mkdir()
+    (ctrl / "config.json").write_text('{"idle_timeout": "30m"}')
+    monkeypatch.chdir(tmp_path)
+    assert _resolve_idle_timeout(argparse.Namespace(idle_timeout="0")) == 1800
+
+
+def test_resolve_idle_timeout_no_config_is_zero(tmp_path, monkeypatch) -> None:
+    from godot_cli_control.cli import _resolve_idle_timeout
+
+    monkeypatch.chdir(tmp_path)
+    assert _resolve_idle_timeout(argparse.Namespace(idle_timeout="0")) == 0
+
+
+def test_resolve_idle_timeout_bad_config_raises_clear_error(tmp_path, monkeypatch) -> None:
+    from godot_cli_control.cli import _resolve_idle_timeout
+
+    ctrl = tmp_path / ".cli_control"
+    ctrl.mkdir()
+    (ctrl / "config.json").write_text('{"idle_timeout": "totally-bad"}')
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="config.json"):
+        _resolve_idle_timeout(argparse.Namespace(idle_timeout="0"))
+
+
+def test_read_project_config_tolerates_missing_and_garbage(tmp_path, monkeypatch) -> None:
+    from godot_cli_control.daemon import read_project_config
+
+    monkeypatch.chdir(tmp_path)
+    assert read_project_config() == {}  # 无文件
+
+    ctrl = tmp_path / ".cli_control"
+    ctrl.mkdir()
+    (ctrl / "config.json").write_text("{ not valid json")
+    assert read_project_config() == {}  # 坏 JSON → {}
+
+    (ctrl / "config.json").write_text("[1, 2, 3]")
+    assert read_project_config() == {}  # 顶层非对象 → {}
+
+
+# ── #69：GODOT_CLI_LONG_OP_TIMEOUT env 覆盖 ───────────────────────────────
+
+
+def test_long_op_timeout_default(monkeypatch) -> None:
+    from godot_cli_control.client import LONG_OP_DEFAULT_TIMEOUT, _resolve_long_op_timeout
+
+    monkeypatch.delenv("GODOT_CLI_LONG_OP_TIMEOUT", raising=False)
+    assert _resolve_long_op_timeout() == LONG_OP_DEFAULT_TIMEOUT
+
+
+def test_long_op_timeout_env_override(monkeypatch) -> None:
+    from godot_cli_control.client import _resolve_long_op_timeout
+
+    monkeypatch.setenv("GODOT_CLI_LONG_OP_TIMEOUT", "1800")
+    assert _resolve_long_op_timeout() == 1800.0
+
+
+@pytest.mark.parametrize("bad", ["-5", "0", "nope", ""])
+def test_long_op_timeout_invalid_env_falls_back(monkeypatch, bad) -> None:
+    from godot_cli_control.client import LONG_OP_DEFAULT_TIMEOUT, _resolve_long_op_timeout
+
+    monkeypatch.setenv("GODOT_CLI_LONG_OP_TIMEOUT", bad)
+    assert _resolve_long_op_timeout() == LONG_OP_DEFAULT_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_wait_game_time_uses_env_override(monkeypatch) -> None:
+    """wait_game_time 每次现取生死线：env 改了即时生效（传给 request 的 timeout）。"""
+    from godot_cli_control.client import GameClient
+
+    monkeypatch.setenv("GODOT_CLI_LONG_OP_TIMEOUT", "1234")
+    client = GameClient(port=9999)
+    client.request = AsyncMock(return_value={"success": True})  # type: ignore[method-assign]
+    await client.wait_game_time(2.0)
+    assert client.request.await_args.kwargs["timeout"] == 1234.0
+
+
+# ── #91：无 port 时 auto-discover .cli_control/port ───────────────────────
+
+
+def test_discover_port_reads_control_dir(tmp_path) -> None:
+    from godot_cli_control.daemon import discover_port
+
+    assert discover_port(tmp_path) is None  # 无 port 文件
+    ctrl = tmp_path / ".cli_control"
+    ctrl.mkdir()
+    (ctrl / "port").write_text("54321\n")
+    assert discover_port(tmp_path) == 54321
+
+
+def test_gameclient_no_port_autodiscovers(tmp_path, monkeypatch) -> None:
+    from godot_cli_control.client import GameClient
+
+    ctrl = tmp_path / ".cli_control"
+    ctrl.mkdir()
+    (ctrl / "port").write_text("55555")
+    monkeypatch.chdir(tmp_path)
+    client = GameClient()  # 无 port → 从 cwd 的 .cli_control/port 发现
+    assert client._port == 55555
+
+
+def test_gameclient_no_port_no_file_falls_back_to_default(tmp_path, monkeypatch) -> None:
+    from godot_cli_control.client import DEFAULT_PORT, GameClient
+
+    monkeypatch.chdir(tmp_path)  # 无 .cli_control/port
+    client = GameClient()
+    assert client._port == DEFAULT_PORT
+
+
+def test_gameclient_explicit_port_skips_discovery(tmp_path, monkeypatch) -> None:
+    from godot_cli_control.client import GameClient
+
+    ctrl = tmp_path / ".cli_control"
+    ctrl.mkdir()
+    (ctrl / "port").write_text("55555")
+    monkeypatch.chdir(tmp_path)
+    client = GameClient(port=8888)  # 显式 port 不走发现
+    assert client._port == 8888


### PR DESCRIPTION
批量修复 10 个 issue，外加一个收尾发现的后续 issue。

Closes #91, #82, #90, #44, #69, #83, #81, #84, #78, #87.

## 核心代码

- **#91** `GameClient()`/`GameBridge()` 无 port 时从 `.cli_control/port` auto-discover（回退 `DEFAULT_PORT`）。发现逻辑收敛到新的 `daemon.discover_port()`，CLI RPC 子命令复用同一入口。
- **#82** `_run_rpc` 的 `ValueError/JSONDecodeError` 分支 `EXIT_INFRA_ERROR(2)` → `EXIT_USAGE(64)`，使 RPC 子命令的 `-1003` 恒等于 64，消除退出码歧义。残留的 `run`/`daemon` 前置失败仍 2，已记 #92。
- **#90** `hold`/`tap`/`combo` 加 `--wait`：输入后阻塞 `wait_game_time(duration)` 再返回（combo 自动求和步时长）；默认仍异步，sticky+timer 模型不变。
- **#44** `.cli_control/config.json` 的 `idle_timeout` 作为 `--idle-timeout` 默认回退（显式 flag 优先）。
- **#69** `GODOT_CLI_LONG_OP_TIMEOUT` env 覆盖长操作 600s 生死线，非法值忽略，每次调用现取。

## 工程化与测试

- **#83** `pyproject` 加 `[tool.ruff]`（锁 0 基线 `E4/E7/E9/F`）+ dev 依赖 `ruff` + 独立 CI `lint` job；顺手清掉 `test_client.py` 5 处不合法 `# noqa`。
- **#81** 新增 `test_e2e_client_direct.py`（进程内直连真 daemon），`client.py` 覆盖率 **68% → 94%**。
- **#84** `python-unit` 的 ubuntu+3.12 覆盖格下载 godot，让 headless e2e 进 CI 并计入覆盖。
- **#78** 新增 `test_e2e_record.py`（`--record` → mp4，`ffprobe` 校时长/分辨率），挂到 macOS GUI job（含 ensure-ffmpeg）。
- 新增 `test_issue_fixes.py` 锁定上述契约（25 例）。

## 文档与示例

- `SKILL.md` 模板 / addon `README` / 项目 `CLAUDE.md` 同步退出码表、`--wait`、config、env、auto-discover。
- **#87** 本机实跑 `examples/platformer-demo/drive.sh` GUI 路径全绿（开窗 / click / 截图 / `stop rc=0`）；并修复连带缺陷——`init` 会改 tracked 的 `project.godot` 且 `.claude/`、`.codex/`、`*.gd.uid` 未忽略，补 example `.gitignore`，改正 drive.sh「never dirties the repo」的不实注释。

## 验证

`coverage run -m pytest python/tests/`：**392 passed / 0 failed / 2 skipped**（GUI-gated），coverage **88%**，`ruff check` 全绿，`drive.sh` GUI 实跑全绿，录屏 e2e 在 `GCC_GUI_E2E=1` 下产出有效 320×240 mp4。

## 后续

- #92：#82 只统一了 RPC 子命令；`run`/`daemon` 前置失败仍发 `-1003` 但退出 2，待彻底消歧。

## 未含（需 maintainer）

- #88（"Used by" 背书，需挑公开下游项目）、#18（提交 Godot AssetLib，需账号登录）——无法自动完成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
