### PR TITLE
feat(get): Variant 编码对称化 + get_properties 同帧原子读 (#99, #100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Godot ships great tools for *playing* a scene, but very little for *programmatic
 
 One install, one daemon, one consistent API across your editor, your tests, your CI, and your agents.
 
+## Recent changes
+
+**BREAKING (unreleased):** `get` now returns compound Variants (Vector2, Color, etc.) as a structured object `{"value": [x, y], "type": "Vector2"}` instead of the old `"(x, y)"` string. The `value` array is the same layout `set` accepts, so round-trips work directly. Also new: `get <path> <prop1> <prop2>` reads multiple properties atomically in one frame (`get_properties` RPC, #100).
+
 ## Highlights
 
 | | |

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING** `get` 复合 Variant 返回从旧版 `"(x, y)"` 字符串改为 set-schema 数组 + type 字段；信封 result 从裸值变 `{"value": <array-or-scalar>, "type"?: "<GodotType>"}` 对象（#99）。写侧 `set` 接受的 Array layout 完全一致，get→set round-trip 无需转换。Python API `get_property` / `get_properties` 只返回裸 value（type 已剥离），要拿 type 字段走 CLI `get` 或底层 `client.request("get_property", ...)`。
+
+### Added
+- **feat: `get_properties` 多属性同帧原子读 + `get` 多属性形式（#100）**：`get <path> <prop1> <prop2>` 一次 RPC 同帧读取多个属性，不存在部分新鲜/部分旧数据的竞态；任一属性缺失整体失败（1002，message 点名所有缺失项）。sub-path 形式（`position:x`）在多属性列表中也支持。
+
 ### Fixed
 - **#52 `set` 走 JSON Array 喂 Vector/Color/Rect 时静默失败**：`set zoom '[1.8, 1.8]'` 等价于 `node.set("zoom", [1.8, 1.8])`，Godot 隐式构造失败 → 实际值是 `Vector2(0,0)` 或被 clamp 到 `0.00001`，但服务端仍返 `{success: true}`。`handle_set_property` 现在查 `get_property_list()` 拿声明类型，把 numeric Array 转成对应 Variant。长度不匹配或元素非数字时 fail-loud 返 `-32602 "value type mismatch ..."`，不再 silent corruption。
 - **sub-path 标量赋值现在真的会写入**：之前 `set <node> position:x 1.8` 调的是 `Object.set("position:x", 1.8)`，Godot 4 的 `Object.set` 把整串当字面属性名找不到就 silent no-op（依旧返 `{success: true}` 但 `position.x` 不变）。改用 `Object.set_indexed(NodePath, value)` 才会按 sub-path 写入。是 #54 review 阶段被新加的 `test_set_subpath_scalar_still_works` 捕获的隐藏 silent-fail。

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -83,7 +83,8 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 | Method | Example |
 |---|---|
 | `click(path)` | `await client.click("/root/MyScene/Button")` |
-| `get_property(path, property)` | `await client.get_property("/root/Player", "position")` |
+| `get_property(path, property)` | `await client.get_property("/root/Player", "position")` — returns bare value; CLI `get` returns `{"value": ..., "type"?: ...}` shape |
+| `get_properties(path, properties)` | `await client.get_properties("/root/Player", ["position", "health"])` — multi-property atomic read; returns `{prop: bare_value, ...}` dict |
 | `set_property(path, property, value)` | `await client.set_property("/root/Player", "visible", False)` |
 | `call_method(path, method, args)` | `await client.call_method("/root/Player", "take_damage", [10])` |
 | `get_text(path)` | `await client.get_text("/root/UI/Label")` |

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -176,6 +176,7 @@ func _register_methods() -> void:
 	# 低层 API（同步）
 	_methods["click"] = {"callable": _low_level_api.handle_click, "kind": "sync"}
 	_methods["get_property"] = {"callable": _low_level_api.handle_get_property, "kind": "sync"}
+	_methods["get_properties"] = {"callable": _low_level_api.handle_get_properties, "kind": "sync"}
 	_methods["set_property"] = {"callable": _low_level_api.handle_set_property, "kind": "sync"}
 	_methods["call_method"] = {"callable": _low_level_api.handle_call_method, "kind": "sync"}
 	_methods["get_text"] = {"callable": _low_level_api.handle_get_text, "kind": "sync"}

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -115,11 +115,27 @@ func handle_get_property(params: Dictionary) -> Dictionary:
 	var node: Node = _get_node_or_error(params)
 	if node == null:
 		return _node_not_found(params.get("path", "") as String)
-	var property: String = params.get("property", "") as String
+	var read: Dictionary = _read_property(node, params.get("property", "") as String)
+	if read.has("error"):
+		return read
+	# issue #99：复合 Variant 走 codec 编码（与 set 侧 array schema 对称），
+	# 返回 {"value": ..., "type": <仅复合类型>}，round-trip 闭环。
+	return CliControlVariantCodec.encode(read["value"])
+
+
+## 读单个属性，支持 sub-path（"position:x"，与 set 侧对称走 get_indexed）。
+## 返回 {"value": Variant} 或 {"error": ...}。
+## sub-path 的 leaf 非法时 get_indexed 返回 null——与「真 null 值」无法区分，
+## SKILL.md 已声明该边界；这里只校验 ":" 前的 top-level 名存在（1002 兜底 typo）。
+func _read_property(node: Node, property: String) -> Dictionary:
 	if property.is_empty():
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'property' parameter")
-	if not _has_property(node, property):
-		return _err(CliControlErrorCodes.PROPERTY_NOT_FOUND, "Property not found: %s" % property)
+	var is_sub_path: bool = ":" in property
+	var top_level: String = property.split(":", true, 1)[0] if is_sub_path else property
+	if not _has_property(node, top_level):
+		return _err(CliControlErrorCodes.PROPERTY_NOT_FOUND, "Property not found: %s" % top_level)
+	if is_sub_path:
+		return {"value": node.get_indexed(NodePath(property))}
 	return {"value": node.get(property)}
 
 

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -126,7 +126,8 @@ func handle_get_property(params: Dictionary) -> Dictionary:
 ## 读单个属性，支持 sub-path（"position:x"，与 set 侧对称走 get_indexed）。
 ## 返回 {"value": Variant} 或 {"error": ...}。
 ## sub-path 的 leaf 非法时 get_indexed 返回 null——与「真 null 值」无法区分，
-## SKILL.md 已声明该边界；这里只校验 ":" 前的 top-level 名存在（1002 兜底 typo）。
+## SKILL.md 已声明该边界（pitfalls 中「Sub-path reading a non-existent leaf」一条）；
+## 这里只校验 ":" 前的 top-level 名存在（1002 兜底 typo）。
 func _read_property(node: Node, property: String) -> Dictionary:
 	if property.is_empty():
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'property' parameter")

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -139,6 +139,36 @@ func _read_property(node: Node, property: String) -> Dictionary:
 	return {"value": node.get(property)}
 
 
+## issue #100：多属性同帧原子读。sync handler 无 await——所有读取天然同一帧。
+## 原子语义：任一属性缺失整体失败（1002 点名全部缺失项），不返回半新半旧组合。
+func handle_get_properties(params: Dictionary) -> Dictionary:
+	var node: Node = _get_node_or_error(params)
+	if node == null:
+		return _node_not_found(params.get("path", "") as String)
+	var props_raw: Variant = params.get("properties", null)
+	if not props_raw is Array or (props_raw as Array).is_empty():
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'properties' must be a non-empty array of strings")
+	var props: Array = props_raw as Array
+	var missing: PackedStringArray = []
+	for raw_prop: Variant in props:
+		if not raw_prop is String or (raw_prop as String).is_empty():
+			return _err(CliControlErrorCodes.INVALID_PARAMS, "'properties' must be a non-empty array of strings")
+		var prop_name: String = raw_prop as String
+		var top_level: String = prop_name.split(":", true, 1)[0] if ":" in prop_name else prop_name
+		if not _has_property(node, top_level):
+			missing.append(prop_name)
+	if not missing.is_empty():
+		return _err(CliControlErrorCodes.PROPERTY_NOT_FOUND, "Properties not found: %s" % ", ".join(missing))
+	var values: Dictionary = {}
+	for raw_prop2: Variant in props:
+		var prop_name2: String = raw_prop2 as String
+		var read: Dictionary = _read_property(node, prop_name2)
+		if read.has("error"):
+			return read  # 防御纵深：上面已全量校验，理论到不了这里
+		values[prop_name2] = CliControlVariantCodec.encode(read["value"])
+	return {"values": values}
+
+
 func handle_set_property(params: Dictionary) -> Dictionary:
 	var node: Node = _get_node_or_error(params)
 	if node == null:

--- a/addons/godot_cli_control/bridge/variant_codec.gd
+++ b/addons/godot_cli_control/bridge/variant_codec.gd
@@ -1,0 +1,141 @@
+class_name CliControlVariantCodec
+extends RefCounted
+## Variant → JSON-safe 编码（issue #99）。
+##
+## 与 set 侧 low_level_api.gd::_coerce_array_to_declared_type 的 array schema
+## **完全对称**（axis-vector 顺序，见该函数 docstring 的 schema 表）：
+## get 输出的 value 数组可原样灌回 set，round-trip 闭环。
+## Color 不对称提示：set 接受 3 或 4 元，这里恒输出 4 元（4 灌 4 成立）。
+##
+## 全函数：任何 Variant 都有确定输出、不报错——杜绝「响应永远不发出」类挂死。
+## type 字段只在 encode() 顶层出现；嵌套（Array/Dictionary 内）复合类型由
+## encode_value() 递归编码为数组但不带 type（spec 声明的取舍）。
+
+const _COMPOUND_TYPE_NAMES: Dictionary = {
+	TYPE_VECTOR2: "Vector2", TYPE_VECTOR2I: "Vector2i",
+	TYPE_VECTOR3: "Vector3", TYPE_VECTOR3I: "Vector3i",
+	TYPE_VECTOR4: "Vector4", TYPE_VECTOR4I: "Vector4i",
+	TYPE_RECT2: "Rect2", TYPE_RECT2I: "Rect2i",
+	TYPE_COLOR: "Color", TYPE_PLANE: "Plane",
+	TYPE_QUATERNION: "Quaternion", TYPE_AABB: "AABB",
+	TYPE_BASIS: "Basis", TYPE_TRANSFORM2D: "Transform2D",
+	TYPE_TRANSFORM3D: "Transform3D", TYPE_PROJECTION: "Projection",
+}
+
+# 递归编码深度上限：防病态深树 / 自引用容器爆栈挂死 daemon
+# （与 low_level_api.gd _BUILD_TREE_DEFAULT_MAX_DEPTH 同源精神）。
+# 超限降级为哨兵字符串而非报错——保住「全函数」承诺。
+const _MAX_ENCODE_DEPTH: int = 64
+const _DEPTH_SENTINEL: String = "<max-depth-exceeded>"
+
+
+## 顶层编码：返回 {"value": <json-safe>}，复合类型 / StringName / NodePath /
+## Object 额外带 "type" 字段。
+## Object / StringName / NodePath 是诊断性单向编码（不参与 round-trip 闭环），
+## 与 Vector/Color/Array 等复合类型的无损 round-trip 严格区分。
+## 深度上限：容器嵌套超过 _MAX_ENCODE_DEPTH 层时以哨兵字符串降级，保住全函数承诺。
+static func encode(v: Variant) -> Dictionary:
+	var t: int = typeof(v)
+	if _COMPOUND_TYPE_NAMES.has(t):
+		return {"value": encode_value(v), "type": _COMPOUND_TYPE_NAMES[t]}
+	match t:
+		TYPE_STRING_NAME:
+			return {"value": String(v), "type": "StringName"}
+		TYPE_NODE_PATH:
+			return {"value": String(v), "type": "NodePath"}
+		TYPE_OBJECT:
+			return {"value": str(v), "type": "Object"}
+	return {"value": encode_value(v)}
+
+
+## 递归值编码（无 type 信息）。JSON 原生类型原样；复合 → set-schema 数组；
+## 非有限 float → "inf"/"-inf"/"nan" 字符串（JSON.stringify 对 inf/nan 产非法 JSON）。
+## depth 超过 _MAX_ENCODE_DEPTH 时返回哨兵字符串，不报错——保住全函数承诺。
+static func encode_value(v: Variant, depth: int = 0) -> Variant:
+	if depth > _MAX_ENCODE_DEPTH:
+		return _DEPTH_SENTINEL
+	match typeof(v):
+		TYPE_FLOAT:
+			return _f(v)
+		TYPE_VECTOR2:
+			return [_f(v.x), _f(v.y)]
+		TYPE_VECTOR2I:
+			return [v.x, v.y]
+		TYPE_VECTOR3:
+			return [_f(v.x), _f(v.y), _f(v.z)]
+		TYPE_VECTOR3I:
+			return [v.x, v.y, v.z]
+		TYPE_VECTOR4:
+			return [_f(v.x), _f(v.y), _f(v.z), _f(v.w)]
+		TYPE_VECTOR4I:
+			return [v.x, v.y, v.z, v.w]
+		TYPE_RECT2:
+			return [_f(v.position.x), _f(v.position.y), _f(v.size.x), _f(v.size.y)]
+		TYPE_RECT2I:
+			return [v.position.x, v.position.y, v.size.x, v.size.y]
+		TYPE_COLOR:
+			return [_f(v.r), _f(v.g), _f(v.b), _f(v.a)]
+		TYPE_PLANE:
+			return [_f(v.normal.x), _f(v.normal.y), _f(v.normal.z), _f(v.d)]
+		TYPE_QUATERNION:
+			return [_f(v.x), _f(v.y), _f(v.z), _f(v.w)]
+		TYPE_AABB:
+			return [
+				_f(v.position.x), _f(v.position.y), _f(v.position.z),
+				_f(v.size.x), _f(v.size.y), _f(v.size.z),
+			]
+		TYPE_BASIS:
+			return _basis_to_array(v)
+		TYPE_TRANSFORM2D:
+			return [_f(v.x.x), _f(v.x.y), _f(v.y.x), _f(v.y.y), _f(v.origin.x), _f(v.origin.y)]
+		TYPE_TRANSFORM3D:
+			var t3_out: Array = _basis_to_array(v.basis)
+			t3_out.append_array([_f(v.origin.x), _f(v.origin.y), _f(v.origin.z)])
+			return t3_out
+		TYPE_PROJECTION:
+			return [
+				_f(v.x.x), _f(v.x.y), _f(v.x.z), _f(v.x.w),
+				_f(v.y.x), _f(v.y.y), _f(v.y.z), _f(v.y.w),
+				_f(v.z.x), _f(v.z.y), _f(v.z.z), _f(v.z.w),
+				_f(v.w.x), _f(v.w.y), _f(v.w.z), _f(v.w.w),
+			]
+		TYPE_STRING_NAME, TYPE_NODE_PATH:
+			return String(v)
+		TYPE_OBJECT:
+			return str(v)
+		TYPE_ARRAY:
+			var arr_out: Array = []
+			for item: Variant in (v as Array):
+				arr_out.append(encode_value(item, depth + 1))
+			return arr_out
+		TYPE_DICTIONARY:
+			var dict_out: Dictionary = {}
+			var dict_in: Dictionary = v as Dictionary
+			for key: Variant in dict_in:
+				dict_out[str(key)] = encode_value(dict_in[key], depth + 1)
+			return dict_out
+		TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY, TYPE_PACKED_STRING_ARRAY:
+			return Array(v)
+		TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY, TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, TYPE_PACKED_COLOR_ARRAY, TYPE_PACKED_VECTOR4_ARRAY:
+			var packed_out: Array = []
+			for item: Variant in v:
+				packed_out.append(encode_value(item, depth + 1))
+			return packed_out
+	return v  # bool / int / String / null
+
+
+## axis-vector 顺序：x/y/z 轴各 3 floats，与 set 侧 Basis(x_axis, y_axis, z_axis) 一致
+static func _basis_to_array(b: Basis) -> Array:
+	return [
+		_f(b.x.x), _f(b.x.y), _f(b.x.z),
+		_f(b.y.x), _f(b.y.y), _f(b.y.z),
+		_f(b.z.x), _f(b.z.y), _f(b.z.z),
+	]
+
+
+static func _f(f: float) -> Variant:
+	if is_nan(f):
+		return "nan"
+	if is_inf(f):
+		return "inf" if f > 0.0 else "-inf"
+	return f

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -766,3 +766,43 @@ func test_get_set_round_trip_vector2() -> void:
 	assert_false(set_result.has("error"))
 	var got2: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "position"})
 	assert_eq(got2["value"], got["value"])
+
+
+# ── issue #100：get_properties 同帧原子读 ──
+
+func test_get_properties_returns_all_encoded() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(1.0, 2.0)
+	node.visible = true
+	var result: Dictionary = _api.handle_get_properties({
+		"path": str(node.get_path()), "properties": ["position", "visible", "position:y"],
+	})
+	assert_false(result.has("error"))
+	var values: Dictionary = result["values"]
+	assert_eq(values["position"], {"value": [1.0, 2.0], "type": "Vector2"})
+	assert_eq(values["visible"], {"value": true})
+	assert_eq(values["position:y"], {"value": 2.0})
+
+
+func test_get_properties_missing_prop_fails_atomically_naming_all() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	var result: Dictionary = _api.handle_get_properties({
+		"path": str(node.get_path()), "properties": ["position", "nope1", "nope2"],
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1002)
+	assert_string_contains(str(result.error.message), "nope1")
+	assert_string_contains(str(result.error.message), "nope2")
+
+
+func test_get_properties_rejects_empty_or_non_string() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	for bad: Variant in [[], null, [1], [""]]:
+		var result: Dictionary = _api.handle_get_properties({
+			"path": str(node.get_path()), "properties": bad,
+		})
+		assert_has(result, "error", "properties=%s 应报错" % [bad])
+		assert_eq(int(result.error.code), -32602)

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -717,3 +717,52 @@ func test_screenshot_returns_image_or_1006_under_headless() -> void:
 func test_screenshot_max_frames_constant_is_positive() -> void:
 	# 防回归：常量被改成 0 或负数会让循环立刻退出 → 等同未修。
 	assert_gt(LowLevelApiScript.SCREENSHOT_MAX_FRAMES, 0)
+
+
+# ── issue #99：get 编码 + sub-path 读 ──
+
+func test_get_property_encodes_vector2_with_type() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(1.5, -2.0)
+	var result: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "position"})
+	assert_eq(result.get("value"), [1.5, -2.0])
+	assert_eq(result.get("type"), "Vector2")
+
+
+func test_get_property_primitive_has_no_type_field() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.visible = false
+	var result: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "visible"})
+	assert_eq(result, {"value": false})
+
+
+func test_get_property_sub_path_reads_leaf() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(7.0, 9.0)
+	var result: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "position:x"})
+	assert_eq(result, {"value": 7.0})
+
+
+func test_get_property_sub_path_bogus_top_level_is_1002() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	var result: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "nope:x"})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1002)
+
+
+func test_get_set_round_trip_vector2() -> void:
+	# round-trip 闭环：get 输出的数组原样灌回 set，再 get 等值
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(3.25, -4.5)
+	var got: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "position"})
+	var set_result: Dictionary = _api.handle_set_property({
+		"path": str(node.get_path()), "property": "position", "value": got["value"],
+	})
+	assert_false(set_result.has("error"))
+	var got2: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "position"})
+	assert_eq(got2["value"], got["value"])

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -806,3 +806,38 @@ func test_get_properties_rejects_empty_or_non_string() -> void:
 		})
 		assert_has(result, "error", "properties=%s 应报错" % [bad])
 		assert_eq(int(result.error.code), -32602)
+
+
+# ── get_properties 边界：sub-path 缺失项 + 重复属性（review 遗留）──
+
+func test_get_properties_missing_sub_path_names_full_key() -> void:
+	# 缺失项是 sub-path 形式时，1002 error message 必须点全名（含 ":"）。
+	# 回归：早期实现只校验 top-level 名，message 里丢掉了 sub-path 后半部分，
+	# 让 agent 无法直接从 message 得知是哪个完整 key 出了问题。
+	var node := Node2D.new()
+	add_child_autofree(node)
+	var result: Dictionary = _api.handle_get_properties({
+		"path": str(node.get_path()),
+		"properties": ["position", "nope:x"],
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1002)
+	# message 必须含完整的 "nope:x"，而不是只有 "nope"
+	assert_string_contains(str(result.error.message), "nope:x")
+
+
+func test_get_properties_duplicate_property_deduped_by_dict() -> void:
+	# 重复属性（["position", "position"]）行为锁定：Dictionary key 语义去重，
+	# values 里 "position" 只有一个 entry（有意行为，和 JSON Dict 的 key-uniqueness 对齐）。
+	# 注意：这是锁定已有行为，而非新增功能——改动此断言前请确认变更是有意而为之。
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(5.0, 6.0)
+	var result: Dictionary = _api.handle_get_properties({
+		"path": str(node.get_path()),
+		"properties": ["position", "position"],
+	})
+	assert_false(result.has("error"), "重复属性不应报错")
+	var values: Dictionary = result["values"]
+	# Dictionary 赋值重复 key 只保留最后一次，故 values 恰好有 1 个 key
+	assert_eq(values.size(), 1, "重复 key 在 Dictionary 语义下去重为 1 条（有意行为）")

--- a/addons/godot_cli_control/tests/gut/test_variant_codec.gd
+++ b/addons/godot_cli_control/tests/gut/test_variant_codec.gd
@@ -1,0 +1,115 @@
+## GUT：CliControlVariantCodec —— Variant → JSON-safe 编码（issue #99）
+## 关键不变量：编码输出与 set 侧 _coerce_array_to_declared_type 的 array schema
+## 完全对称（axis-vector 顺序），get 输出可原样灌回 set。
+extends GutTest
+
+const Codec := preload("res://addons/godot_cli_control/bridge/variant_codec.gd")
+
+
+func test_primitives_pass_through_without_type() -> void:
+	assert_eq(Codec.encode(true), {"value": true})
+	assert_eq(Codec.encode(42), {"value": 42})
+	assert_eq(Codec.encode(1.5), {"value": 1.5})
+	assert_eq(Codec.encode("hi"), {"value": "hi"})
+	assert_eq(Codec.encode(null), {"value": null})
+
+
+func test_compound_types_table() -> void:
+	# [输入 Variant, 期望 value, 期望 type]
+	var cases: Array = [
+		[Vector2(1.5, -2.0), [1.5, -2.0], "Vector2"],
+		[Vector2i(1, 2), [1, 2], "Vector2i"],
+		[Vector3(1, 2, 3), [1.0, 2.0, 3.0], "Vector3"],
+		[Vector3i(1, 2, 3), [1, 2, 3], "Vector3i"],
+		[Vector4(1, 2, 3, 4), [1.0, 2.0, 3.0, 4.0], "Vector4"],
+		[Vector4i(1, 2, 3, 4), [1, 2, 3, 4], "Vector4i"],
+		[Rect2(1, 2, 3, 4), [1.0, 2.0, 3.0, 4.0], "Rect2"],
+		[Rect2i(1, 2, 3, 4), [1, 2, 3, 4], "Rect2i"],
+		[Color(0.1, 0.2, 0.3), [Color(0.1, 0.2, 0.3).r, Color(0.1, 0.2, 0.3).g, Color(0.1, 0.2, 0.3).b, 1.0], "Color"],
+		[Plane(0, 1, 0, 5), [0.0, 1.0, 0.0, 5.0], "Plane"],
+		[Quaternion(0, 0, 0, 1), [0.0, 0.0, 0.0, 1.0], "Quaternion"],
+		[AABB(Vector3(1, 2, 3), Vector3(4, 5, 6)), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], "AABB"],
+		[Basis.IDENTITY, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0], "Basis"],
+		[Transform2D.IDENTITY, [1.0, 0.0, 0.0, 1.0, 0.0, 0.0], "Transform2D"],
+		[Transform3D.IDENTITY, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0], "Transform3D"],
+		[Projection.IDENTITY, [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0], "Projection"],
+	]
+	for case: Array in cases:
+		var encoded: Dictionary = Codec.encode(case[0])
+		assert_eq(encoded.get("type"), case[2], "type for %s" % [case[0]])
+		assert_eq(encoded.get("value"), case[1], "value for %s" % [case[0]])
+
+
+func test_string_name_node_path_object() -> void:
+	assert_eq(Codec.encode(&"sn"), {"value": "sn", "type": "StringName"})
+	assert_eq(Codec.encode(NodePath("/root/A")), {"value": "/root/A", "type": "NodePath"})
+	var node := Node.new()
+	var encoded: Dictionary = Codec.encode(node)
+	assert_eq(encoded.get("type"), "Object")
+	assert_true(encoded.get("value") is String)
+	node.free()
+
+
+func test_nested_compound_encodes_without_type() -> void:
+	# 嵌套复合类型：递归编码为数组但不带 type（spec 已声明的取舍）
+	var encoded: Dictionary = Codec.encode([Vector2(1, 2), {"p": Vector3(3, 4, 5)}])
+	assert_false(encoded.has("type"))
+	assert_eq(encoded["value"], [[1.0, 2.0], {"p": [3.0, 4.0, 5.0]}])
+
+
+func test_non_finite_floats_become_strings() -> void:
+	assert_eq(Codec.encode(INF), {"value": "inf"})
+	assert_eq(Codec.encode(-INF), {"value": "-inf"})
+	assert_eq(Codec.encode(NAN), {"value": "nan"})
+	assert_eq(Codec.encode(Vector2(INF, 1.0)), {"value": ["inf", 1.0], "type": "Vector2"})
+
+
+func test_packed_arrays_become_plain_arrays() -> void:
+	assert_eq(Codec.encode(PackedInt32Array([1, 2])), {"value": [1, 2]})
+	assert_eq(Codec.encode(PackedFloat64Array([1.5])), {"value": [1.5]})
+	assert_eq(Codec.encode(PackedStringArray(["a"])), {"value": ["a"]})
+	assert_eq(
+		Codec.encode(PackedVector2Array([Vector2(1, 2)])),
+		{"value": [[1.0, 2.0]]}
+	)
+
+
+func test_deep_nesting_truncates_at_max_depth() -> void:
+	# 超过 _MAX_ENCODE_DEPTH 的深树降级为哨兵，不爆栈
+	var deep: Array = []
+	var cursor: Array = deep
+	for _i in 100:
+		var inner: Array = []
+		cursor.append(inner)
+		cursor = inner
+	cursor.append(42)
+	var encoded: Dictionary = Codec.encode(deep)
+	assert_true(JSON.stringify(encoded["value"]).contains("<max-depth-exceeded>"))
+
+
+func test_self_referential_array_terminates() -> void:
+	var a: Array = [1]
+	a.append(a)
+	var encoded: Dictionary = Codec.encode(a)
+	assert_true(JSON.stringify(encoded["value"]).contains("<max-depth-exceeded>"))
+	a.clear()  # 解开自引用，避免 Godot 退出时 ObjectDB 泄漏警告
+
+
+func test_self_referential_dictionary_terminates() -> void:
+	var d: Dictionary = {"x": 1}
+	d["self"] = d
+	var encoded: Dictionary = Codec.encode(d)
+	assert_true(JSON.stringify(encoded["value"]).contains("<max-depth-exceeded>"))
+	d.clear()  # 解开自引用，避免 Godot 退出时 ObjectDB 泄漏警告
+
+
+func test_packed_byte_array_minor() -> void:
+	assert_eq(Codec.encode(PackedByteArray([1, 2])), {"value": [1, 2]})
+
+
+func test_packed_int64_array_minor() -> void:
+	assert_eq(Codec.encode(PackedInt64Array([9])), {"value": [9]})
+
+
+func test_int_key_dictionary_minor() -> void:
+	assert_eq(Codec.encode({1: "a"}), {"value": {"1": "a"}})

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -143,6 +143,10 @@ class GameBridge:
         """获取节点属性。"""
         return self._run(self._client.get_property(path, prop))
 
+    def get_properties(self, path: str, props: list[str]) -> dict[str, Any]:
+        """同帧原子读多个属性（issue #100），返回 {prop: value} 映射。"""
+        return self._run(self._client.get_properties(path, props))
+
     def set_property(self, path: str, prop: str, value: Any) -> None:
         """设置节点属性。"""
         self._run(self._client.set_property(path, prop, value))

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -341,9 +341,21 @@ async def cmd_release_all(client: GameClient, ns: argparse.Namespace) -> dict:
 # ── 新增的 12 个 AI 友好命令 ──
 
 
-async def cmd_get(client: GameClient, ns: argparse.Namespace) -> Any:
-    """读节点属性，返回原值（字符串/数字/数组/对象/null）。"""
-    return await client.get_property(ns.node_path, ns.prop)
+async def cmd_get(client: GameClient, ns: argparse.Namespace) -> dict:
+    """读节点属性（1 个或多个，支持 sub-path 如 position:x）。
+
+    透传 RPC result（带 type 字段）——client.get_property 的裸 value 是给
+    Python 脚本的便捷层；CLI 信封必须带 type 给 agent 消歧（issue #99/#100）。
+    单属性 result={"value", "type"?}；多属性 result={"values": {...}}。
+    """
+    props: list[str] = ns.props
+    if len(props) == 1:
+        return await client.request(
+            "get_property", {"path": ns.node_path, "property": props[0]}
+        )
+    return await client.request(
+        "get_properties", {"path": ns.node_path, "properties": props}
+    )
 
 
 async def cmd_set(client: GameClient, ns: argparse.Namespace) -> dict:
@@ -432,6 +444,16 @@ def _fmt_get_text(value: Any) -> str:
     if isinstance(value, str):
         return value
     return json.dumps(value, ensure_ascii=False)
+
+
+def _fmt_get_result_text(r: dict) -> str:
+    """get 的文本渲染：单属性打印 value；多属性每行 ``prop = value``。"""
+    if "values" in r:
+        return "\n".join(
+            f"{prop} = {_fmt_get_text(entry.get('value'))}"
+            for prop, entry in r["values"].items()
+        )
+    return _fmt_get_text(r.get("value"))
 
 
 def _fmt_tree_text(tree: Any) -> str:
@@ -676,13 +698,17 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
     RpcSpec(
         name="get",
         handler=cmd_get,
-        description="读节点属性。",
+        description=(
+            "读节点属性（1 个或多个；多个时服务端同帧原子读，issue #100）。"
+            "复合类型（Vector2 等）返回与 set 同 schema 的数组 + type 字段，"
+            "可直接回灌 set（issue #99）。支持 sub-path：position:x。"
+        ),
         positionals=(
             Positional("node_path", None, "绝对节点路径，如 /root/Main"),
-            Positional("prop", None, "属性名，如 position / text / visible"),
+            Positional("props", "+", "属性名，1 个或多个；支持 sub-path 如 position:x"),
         ),
-        example="get /root/Main/Score text",
-        text_formatter=_fmt_get_text,
+        example="get /root/Player position visible",
+        text_formatter=_fmt_get_result_text,
     ),
     RpcSpec(
         name="set",

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -450,7 +450,7 @@ def _fmt_get_result_text(r: dict) -> str:
     """get 的文本渲染：单属性打印 value；多属性每行 ``prop = value``。"""
     if "values" in r:
         return "\n".join(
-            f"{prop} = {_fmt_get_text(entry.get('value'))}"
+            f"{prop} = {_fmt_get_text(entry.get('value') if isinstance(entry, dict) else entry)}"
             for prop, entry in r["values"].items()
         )
     return _fmt_get_text(r.get("value"))

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -258,6 +258,20 @@ class GameClient:
         )
         return result.get("value")
 
+    async def get_properties(self, path: str, props: list[str]) -> dict[str, Any]:
+        """同帧原子读多个属性（issue #100），返回 {prop: 裸 value} 映射。
+
+        type 字段是给 CLI JSON 信封的（agent 消费）；Python 层要 type 时直接
+        ``await client.request("get_properties", ...)`` 拿原始 result。
+        """
+        result = await self.request(
+            "get_properties", {"path": path, "properties": list(props)}
+        )
+        return {
+            k: (v.get("value") if isinstance(v, dict) else v)
+            for k, v in result.get("values", {}).items()
+        }
+
     async def set_property(self, path: str, prop: str, value: Any) -> dict:
         return await self.request(
             "set_property", {"path": path, "property": prop, "value": value}

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -84,6 +84,18 @@ $ godot-cli-control click /root/DoesNotExist
 $ godot-cli-control --text exists /root/Main
 true
 
+$ godot-cli-control get /root/Player position
+{"ok": true, "result": {"value": [-2480.0, 1400.0], "type": "Vector2"}}
+
+$ godot-cli-control get /root/Player visible
+{"ok": true, "result": {"value": true}}
+
+$ godot-cli-control get /root/Player position:x
+{"ok": true, "result": {"value": -2480.0}}
+
+$ godot-cli-control get /root/Player position health
+{"ok": true, "result": {"values": {"position": {"value": [-2480.0, 1400.0], "type": "Vector2"}, "health": {"value": 80}}}}
+
 $ godot-cli-control init
 {"ok": true, "result": {"project_root": "/path/to/proj", "plugin_copied": true, "plugin_overwritten": false, "project_godot_changes": ["autoload/GameBridgeNode", "editor_plugins/enabled"], "godot_bin": "/usr/bin/godot", "skills_written": [".../SKILL.md", ".../SKILL.md"], "gitignore_added": [".cli_control/"], "skills_only": false, "write_skills": true}}
 
@@ -138,7 +150,7 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 ## Command catalogue
 
 **Read:**
-- `get <path> <prop>` — read a node property
+- `get <path> <prop> [<prop2> ...]` — read one or more node properties in a single atomic frame. Single-property result: `{"value": <encoded>, "type": "<GodotType>"}` (type field present only for compound Variants — Vector2, Color, etc.; absent for primitives like `bool`/`int`/`float`/`String`). Multi-property result: `{"values": {"<prop>": {"value": ..., "type"?: ...}, ...}}`. Sub-path form: `get <path> position:x` reads a scalar leaf of a compound Variant (e.g. returns `{"value": 1.5}` with no type field). Security note: sub-path reading can reach write-blacklisted nested attributes (e.g. `script:source_code`) — read-only diagnostic capability, intentional under localhost-only + debug-build gate.
 - `text <path>` — read Label / Button text
 - `exists <path>` — boolean existence check (exit-code-as-result)
 - `visible <path>` — boolean visibility check (exit-code-as-result)
@@ -313,7 +325,8 @@ Errors raise `RpcError(code, message)` (a `RuntimeError` subclass) that preserve
 | Method | CLI equivalent |
 |---|---|
 | `await client.click(path)` | `click <path>` |
-| `await client.get_property(path, prop)` | `get <path> <prop>` |
+| `await client.get_property(path, prop)` | `get <path> <prop>` — returns bare value only (no type field); use `client.request("get_property", ...)` to get `{"value", "type"}` shape |
+| `await client.get_properties(path, props)` | `get <path> <prop1> <prop2> ...` — returns `{prop: bare_value, ...}` dict (no type fields); use `client.request("get_properties", ...)` for full shape |
 | `await client.set_property(path, prop, value)` | `set <path> <prop> <json-value>` |
 | `await client.call_method(path, method, args)` | `call <path> <method> [json-args...]` |
 | `await client.get_text(path)` | `text <path>` |
@@ -408,6 +421,10 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **`run <script>` opens a window even though stdout is piped** — by design. `run` grep's the script for `screenshot` and force-flips to GUI when found, so `bridge.screenshot(...)` doesn't 1006-fail under the dummy renderer. Pass `--no-gui-auto` to disable detection; explicit `--headless` always wins. See issue #65.
 - **`screenshot` used to fail with `1006` on the first call** — fixed. GameBridge now waits for the viewport's first frame before opening the port, so `connect succeeded` implies `viewport has rendered ≥ once`. The magic `bridge.wait(1.5)` before the first screenshot in older example scripts is no longer needed.
 - **`press`/`tap`/`hold`/`combo` inject `InputEventAction` (no mouse coordinates) — position-dependent `_gui_input` widgets need `click` instead.** These commands route through the engine's event pipeline, so `_input` / `_unhandled_input` callbacks receive the event; however, `InputEventAction` does not carry a screen position. UI controls that rely on cursor position (e.g. `TextureButton` with a custom shape, `TouchScreenButton`) won't fire `_gui_input` correctly — use `click <path>` for those.
+- **`get` on a compound Variant returns an array + type — you can round-trip it straight into `set`.** `get /root/Player position` returns `{"value": [-2480.0, 1400.0], "type": "Vector2"}`. That `value` array is the exact format `set` accepts: `set /root/Player position '[-2480.0, 1400.0]'`. No conversion needed.
+- **Arrays/Dicts nested inside compound Variants encode as arrays but carry no `type` field — use a sub-path to read a typed leaf.** For example, a `Dictionary` property that happens to contain a `Vector3` will give you an untyped array. If you need the type, use `get <node> mydict:somekey` to read the leaf directly and get its type.
+- **Sub-path reading a non-existent leaf returns `null` — indistinguishable from a real `null` value (typo only detected at the top-level name).** `get /root/Node position:typo` returns `{"value": null}` with no error — the `":" `suffix is not validated beyond checking that `"position"` exists as a top-level property. Verify your leaf name carefully; the only error you'll get is `1002` if the part before `":"` itself doesn't exist.
+- **Python API (`bridge.get_property` / `bridge.get_properties`) returns bare values only — no `type` field.** These convenience methods strip the `type` from the server response to reduce boilerplate. When you need the `type` field (e.g. to distinguish `Vector2` from a plain 2-element array), go through `client.request("get_property", {"path": ..., "property": ...})` directly.
 
 ---
 

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -100,6 +100,9 @@ class _StubClient:
     async def get_property(self, path: str, prop: str) -> Any:
         return self._record("get_property", (path, prop), {})
 
+    async def get_properties(self, path: str, props: list) -> dict:
+        return self._record("get_properties", (path, props), {})
+
     async def set_property(self, path: str, prop: str, value: Any) -> dict:
         return self._record("set_property", (path, prop, value), {})
 
@@ -401,6 +404,16 @@ def test_get_property(stub_client: dict) -> None:
     c.returns["get_property"] = 42
     assert b.get_property("/root/X", "value") == 42
     assert c.calls[-1] == ("get_property", ("/root/X", "value"), {})
+    b.close()
+
+
+def test_get_properties_delegates_to_client(stub_client: dict) -> None:
+    """``bridge.get_properties`` 必须委托到 ``client.get_properties``，参数透传，返回值透传。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["get_properties"] = {"position": [1, 2], "visible": True}
+    result = b.get_properties("/root/Player", ["position", "visible"])
+    assert c.calls[-1] == ("get_properties", ("/root/Player", ["position", "visible"]), {})
+    assert result == {"position": [1, 2], "visible": True}
     b.close()
 
 

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -321,8 +321,8 @@ def test_init_subcommand_accepts_skills_no_clobber() -> None:
 @pytest.mark.parametrize(
     "argv,expected_attrs",
     [
-        # 读
-        (["get", "/root/Main", "position"], {"node_path": "/root/Main", "prop": "position"}),
+        # 读（get props 改为 nargs='+'，ns.props 是 list）
+        (["get", "/root/Main", "position"], {"node_path": "/root/Main", "props": ["position"]}),
         (["text", "/root/Main/Title"], {"node_path": "/root/Main/Title"}),
         (["exists", "/root/Foo"], {"node_path": "/root/Foo"}),
         (["visible", "/root/Hud"], {"node_path": "/root/Hud"}),
@@ -1536,6 +1536,169 @@ def test_run_rpc_text_mode_uses_text_formatter(
 
     assert rc == 0
     assert capsys.readouterr().out.strip() == "true"
+
+
+# ── get 命令：多属性 + 信封透传（issue #99 / #100）──
+
+
+def test_get_single_prop_envelope_passthrough(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """单属性 get 必须透传 RPC result（含 type），不拆包裸值。
+
+    信封 result = {"value": [...], "type": "Vector2"}。
+    agent 用 type 字段消歧，这是 issue #99 的核心契约。
+    """
+    import json as _json
+
+    from godot_cli_control.cli import OUTPUT_JSON, RPC_BY_NAME, _run_rpc
+    from unittest.mock import AsyncMock, patch
+
+    spec = RPC_BY_NAME["get"]
+    ns = __import__("argparse").Namespace(
+        node_path="/root/Player", props=["position"]
+    )
+
+    mock_client = AsyncMock()
+    # client.request 直接返回服务端 result dict（{"value": ..., "type": ...}）
+    mock_client.request = AsyncMock(
+        return_value={"value": [1.0, 2.0], "type": "Vector2"}
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_JSON))
+
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload == {
+        "ok": True,
+        "result": {"value": [1.0, 2.0], "type": "Vector2"},
+    }
+    # 必须走 client.request，不走 client.get_property（裸值便捷层）
+    mock_client.request.assert_awaited_once_with(
+        "get_property", {"path": "/root/Player", "property": "position"}
+    )
+
+
+def test_get_multi_prop_envelope_passthrough(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """多属性 get 必须发 get_properties，信封 result = {"values": {...}}。
+
+    这是 issue #100 的原子读契约。
+    """
+    import json as _json
+
+    from godot_cli_control.cli import OUTPUT_JSON, RPC_BY_NAME, _run_rpc
+    from unittest.mock import AsyncMock, patch
+
+    spec = RPC_BY_NAME["get"]
+    ns = __import__("argparse").Namespace(
+        node_path="/root/Enemy", props=["position", "health"]
+    )
+
+    mock_result = {
+        "values": {
+            "position": {"value": [3.0, 4.0], "type": "Vector2"},
+            "health": {"value": 80, "type": "int"},
+        }
+    }
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=mock_result)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_JSON))
+
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload == {"ok": True, "result": mock_result}
+    mock_client.request.assert_awaited_once_with(
+        "get_properties",
+        {"path": "/root/Enemy", "properties": ["position", "health"]},
+    )
+
+
+def test_get_single_prop_text_mode(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--text 下单属性打印裸 value（保持旧 text 行为，只把 value 取出渲染）。"""
+    from godot_cli_control.cli import OUTPUT_TEXT, RPC_BY_NAME, _run_rpc
+    from unittest.mock import AsyncMock, patch
+
+    spec = RPC_BY_NAME["get"]
+    ns = __import__("argparse").Namespace(
+        node_path="/root/Player", props=["position"]
+    )
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(
+        return_value={"value": [1.5, -2.0], "type": "Vector2"}
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_TEXT))
+
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    # value 是 list → JSON 序列化
+    assert out == "[1.5, -2.0]"
+
+
+def test_get_multi_prop_text_mode(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--text 下多属性每行输出 ``prop = value``。"""
+    from godot_cli_control.cli import OUTPUT_TEXT, RPC_BY_NAME, _run_rpc
+    from unittest.mock import AsyncMock, patch
+
+    spec = RPC_BY_NAME["get"]
+    ns = __import__("argparse").Namespace(
+        node_path="/root/Enemy", props=["position", "health"]
+    )
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(
+        return_value={
+            "values": {
+                "position": {"value": [3.0, 4.0], "type": "Vector2"},
+                "health": {"value": 80, "type": "int"},
+            }
+        }
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_TEXT))
+
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert "position = [3.0, 4.0]" in out
+    assert "health = 80" in out
+
+
+def test_get_parses_multiple_props_from_argv() -> None:
+    """argparse 层面 props nargs='+' 能解析 2+ 属性。"""
+    from godot_cli_control.cli import build_parser
+
+    ns = build_parser().parse_args(["get", "/root/Node", "position", "visible"])
+    assert ns.cmd == "get"
+    assert ns.node_path == "/root/Node"
+    assert ns.props == ["position", "visible"]
+
+
+def test_get_parses_single_prop_from_argv() -> None:
+    """argparse 层面 props nargs='+' 能解析单个属性。"""
+    from godot_cli_control.cli import build_parser
+
+    ns = build_parser().parse_args(["get", "/root/Node", "health"])
+    assert ns.props == ["health"]
 
 
 def test_daemon_ls_empty(

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1932,6 +1932,62 @@ def test_set_default_still_json_parses() -> None:
     assert _resolve_value_for_set(ns) is True
 
 
+# ── _fmt_get_result_text 防御 + 文本渲染补测（review 遗留）──
+
+
+def test_fmt_get_result_text_nested_compound_value(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """嵌套复合 value（Array 内含 dict）在 --text 模式下渲染成 JSON 串，不崩。
+
+    info：client.request("get_property") 返回 {"value": [[1.0, 2.0], {"p": [3.0, 4.0, 5.0]}]}；
+    这种结构在普通 Python 属性里少见，但 agent 可能读到 custom Variant / Rect2 等。
+    """
+    from godot_cli_control.cli import OUTPUT_TEXT, RPC_BY_NAME, _run_rpc
+    from unittest.mock import AsyncMock, patch
+
+    import json as _json
+
+    spec = RPC_BY_NAME["get"]
+    ns = __import__("argparse").Namespace(
+        node_path="/root/Node", props=["weird"]
+    )
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(
+        return_value={"value": [[1.0, 2.0], {"p": [3.0, 4.0, 5.0]}]}
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_TEXT))
+
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    # 必须是合法 JSON 串（value 是复合类型，走 json.dumps 分支）
+    parsed = _json.loads(out)
+    assert parsed == [[1.0, 2.0], {"p": [3.0, 4.0, 5.0]}]
+
+
+def test_fmt_get_result_text_multi_prop_non_dict_entry_does_not_crash(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """多属性 result 中 entry 不是 dict（防御性非 dict 分支）不崩，打印为 str(entry)。
+
+    正常路径下服务端总是返回 dict，但防御性代码必须能接受非 dict 的 entry
+    （如 result.values["weird"] = 42 这种裸值，对齐 client 侧 guard）。
+    """
+    from godot_cli_control.cli import _fmt_get_result_text
+
+    # 多属性 result，values 里有一个非 dict 的裸值 42
+    r = {"values": {"weird": 42}}
+    out = _fmt_get_result_text(r)
+    # 不抛；渲染出来包含 key 和值
+    assert "weird" in out
+    assert "42" in out
+
+
 def test_call_text_value_disables_arg_parse() -> None:
     from godot_cli_control.cli import build_parser, _resolve_args_for_call
 

--- a/python/tests/test_cli_helpers.py
+++ b/python/tests/test_cli_helpers.py
@@ -94,11 +94,18 @@ def test_cmd_release_all() -> None:
 
 
 def test_cmd_get_returns_value_directly() -> None:
+    """cmd_get 单属性透传 client.request("get_property") 的完整 result（含 type 字段）。
+
+    注：cmd_get 自 #99 改为走 client.request 而非 client.get_property，
+    透传带 type 字段的 RPC result 给 agent 消歧；get_property 是裸 value 便捷层。
+    """
     client = AsyncMock()
-    client.get_property = AsyncMock(return_value=42)
-    result = _run(cli.cmd_get(client, _ns(node_path="/X", prop="value")))
-    assert result == 42
-    client.get_property.assert_awaited_once_with("/X", "value")
+    client.request = AsyncMock(return_value={"value": 42})
+    result = _run(cli.cmd_get(client, _ns(node_path="/X", props=["value"])))
+    assert result == {"value": 42}
+    client.request.assert_awaited_once_with(
+        "get_property", {"path": "/X", "property": "value"}
+    )
 
 
 def test_cmd_set_parses_json_value() -> None:

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -525,6 +525,54 @@ async def test_combo_client_timeout_decoupled_from_steps_total() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_properties_sends_correct_rpc_params() -> None:
+    """``get_properties`` 必须发出 method="get_properties"、params={"path": ..., "properties": [...]}。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        return {"values": {}}
+
+    client = client_mod.GameClient(port=1)
+    monkeypatch_target = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        await client.get_properties("/root/Player", ["position", "visible"])
+    finally:
+        client_mod.GameClient.request = monkeypatch_target
+    assert captured["method"] == "get_properties"
+    assert captured["params"] == {"path": "/root/Player", "properties": ["position", "visible"]}
+
+
+@pytest.mark.asyncio
+async def test_get_properties_unwraps_values_to_bare_value_map() -> None:
+    """服务端 ``{"values": {prop: {"value": ..., "type"?: ...}}}`` 必须被解包成
+    ``{prop: 裸value}`` 映射；非 dict 容错分支（如 ``"weird": 42``）也需透传。"""
+    import godot_cli_control.client as client_mod
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        return {
+            "values": {
+                "position": {"value": [1, 2], "type": "Vector2"},
+                "visible": {"value": True},
+                "weird": 42,  # 非 dict，容错：直接透传
+            }
+        }
+
+    client = client_mod.GameClient(port=1)
+    monkeypatch_target = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.get_properties("/root/Player", ["position", "visible", "weird"])
+    finally:
+        client_mod.GameClient.request = monkeypatch_target
+    assert result == {"position": [1, 2], "visible": True, "weird": 42}
+
+
+@pytest.mark.asyncio
 async def test_connect_locks_ws_ping_keepalive() -> None:
     """issue #45 治本依赖：去掉 wall 上限后，死连接靠 ws ping/pong 检测。
 

--- a/python/tests/test_e2e_client_direct.py
+++ b/python/tests/test_e2e_client_direct.py
@@ -215,3 +215,40 @@ async def test_client_autodiscovers_port_from_control_dir(
     monkeypatch.chdir(project)
     async with GameClient() as client:  # 无 port → auto-discover
         assert await client.node_exists("/root/Main") is True
+
+
+@pytest.mark.asyncio
+async def test_client_get_properties_multi(daemon_port: Any) -> None:
+    """client.get_properties(path, props) 原子读——返回 dict，key 齐，每项是裸 value
+    （不含 type 字段）。覆盖 client.py get_properties 方法体（issue #100 direct-connect）。"""
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        result = await client.get_properties("/root/Main", ["counter", "name"])
+        assert isinstance(result, dict), result
+        # 两个 key 都在
+        assert "counter" in result, result
+        assert "name" in result, result
+        # Python API 只给裸 value（不含 type），counter 是 int，name 是 str
+        assert isinstance(result["counter"], int), result
+        assert isinstance(result["name"], str), result
+
+
+@pytest.mark.asyncio
+async def test_client_request_get_property_has_type_field(daemon_port: Any) -> None:
+    """client.request('get_property', {...}) 对 Node2D.position 返回带 type 字段的对象。
+
+    Python API (get_property) 只给裸 value；要拿 type + value 必须走底层 request()。
+    这里直接断言 shape: {"value": [x, y], "type": "Vector2"}。
+    覆盖 issue #99 的服务端编码 + client.request 直通路径。"""
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        result = await client.request(
+            "get_property", {"path": "/root/Main/Player", "property": "position"}
+        )
+        assert isinstance(result, dict), result
+        # value 是 list（Vector2 编码为数组）
+        assert "value" in result, result
+        assert isinstance(result["value"], list), result
+        assert len(result["value"]) == 2, result
+        # type 字段存在且是 "Vector2"
+        assert result.get("type") == "Vector2", result

--- a/python/tests/test_e2e_example.py
+++ b/python/tests/test_e2e_example.py
@@ -113,11 +113,12 @@ def test_demo_drives_jump_and_move(daemon: Any) -> None:
 
     jump = _run_cli(project, "get", "/root/Main/World/Player", "jump_count")
     assert jump["ok"] is True, jump
-    assert jump["result"] == 1, f"期望恰好跳 1 次，实际 {jump['result']}"
+    # PR2 后 get result 透传 RPC shape: {"value": ..., "type": ...}
+    assert jump["result"]["value"] == 1, f"期望恰好跳 1 次，实际 {jump['result']}"
 
     # 向右跑 1s，moved_right 应被置真。
     assert _run_cli(project, "hold", "move_right", "1.0")["ok"]
     _run_cli(project, "wait-time", "0.2")
     moved = _run_cli(project, "get", "/root/Main/World/Player", "moved_right")
     assert moved["ok"] is True, moved
-    assert moved["result"] is True, f"期望 moved_right=true，实际 {moved['result']}"
+    assert moved["result"]["value"] is True, f"期望 moved_right=true，实际 {moved['result']}"

--- a/python/tests/test_e2e_input.py
+++ b/python/tests/test_e2e_input.py
@@ -232,8 +232,8 @@ def test_press_reaches_unhandled_input_callback(probe_project: Path) -> None:
 
         payload = _run_cli(probe_project, "get", "/root/Main", "saw_jump_event")
         assert payload["ok"] is True, payload
-        # PR1 阶段 get 仍是旧编码（裸值）；PR2 落地后此断言改 result["value"]
-        assert payload["result"] is True, (
+        # PR2 已迁移：get 信封透传 RPC result，result["value"] 取裸值
+        assert payload["result"]["value"] is True, (
             f"_unhandled_input 应收到 press 事件并置 saw_jump_event=true，实际 result={payload['result']!r}"
         )
     finally:


### PR DESCRIPTION
Closes #99, closes #100。Stacked on #104（PR1 合并后将 retarget 到 main）。

## 动机

- **#99**：`get` 对复合 Variant 返回未定义的 `"(x, y)"` 字符串（JSON.stringify 默认行为），与 set 侧 array schema 不对称、无法 round-trip，下游被迫写双格式防御解析
- **#100**：一次只能读一个属性，读「一对相关状态」要两次 RPC，中间隔帧 → 隐蔽 flaky

## 改动

### ⚠️ BREAKING

`get` 信封 result 从裸值变为 `{"value": ..., "type"?: ...}`；复合 Variant 的 value 是与 set 完全对称的数组（axis-vector 顺序），**可直接回灌 set**（round-trip 闭环，GUT 实测锁定）。

### 新增

- `bridge/variant_codec.gd`（CliControlVariantCodec）：16 种复合 Variant → set-schema 数组 + type；StringName/NodePath/Object 诊断性编码；非有限 float → `"inf"/"nan"` 字符串（防 JSON.stringify 产非法 JSON）；**递归深度上限 64 + 哨兵**（防自引用容器/病态深树爆栈挂死 daemon——review 实证后加固，5000 层/自引用均 2ms 内安全返回）
- `get` 支持 **sub-path 读**（`position:x`，走 get_indexed，与 set 侧对称）
- `get_properties` RPC + CLI `get <path> <p1> <p2> ...`：sync handler 同帧原子读，任一属性缺失 1002 点名全部缺失项
- Python：`client.get_properties` / `bridge.get_properties`（裸 value 便捷层；要 type 走 CLI/原始 RPC）

### 文档

SKILL.md（信封示例 + 4 条新 pitfalls + sub-path 读安全注记）/ addon README / CHANGELOG（BREAKING 显著标注）/ 根 README Recent changes

## 验证

- GUT 121/121（codec 表驱动 + round-trip + 原子语义 + 自引用/深树降级 + 重复属性行为锁定）
- pytest 406 passed / 2 skipped（含 e2e 真跑：get 信封 shape、get_properties 直连），coverage 96%
- ruff 全绿；SKILL.md 渲染 OK
- 下游迁移：XGame 等双格式防御解析自动走进数组分支

🤖 Generated with [Claude Code](https://claude.com/claude-code)