### PR TITLE
chore: 提升可发现性 —— PyPI 元数据 + 社区健康文件

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+# Contributing to godot-cli-control
+
+Thanks for your interest! Issues and pull requests are welcome.
+
+This project has one north star: it is an **AI-friendly CLI** for driving a running Godot 4
+scene from the outside (shell, pytest, Python, or an AI agent). Before you change anything,
+read the [contract section below](#the-contracts-you-must-not-silently-break) — it is what
+makes the tool usable by an agent that can only run one shell command and parse one line of
+JSON at a time. Breaking it quietly is the one thing we cannot merge.
+
+## Ways to contribute
+
+- **Report a bug** — use the [bug report template](ISSUE_TEMPLATE/bug_report.yml). Include the
+  CLI version, Godot version, OS, the exact command, and the single-line JSON envelope it
+  printed. That envelope is usually enough to localize the failure.
+- **Request a feature** — use the [feature request template](ISSUE_TEMPLATE/feature_request.yml).
+  Say which surface it touches (CLI / `GameClient` / pytest fixture / addon).
+- **Send a PR** — see the workflow below.
+
+## Development setup
+
+```bash
+git clone https://github.com/ClaymanTwinkle/godot-cli-control.git
+cd godot-cli-control
+
+# Python client + CLI, editable, with the full test/lint toolchain
+pip install -e ".[test]"
+```
+
+The repository has two halves that are tested independently:
+
+```
+addons/godot_cli_control/   # Godot 4 GDScript plugin + GUT tests
+python/godot_cli_control/   # Python CLI / GameClient (async) / GameBridge (sync) / pytest plugin
+python/tests/               # pytest suite
+```
+
+## Running the checks
+
+All three must be green before a PR can merge; CI runs them on Linux, macOS, and Windows.
+
+```bash
+# 1. Python tests + coverage gate.
+#    Use `coverage run -m pytest`, NOT `pytest --cov`: the pytest11 entry-point imports the
+#    package at startup, before pytest-cov attaches, so --cov misses import-time statements.
+coverage run -m pytest python/tests/
+coverage report          # fails under 80% line/branch coverage
+
+# 2. Lint gate (ruff). Rule set is intentionally the 0-error baseline: pyflakes (F) +
+#    pycodestyle E4/E7/E9. Widening it is a separate PR with the autofix included.
+ruff check
+
+# 3. GUT unit tests for the GDScript plugin (needs a Godot 4 binary).
+#    Cross-platform runner — this is what CI uses:
+GODOT_BIN=/path/to/godot python addons/godot_cli_control/tests/run_gut.py
+```
+
+> Per project policy we don't use `pytest --cov`; the reasoning lives in the comment above
+> `[tool.coverage.run]` in `pyproject.toml`.
+
+## The contracts you must NOT silently break
+
+These are the invariants that make the tool AI-friendly. If your change touches them, it must
+keep them whole **and** update the docs that advertise them (see [Docs that travel with code](#docs-that-travel-with-code)).
+
+1. **JSON envelope is the default.** Every command prints a single line of JSON on stdout:
+   `{"ok": true, "result": ...}` or `{"ok": false, "error": {"code": <int>, "message": "..."}}`.
+   No traceback ever reaches stdout (tracebacks go to stderr, for humans). `--text` / `--no-json`
+   is a legacy bypass — it must never become the default.
+2. **Error codes are three non-overlapping bands.** Server-side GDScript: positive `1xxx`
+   (business) + `-32xxx` (JSON-RPC standard). Python client: `-1xxx`. A single `code` field is
+   unambiguous. Before adding a code, check the error-code table in the addon `README.md` and
+   the constants in `addons/godot_cli_control/bridge/error_codes.gd`.
+3. **Exit codes are semantic.** `0` = success / boolean true / node exists / wait hit; `1` = RPC
+   error (including `exists`/`visible` = false, `wait-node` timeout); `2` = connection / IO error
+   or `run`/`daemon` preflight failure; `64` = usage error; `3` = `daemon stop --all` partial
+   failure. `if godot-cli-control exists /root/Foo; then ...` must keep working.
+4. **Shell is the canonical surface.** Every RPC has a CLI subcommand with positional args and
+   JSON literals. The `def run(bridge):` script form is the fallback, only for "must hold one
+   connection across many steps."
+5. **Preflight beats a network round-trip.** A usage error (e.g. `combo` with no steps) must fail
+   *before* connecting to the daemon, so an agent doesn't wait out a 30s connection retry to learn
+   it mistyped an argument. See `RpcSpec.preflight`.
+6. **Don't blow up the agent's context window.** `screenshot` writes to a file path — never base64
+   on stdout. `tree` / `children` have a depth cap and a truncation signal. New RPCs that return
+   large data need a trim strategy up front.
+7. **localhost-only / blacklist safety net stays.** The bridge always binds `127.0.0.1`; release
+   builds are unconditionally disabled; the method/property blacklist is the last line against RCE.
+   Third-party projects extend it additively via the `godot_cli_control/method_blacklist_extra`
+   ProjectSetting — never by loosening the built-in list.
+
+## Adding a new RPC
+
+Follow this exact order so the shell surface, the Python API, and the agent docs stay in lockstep:
+
+1. Add an `async` method to `python/godot_cli_control/client.py` (`GameClient`).
+2. Add the sync wrapper to `python/godot_cli_control/bridge.py` (`GameBridge`).
+3. In `python/godot_cli_control/cli.py`: add the `RpcSpec` + handler + text formatter, plus a
+   `preflight` and/or `exit_code_from` if the command needs them.
+4. Add the RPC handler to `addons/godot_cli_control/.../low_level_api.gd` or
+   `input_simulation_api.gd`.
+5. Update the docs — see below.
+
+## Docs that travel with code
+
+`SKILL.md` is the only ground truth an AI agent sees. **If you change a CLI subcommand, an error
+code, or a default, you must update the same change in:**
+
+- `python/godot_cli_control/templates/skill/SKILL.md` (the template that `init` renders into a
+  project's `.claude/` and `.codex/` skill files)
+- `addons/godot_cli_control/README.md` (error-code table, exit-code table, command table)
+
+After editing the SKILL template, sanity-check that it still renders:
+
+```bash
+python -c "from godot_cli_control import cli; print(cli.format_full_help())"
+```
+
+## Pull request workflow
+
+- Branch from `main`. Keep PRs focused.
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+  (`feat:`, `fix:`, `docs:`, `test:`, `chore:`, …) — matching the existing history.
+- Fill in the PR template checklist, especially the "SKILL.md updated?" box if you touched the
+  CLI surface, error codes, or defaults.
+- All CI checks (tests on 3 platforms, coverage ≥ 80%, ruff, GUT) must pass.
+- Don't `--no-verify`, don't `xfail`/skip a test to make CI green, don't comment out failing code.
+  If something is genuinely blocked, say so in the PR and open a tracking issue.
+
+## Be respectful
+
+Be kind and constructive in issues, PRs, and discussions. We follow the spirit of the
+[Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) —
+harassment or abuse of any kind isn't welcome here.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Something doesn't behave the way the docs say it should.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! Every command prints a single-line JSON envelope — that envelope
+        is usually enough to localize a failure, so please paste it below.
+  - type: input
+    id: cli-version
+    attributes:
+      label: godot-cli-control version
+      description: Output of `godot-cli-control --version`.
+      placeholder: e.g. 0.2.13
+    validations:
+      required: true
+  - type: input
+    id: godot-version
+    attributes:
+      label: Godot version
+      placeholder: e.g. 4.3.stable
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows (native)
+        - Other (note in description)
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How did you install it?
+      options:
+        - pipx install godot-cli-control
+        - pip install godot-cli-control
+        - editable / from source (pip install -e)
+        - other (note below)
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Exact command(s)
+      description: The shell command(s) or `run` script you executed, including all flags.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: envelope
+    attributes:
+      label: JSON envelope / output
+      description: The single line of JSON printed on stdout, plus anything on stderr.
+      render: json
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+      description: What you expected to happen, and what happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: Scene setup, a minimal repro project, activation mode, headless vs GUI, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation — RPC reference, error & exit codes, security model
+    url: https://github.com/ClaymanTwinkle/godot-cli-control/blob/main/addons/godot_cli_control/README.md
+    about: The plugin README covers the full command surface, error/exit codes, activation modes, and the security model. Please skim it before filing.
+  - name: Report a security vulnerability (private)
+    url: https://github.com/ClaymanTwinkle/godot-cli-control/security/advisories/new
+    about: Please report security issues privately via a GitHub security advisory, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest a new capability or an improvement.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do that you can't (easily) do today?
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface does this touch?
+      multiple: true
+      options:
+        - CLI subcommand
+        - GameClient (async) / GameBridge (sync)
+        - pytest fixtures
+        - GDScript addon / RPC
+        - SKILL.md / agent docs
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: A sketch of the command/API and the JSON output it would print, if you have one.
+    validations:
+      required: false
+  - type: textarea
+    id: ai-friendly
+    attributes:
+      label: AI-friendliness
+      description: >
+        How would an AI agent discover and use this from a single shell command plus one line of
+        JSON? See the contract in CONTRIBUTING.md.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## What & why
+
+<!-- What does this change do, and why? -->
+
+Closes #
+
+## Checklist
+
+- [ ] Tests added/updated, and `coverage run -m pytest python/tests/` passes (coverage ≥ 80%)
+- [ ] `ruff check` is clean
+- [ ] GUT tests pass if GDScript changed (`GODOT_BIN=... python addons/godot_cli_control/tests/run_gut.py`)
+- [ ] **Changed a CLI subcommand, an error code, or a default behavior?** Then I also updated:
+  - [ ] `python/godot_cli_control/templates/skill/SKILL.md`
+  - [ ] the error-code / exit-code / command tables in `addons/godot_cli_control/README.md`
+- [ ] **New RPC?** I added the full chain: `GameClient` → `GameBridge` → `cli.py` (`RpcSpec` + handler + text formatter) → GDScript handler
+- [ ] No `--no-verify`, no skipped/`xfail`'d tests, no commented-out failing code
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+
+## Notes for the reviewer
+
+<!-- Anything tricky, follow-ups deferred to issues, screenshots, etc. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Threat model in one paragraph
+
+`godot-cli-control` exposes a JSON-RPC server inside a running Godot project so that a local
+process can drive the scene. By design that server is **development/test tooling only**:
+
+- it always binds `127.0.0.1` (never a routable interface);
+- it is **off by default** even when the plugin is enabled, and must be explicitly activated;
+- it is **unconditionally disabled in release/exported builds**;
+- a method/property **blacklist** is the last line of defense against turning RPC into arbitrary
+  code execution, and third parties may only extend it *additively* via the
+  `godot_cli_control/method_blacklist_extra` ProjectSetting.
+
+The full model is documented in the
+[plugin README → Security Model](https://github.com/ClaymanTwinkle/godot-cli-control/blob/main/addons/godot_cli_control/README.md#security-model).
+A vulnerability, for the purposes of this policy, is anything that breaks one of those guarantees —
+e.g. the server binding a non-loopback address, the bridge surviving into a release build, or a
+blacklist bypass that reaches a dangerous engine method.
+
+## Supported versions
+
+This project is in **alpha**. Security fixes land on `main` and ship in the next release on PyPI.
+Only the latest released version is supported — please reproduce on the latest version before
+reporting.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a suspected vulnerability.**
+
+Preferred: use GitHub's private vulnerability reporting —
+[**Report a vulnerability**](https://github.com/ClaymanTwinkle/godot-cli-control/security/advisories/new)
+(repo → **Security** tab → *Report a vulnerability*). This keeps the report private until a fix is
+ready and lets us collaborate on a patch and advisory.
+
+If you cannot use that, email **claymantwinkle@gmail.com** with `[security]` in the subject.
+
+Please include:
+
+- affected version (`godot-cli-control --version`) and Godot version;
+- a description of the broken guarantee and its impact;
+- a minimal reproduction (command sequence, project setup, or script).
+
+## What to expect
+
+This is maintained by a single author on a best-effort basis. We'll acknowledge a valid report,
+work with you on a fix and a coordinated disclosure timeline, and credit you in the advisory unless
+you prefer to remain anonymous.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ godot-cli-control screenshot /tmp/x.png
 godot-cli-control daemon stop
 ```
 
-Want unreleased main? `pipx install "git+https://github.com/ClaymanTwinkle/godot-cli-control.git#subdirectory=python"`.
+Want unreleased main? `pipx install "git+https://github.com/ClaymanTwinkle/godot-cli-control.git"`.
 
 ## Try the demo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,43 @@ readme = "python/README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "kesar" }]
+# keywords / classifiers 仅供 PyPI 搜索与分类筛选；与 GitHub repo topics 对齐。
+# 改这里时顺手对一眼 README 顶部徽章 + repo About 的 topics，别让三处漂移。
+keywords = [
+    "godot",
+    "godot4",
+    "godot-plugin",
+    "gdscript",
+    "automation",
+    "game-testing",
+    "pytest",
+    "websocket",
+    "json-rpc",
+    "ai-agent",
+    "llm",
+    "screenshot",
+    "headless",
+    "cli",
+]
+classifiers = [
+    # README 自称 Alpha；升 Beta/Stable 时记得同步这里与 README 的 Status 段。
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Environment :: Console",
+    # Python 版本与 CI matrix（.github/workflows/ci.yml）保持一致：实测 3.10–3.13。
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Testing",
+    "Topic :: Games/Entertainment",
+    # pytest11 entry-point 让它成为一个 pytest 插件 —— 这条 classifier 能把包
+    # 收进 PyPI 的 pytest-plugin 分类列表，是面向 pytest 用户的关键发现入口。
+    "Framework :: Pytest",
+]
 dependencies = [
     "websockets>=14,<16",
 ]
@@ -21,6 +58,15 @@ godot-cli-control = "godot_cli_control.cli:main"
 
 [project.entry-points.pytest11]
 godot-cli-control = "godot_cli_control.pytest_plugin"
+
+# PyPI 项目页侧栏的链接全靠这张表（现在为空 = 侧栏只有一个 PyPI 自身链接）。
+# Changelog 指向 addon 内的 CHANGELOG（README「Status」段也引这份），别改成根目录。
+[project.urls]
+Homepage = "https://github.com/ClaymanTwinkle/godot-cli-control"
+Repository = "https://github.com/ClaymanTwinkle/godot-cli-control"
+Documentation = "https://github.com/ClaymanTwinkle/godot-cli-control#readme"
+Changelog = "https://github.com/ClaymanTwinkle/godot-cli-control/blob/main/addons/godot_cli_control/CHANGELOG.md"
+Issues = "https://github.com/ClaymanTwinkle/godot-cli-control/issues"
 
 [tool.pytest.ini_options]
 # pytest-asyncio：显式钉死 async fixture 的 loop scope 为 function（= 未来版本默认值），

--- a/python/README.md
+++ b/python/README.md
@@ -8,7 +8,7 @@ WebSocket bridge for headless / scripted control of Godot 4 scenes — Python cl
 pipx install godot-cli-control
 
 # or, for unreleased main:
-pipx install "git+https://github.com/ClaymanTwinkle/godot-cli-control.git#subdirectory=python"
+pipx install "git+https://github.com/ClaymanTwinkle/godot-cli-control.git"
 ```
 
 The wheel ships the Godot plugin source so the `init` command can drop it into your project.


### PR DESCRIPTION
## 目标

让项目更容易被发现（GitHub + PyPI）并降低首次贡献门槛。承接「如何让本项目成为受欢迎的 GitHub 项目」讨论里的 Tier 2 + Tier 3 代码项，并顺手修掉过程中发现的文档 bug。

## 改动

**1. PyPI 元数据（`pyproject.toml`）**
- `keywords` ×14，与 repo topics 对齐
- `classifiers` ×12：含 `Framework :: Pytest`（进 PyPI pytest 插件分类）、`Topic :: Software Development :: Testing` / `Games/Entertainment`、Python 3.10–3.13（按 CI matrix 如实写）
- `[project.urls]` ×5：Homepage / Repository / Documentation / Changelog / Issues，填上此前空白的 PyPI 侧栏链接
- 已本地 `uv build --wheel` 验证 METADATA 正确、无 PEP 639 / classifier 告警
- ⚠️ 元数据要**下次发版随 wheel** 才会在 PyPI 上生效

**2. 社区健康文件（`.github/`）**
- `CONTRIBUTING.md`：开发/测试/lint 命令 + 把 AI 友好契约（JSON 信封 / 错误码三段 / 退出码语义 / shell canonical / preflight / SKILL.md 同步 / localhost 安全网）列成贡献红线 + 新增 RPC 五步流程
- `SECURITY.md`：锚定真实安全模型 + 引导 GitHub 私密漏洞上报
- `ISSUE_TEMPLATE/`：bug（要 CLI/Godot 版本 + 单行 JSON 信封）、feature（按 surface 归类）、config（关空白 issue + 文档/安全链接）
- `PULL_REQUEST_TEMPLATE.md`：核心勾选项「改 CLI/错误码/默认值必同步 SKILL.md」

**3. 文档修复（#94）**
- 删掉 `README.md` / `python/README.md` 里失效的 `#subdirectory=python` git 安装后缀。构建根已上移到仓库根，`python/` 下无 `pyproject.toml`，旧命令会让 pip 进 `python/` 找不到构建配置而失败。
- 已**实跑验证**：旧命令 `pip install "git+...#subdirectory=python"` → 失败（`neither 'setup.py' nor 'pyproject.toml' found`）；新命令 `pip install "git+..."` → 成功，`godot-cli-control --version` 打印 `0.2.13`。

CODE_OF_CONDUCT 暂不纳入；CONTRIBUTING 内引 Contributor Covenant 外链（无死链）。

## 合并 / 生效前提
- issue 选择器、PR 模板、Security policy、CONTRIBUTING 提示**只读默认分支** → 合进 `main` 才生效
- `SECURITY.md` 的私密上报链接需在 Settings → Security 打开 **Private vulnerability reporting**

## 关联

Closes #94

## 自检
- [x] 仅文档 / 打包元数据，无运行时逻辑改动
- [x] 三个 issue 表单 YAML 解析通过
- [x] wheel 构建通过，METADATA 三类字段正确
- [x] 安装命令修复经真实 pip install 双向验证（旧失败 / 新成功）

🤖 Generated with [Claude Code](https://claude.com/claude-code)