### PR TITLE
feat(wait): wait-prop / wait-signal / wait-frames 条件等待原语 (#96)

### DIFF
--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **feat(wait): `wait-prop` / `wait-signal` / `wait-frames` 条件等待原语 + 错误码 1007（#96）**: 三个新 CLI 子命令。`wait-prop <path> <prop> <value> [--op eq|ne|gt|ge|lt|le] [--timeout] [--tolerance] [--physics]` 等属性满足条件（exit 0=matched, 1=timeout）；`wait-signal <path> <signal> [--timeout]` 等信号发射（exit 0=emitted, 1=timeout）；`wait-frames <N> [--physics]` 推进 N 帧。服务端错误码 1007 SIGNAL_NOT_FOUND（wait-signal 传未知信号名，永久性 schema 错，不应 retry）。Python `GameClient` 对应方法：`wait_property` / `wait_signal` / `wait_frames`。
+
 ### Changed
 - **BREAKING** `get` 复合 Variant 返回从旧版 `"(x, y)"` 字符串改为 set-schema 数组 + type 字段；信封 result 从裸值变 `{"value": <array-or-scalar>, "type"?: "<GodotType>"}` 对象（#99）。写侧 `set` 接受的 Array layout 完全一致，get→set round-trip 无需转换。Python API `get_property` / `get_properties` 只返回裸 value（type 已剥离），要拿 type 字段走 CLI `get` 或底层 `client.request("get_property", ...)`。
 

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- **feat(wait): `wait-prop` / `wait-signal` / `wait-frames` 条件等待原语 + 错误码 1007（#96）**: 三个新 CLI 子命令。`wait-prop <path> <prop> <value> [--op eq|ne|gt|ge|lt|le] [--timeout] [--tolerance] [--physics]` 等属性满足条件（exit 0=matched, 1=timeout）；`wait-signal <path> <signal> [--timeout]` 等信号发射（exit 0=emitted, 1=timeout）；`wait-frames <N> [--physics]` 推进 N 帧。服务端错误码 1007 SIGNAL_NOT_FOUND（wait-signal 传未知信号名，永久性 schema 错，不应 retry）。Python `GameClient` 对应方法：`wait_property` / `wait_signal` / `wait_frames`。
+- **feat(wait): `wait-prop` / `wait-signal` / `wait-frames` 条件等待原语 + 错误码 1007（#96）**: 三个新 CLI 子命令。`wait-prop <path> <prop> <value> [--op eq|ne|gt|lt|ge|le] [--timeout] [--tolerance]` 等属性满足条件（exit 0=matched, 1=timeout）；`wait-signal <path> <signal> [--timeout]` 等信号发射（exit 0=emitted, 1=timeout）；`wait-frames <N> [--physics]` 推进 N 帧。服务端错误码 1007 SIGNAL_NOT_FOUND（wait-signal 传未知信号名，永久性 schema 错，不应 retry）。Python `GameClient` 对应方法：`wait_property` / `wait_signal` / `wait_frames`。
 
 ### Changed
 - **BREAKING** `get` 复合 Variant 返回从旧版 `"(x, y)"` 字符串改为 set-schema 数组 + type 字段；信封 result 从裸值变 `{"value": <array-or-scalar>, "type"?: "<GodotType>"}` 对象（#99）。写侧 `set` 接受的 Array layout 完全一致，get→set round-trip 无需转换。Python API `get_property` / `get_properties` 只返回裸 value（type 已剥离），要拿 type 字段走 CLI `get` 或底层 `client.request("get_property", ...)`。

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -95,6 +95,9 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 | `screenshot()` | `png_bytes = await client.screenshot()` |
 | `wait_for_node(path, timeout)` | `await client.wait_for_node("/root/Boss", timeout=10.0)` |
 | `wait_game_time(seconds)` | `await client.wait_game_time(2.5)` |
+| `wait_property(path, prop, value, op, timeout, tolerance)` | `await client.wait_property("/root/Player", "position:x", 500, op="gt", timeout=3.0)` |
+| `wait_signal(path, signal, timeout)` | `await client.wait_signal("/root/Game", "level_complete", timeout=10.0)` |
+| `wait_frames(frames, physics)` | `await client.wait_frames(4)` |
 | `action_press(action)` | `await client.action_press("jump")` |
 | `action_release(action)` | `await client.action_release("jump")` |
 | `action_tap(action, duration)` | `await client.action_tap("attack", 0.1)` |
@@ -125,6 +128,7 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `1004` | server | Combo already in progress (call `combo-cancel` to retry) |
 | `1005` | server | Scene tree too large (lower `depth` or pass `--max-nodes`) |
 | `1006` | server | Resource transiently unavailable (e.g. screenshot during scene transition). Rare under normal use — GameBridge waits for viewport first-frame before listening, and `screenshot` retries internally. Safe to retry if you do hit it. |
+| `1007` | server | Signal not found on the node (`wait-signal` schema error — signal name typo or the node doesn't define it). Permanent — don't retry; inspect with `tree` or `children` to find valid signals. |
 | `-32600` | server | Malformed JSON-RPC request |
 | `-32601` | server | Unknown method name |
 | `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements, or `hold` given `duration ≤ 0` — use `press` for an indefinite hold) |
@@ -158,8 +162,8 @@ Semantic exit codes so `if godot-cli-control exists /root/Foo; then …` works i
 
 | Code | Meaning |
 |---|---|
-| 0 | Success (or boolean true for `exists` / `visible`, node found for `wait-node`) |
-| 1 | RPC error; also `exists`/`visible`=false, `wait-node` timeout, `daemon status`=stopped |
+| 0 | Success (or boolean true for `exists` / `visible`, node found for `wait-node`, condition matched for `wait-prop` / `wait-signal`) |
+| 1 | RPC error; also `exists`/`visible`=false, `wait-node`/`wait-prop`/`wait-signal` timeout, `daemon status`=stopped |
 | 2 | Connection / IO error, or `daemon stop` ffmpeg-transcode failure |
 | 3 | `daemon stop --all` partial failure (≥1 daemon failed to stop) |
 | 64 | Usage error on an RPC subcommand — bad argparse args, a pre-flight reject (`combo` with no steps / malformed `--steps-json`), a non-numeric `tap`/`wait-time` arg, or a `set`/`call` value that fails JSON parsing. These all carry client code `-1003` and now consistently exit 64 (#82; a few previously exited 2). |

--- a/addons/godot_cli_control/bridge/error_codes.gd
+++ b/addons/godot_cli_control/bridge/error_codes.gd
@@ -22,6 +22,8 @@ const SCENE_TREE_TOO_LARGE: int = 1005
 # client 必须保留对 1006 的处理（不要假设它消失），未来若改为 fail-loud
 # 会让 scene 切换瞬间的截图变成硬错。
 const RESOURCE_UNAVAILABLE: int = 1006
+# 信号不存在（wait_signal 的 schema 错，永久性——与 1003 method、1002 property 同族）
+const SIGNAL_NOT_FOUND: int = 1007
 
 const INVALID_PARAMS: int = -32602
 const INVALID_REQUEST: int = -32600

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -189,6 +189,7 @@ func _register_methods() -> void:
 	_methods["wait_game_time"] = {"callable": _low_level_api.wait_game_time_async, "kind": "async"}
 	_methods["wait_frames"] = {"callable": _low_level_api.wait_frames_async, "kind": "async"}
 	_methods["wait_property"] = {"callable": _low_level_api.wait_property_async, "kind": "async"}
+	_methods["wait_signal"] = {"callable": _low_level_api.wait_signal_async, "kind": "async"}
 	_methods["screenshot"] = {"callable": _wrap_screenshot, "kind": "async"}
 	# 输入模拟（同步）
 	_methods["input_action_press"] = {

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -187,6 +187,7 @@ func _register_methods() -> void:
 	# 低层 API（异步）
 	_methods["wait_for_node"] = {"callable": _low_level_api.wait_for_node_async, "kind": "async"}
 	_methods["wait_game_time"] = {"callable": _low_level_api.wait_game_time_async, "kind": "async"}
+	_methods["wait_frames"] = {"callable": _low_level_api.wait_frames_async, "kind": "async"}
 	_methods["screenshot"] = {"callable": _wrap_screenshot, "kind": "async"}
 	# 输入模拟（同步）
 	_methods["input_action_press"] = {

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -188,6 +188,7 @@ func _register_methods() -> void:
 	_methods["wait_for_node"] = {"callable": _low_level_api.wait_for_node_async, "kind": "async"}
 	_methods["wait_game_time"] = {"callable": _low_level_api.wait_game_time_async, "kind": "async"}
 	_methods["wait_frames"] = {"callable": _low_level_api.wait_frames_async, "kind": "async"}
+	_methods["wait_property"] = {"callable": _low_level_api.wait_property_async, "kind": "async"}
 	_methods["screenshot"] = {"callable": _wrap_screenshot, "kind": "async"}
 	# 输入模拟（同步）
 	_methods["input_action_press"] = {

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -562,10 +562,16 @@ func wait_property_async(params: Dictionary) -> Dictionary:
 	var op: String = params.get("op", "eq") as String
 	if not op in _WAIT_PROP_OPS:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "op must be one of: %s" % ", ".join(_WAIT_PROP_OPS))
-	var timeout: float = params.get("timeout", 5.0) as float
+	var timeout_raw: Variant = params.get("timeout", 5.0)
+	if not (timeout_raw is int or timeout_raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'timeout' must be a number")
+	var timeout: float = float(timeout_raw)
 	if timeout < 0.0 or timeout > _MAX_WAIT_SECONDS:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "timeout must be 0..%s" % _MAX_WAIT_SECONDS)
-	var tolerance: float = params.get("tolerance", 0.0) as float
+	var tolerance_raw: Variant = params.get("tolerance", 0.0)
+	if not (tolerance_raw is int or tolerance_raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'tolerance' must be a number")
+	var tolerance: float = float(tolerance_raw)
 	if tolerance < 0.0:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "tolerance must be >= 0")
 	var expected: Variant = params.get("value", null)
@@ -666,7 +672,10 @@ func wait_signal_async(params: Dictionary) -> Dictionary:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'signal' parameter")
 	if not node.has_signal(signal_name):
 		return _err(CliControlErrorCodes.SIGNAL_NOT_FOUND, "Signal not found: %s" % signal_name)
-	var timeout: float = params.get("timeout", 5.0) as float
+	var timeout_raw2: Variant = params.get("timeout", 5.0)
+	if not (timeout_raw2 is int or timeout_raw2 is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'timeout' must be a number")
+	var timeout: float = float(timeout_raw2)
 	if timeout < 0.0 or timeout > _MAX_WAIT_SECONDS:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "timeout must be 0..%s" % _MAX_WAIT_SECONDS)
 	var argc: int = 0

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -15,6 +15,8 @@ const _BUILD_TREE_DEFAULT_MAX_DEPTH: int = 50
 const _BUILD_TREE_MAX_NODES: int = 5000
 # wait_game_time_async 防呆上限：防止误传 1e9 之类的数值挂死 session
 const _MAX_WAIT_SECONDS: float = 3600.0
+# wait_frames 防呆上限：60fps 下 1 分钟。要等更久用 wait_game_time / wait_property。
+const _MAX_WAIT_FRAMES: int = 3600
 # take_screenshot_async 循环上限：常态下 GameBridge 启动 gate 已保证 viewport
 # ready（issue #61 H 部分），这个循环只兜动态 transient（scene transition、
 # 窗口 resize 一瞬）。30 帧 ~500ms @ 60fps，超时报 1006 给 client 兜底。
@@ -505,6 +507,23 @@ func wait_game_time_async(params: Dictionary) -> Dictionary:
 		return {"success": true}
 	await get_tree().create_timer(seconds).timeout
 	return {"success": true}
+
+
+## issue #96：等 N 帧（确定性帧推进）。physics=true 等 physics_frame。
+func wait_frames_async(params: Dictionary) -> Dictionary:
+	var frames_raw: Variant = params.get("frames", null)
+	if not (frames_raw is int or frames_raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'frames' must be an integer")
+	var frames: int = int(frames_raw)
+	if frames < 1 or frames > _MAX_WAIT_FRAMES:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "frames must be 1..%d (got %d)" % [_MAX_WAIT_FRAMES, frames])
+	var physics: bool = bool(params.get("physics", false))
+	for _i in frames:
+		if physics:
+			await get_tree().physics_frame
+		else:
+			await get_tree().process_frame
+	return {"success": true, "frames": frames}
 
 
 func _get_node_or_error(params: Dictionary) -> Node:

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -17,6 +17,8 @@ const _BUILD_TREE_MAX_NODES: int = 5000
 const _MAX_WAIT_SECONDS: float = 3600.0
 # wait_frames 防呆上限：60fps 下 1 分钟。要等更久用 wait_game_time / wait_property。
 const _MAX_WAIT_FRAMES: int = 3600
+# wait_property 支持的比较操作符列表
+const _WAIT_PROP_OPS: PackedStringArray = ["eq", "ne", "gt", "lt", "ge", "le"]
 # take_screenshot_async 循环上限：常态下 GameBridge 启动 gate 已保证 viewport
 # ready（issue #61 H 部分），这个循环只兜动态 transient（scene transition、
 # 窗口 resize 一瞬）。30 帧 ~500ms @ 60fps，超时报 1006 给 client 兜底。
@@ -507,6 +509,92 @@ func wait_game_time_async(params: Dictionary) -> Dictionary:
 		return {"success": true}
 	await get_tree().create_timer(seconds).timeout
 	return {"success": true}
+
+
+## issue #96：逐帧轮询等属性满足条件。超时不报错——返回 matched=false +
+## reason（timeout / node_not_found / property_not_found，按最后一次轮询状态）
+## + value（最后一次读到的编码值），容忍节点/属性中途出现，typo 靠 reason 诊断。
+func wait_property_async(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "") as String
+	var property: String = params.get("property", "") as String
+	if property.is_empty():
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'property' parameter")
+	var op: String = params.get("op", "eq") as String
+	if not op in _WAIT_PROP_OPS:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "op must be one of: %s" % ", ".join(_WAIT_PROP_OPS))
+	var timeout: float = params.get("timeout", 5.0) as float
+	if timeout < 0.0 or timeout > _MAX_WAIT_SECONDS:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "timeout must be 0..%s" % _MAX_WAIT_SECONDS)
+	var tolerance: float = params.get("tolerance", 0.0) as float
+	if tolerance < 0.0:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "tolerance must be >= 0")
+	var expected: Variant = params.get("value", null)
+	if not (expected is int or expected is float) and not op in ["eq", "ne"]:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "op '%s' requires a numeric value; compound/string values only support eq/ne" % op)
+	var start_ms: int = Time.get_ticks_msec()
+	var reason: String = "timeout"
+	var last_value: Variant = null
+	while true:
+		var node: Node = get_tree().root.get_node_or_null(path)
+		if node == null:
+			reason = "node_not_found"
+			last_value = null
+		else:
+			var read: Dictionary = _read_property(node, property)
+			if read.has("error"):
+				reason = "property_not_found"
+				last_value = null
+			else:
+				reason = "timeout"
+				last_value = CliControlVariantCodec.encode_value(read["value"])
+				if _wait_compare(last_value, expected, op, tolerance):
+					return {
+						"matched": true,
+						"value": last_value,
+						"waited": float(Time.get_ticks_msec() - start_ms) / 1000.0,
+					}
+		if float(Time.get_ticks_msec() - start_ms) / 1000.0 >= timeout:
+			break
+		await get_tree().process_frame
+	return {"matched": false, "reason": reason, "value": last_value}
+
+
+## 编码后值比较。数值走 6 op（eq/ne 带 tolerance）；其余类型仅 eq/ne 深比较
+## （数组逐元素，数值元素同样吃 tolerance）。ordering op + 非数值 actual →
+## false（继续轮询直到 timeout，reason 诊断）。
+func _wait_compare(actual: Variant, expected: Variant, op: String, tolerance: float) -> bool:
+	if (actual is int or actual is float) and (expected is int or expected is float):
+		var a: float = float(actual)
+		var b: float = float(expected)
+		match op:
+			"eq": return absf(a - b) <= tolerance
+			"ne": return absf(a - b) > tolerance
+			"gt": return a > b
+			"lt": return a < b
+			"ge": return a >= b
+			"le": return a <= b
+		return false
+	var equal: bool = _deep_equal(actual, expected, tolerance)
+	if op == "eq":
+		return equal
+	if op == "ne":
+		return not equal
+	return false
+
+
+func _deep_equal(a: Variant, b: Variant, tolerance: float) -> bool:
+	if (a is int or a is float) and (b is int or b is float):
+		return absf(float(a) - float(b)) <= tolerance
+	if a is Array and b is Array:
+		var aa: Array = a as Array
+		var ba: Array = b as Array
+		if aa.size() != ba.size():
+			return false
+		for i in aa.size():
+			if not _deep_equal(aa[i], ba[i], tolerance):
+				return false
+		return true
+	return a == b  # String / bool / null / Dictionary（引擎深比较）
 
 
 ## issue #96：等 N 帧（确定性帧推进）。physics=true 等 physics_frame。

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -69,6 +69,46 @@ const _ARRAY_PASSTHROUGH_SAFE_TYPES: Array[int] = [
 ]
 
 
+## wait_signal 的参数捕获器（issue #96）。GDScript 无变参 Callable，
+## 按信号声明 argc（get_signal_list）从 0..MAX_ARGS 选对应 cap 函数。
+class _SignalCapture:
+	extends RefCounted
+
+	const MAX_ARGS: int = 8
+
+	var fired: bool = false
+	var args: Array = []
+
+	func cap0() -> void: _hit([])
+	func cap1(a1: Variant) -> void: _hit([a1])
+	func cap2(a1: Variant, a2: Variant) -> void: _hit([a1, a2])
+	func cap3(a1: Variant, a2: Variant, a3: Variant) -> void: _hit([a1, a2, a3])
+	func cap4(a1: Variant, a2: Variant, a3: Variant, a4: Variant) -> void: _hit([a1, a2, a3, a4])
+	func cap5(a1: Variant, a2: Variant, a3: Variant, a4: Variant, a5: Variant) -> void: _hit([a1, a2, a3, a4, a5])
+	func cap6(a1: Variant, a2: Variant, a3: Variant, a4: Variant, a5: Variant, a6: Variant) -> void: _hit([a1, a2, a3, a4, a5, a6])
+	func cap7(a1: Variant, a2: Variant, a3: Variant, a4: Variant, a5: Variant, a6: Variant, a7: Variant) -> void: _hit([a1, a2, a3, a4, a5, a6, a7])
+	func cap8(a1: Variant, a2: Variant, a3: Variant, a4: Variant, a5: Variant, a6: Variant, a7: Variant, a8: Variant) -> void: _hit([a1, a2, a3, a4, a5, a6, a7, a8])
+
+	func callable_for(argc: int) -> Callable:
+		match argc:
+			0: return cap0
+			1: return cap1
+			2: return cap2
+			3: return cap3
+			4: return cap4
+			5: return cap5
+			6: return cap6
+			7: return cap7
+			8: return cap8
+		return Callable()
+
+	func _hit(captured: Array) -> void:
+		if fired:
+			return
+		fired = true
+		args = captured
+
+
 func _ready() -> void:
 	_property_blacklist = _merge_extra(_property_blacklist, SETTING_PROPERTY_BLACKLIST_EXTRA)
 	_method_blacklist = _merge_extra(_method_blacklist, SETTING_METHOD_BLACKLIST_EXTRA)
@@ -612,6 +652,52 @@ func wait_frames_async(params: Dictionary) -> Dictionary:
 		else:
 			await get_tree().process_frame
 	return {"success": true, "frames": frames}
+
+
+## issue #96：等信号发射（带超时）。竞态注意（SKILL.md pitfall）：必须先挂
+## 等待再触发动作——信号在 connect 之前发射不会被捕获。
+func wait_signal_async(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "") as String
+	var node: Node = get_tree().root.get_node_or_null(path)
+	if node == null:
+		return _node_not_found(path)
+	var signal_name: String = params.get("signal", "") as String
+	if signal_name.is_empty():
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'signal' parameter")
+	if not node.has_signal(signal_name):
+		return _err(CliControlErrorCodes.SIGNAL_NOT_FOUND, "Signal not found: %s" % signal_name)
+	var timeout: float = params.get("timeout", 5.0) as float
+	if timeout < 0.0 or timeout > _MAX_WAIT_SECONDS:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "timeout must be 0..%s" % _MAX_WAIT_SECONDS)
+	var argc: int = 0
+	for sig: Dictionary in node.get_signal_list():
+		if sig["name"] == signal_name:
+			argc = (sig["args"] as Array).size()
+			break
+	if argc > _SignalCapture.MAX_ARGS:
+		return _err(
+			CliControlErrorCodes.INVALID_PARAMS,
+			"signal '%s' has %d args (max %d supported)" % [signal_name, argc, _SignalCapture.MAX_ARGS],
+		)
+	var capture: _SignalCapture = _SignalCapture.new()
+	var cb: Callable = capture.callable_for(argc)
+	node.connect(signal_name, cb, CONNECT_ONE_SHOT)
+	var start_ms: int = Time.get_ticks_msec()
+	while not capture.fired:
+		if float(Time.get_ticks_msec() - start_ms) / 1000.0 >= timeout:
+			break
+		await get_tree().process_frame
+		if not is_instance_valid(node):
+			break  # 节点被释放：连接随之失效，按未命中处理
+	if not capture.fired:
+		# one-shot 未触发时连接仍挂着，必须显式清理（防悬挂 Callable 泄漏）
+		if is_instance_valid(node) and node.is_connected(signal_name, cb):
+			node.disconnect(signal_name, cb)
+		return {"emitted": false}
+	var encoded_args: Array = []
+	for arg: Variant in capture.args:
+		encoded_args.append(CliControlVariantCodec.encode(arg))
+	return {"emitted": true, "args": encoded_args}
 
 
 func _get_node_or_error(params: Dictionary) -> Node:

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -841,3 +841,26 @@ func test_get_properties_duplicate_property_deduped_by_dict() -> void:
 	var values: Dictionary = result["values"]
 	# Dictionary 赋值重复 key 只保留最后一次，故 values 恰好有 1 个 key
 	assert_eq(values.size(), 1, "重复 key 在 Dictionary 语义下去重为 1 条（有意行为）")
+
+
+# ── issue #96：wait_frames ──
+
+func test_wait_frames_advances_n_process_frames() -> void:
+	var start: int = Engine.get_process_frames()
+	var result: Dictionary = await _api.wait_frames_async({"frames": 3})
+	assert_eq(result, {"success": true, "frames": 3})
+	assert_gte(Engine.get_process_frames() - start, 3)
+
+
+func test_wait_frames_physics_mode() -> void:
+	var start: int = Engine.get_physics_frames()
+	var result: Dictionary = await _api.wait_frames_async({"frames": 2, "physics": true})
+	assert_eq(result, {"success": true, "frames": 2})
+	assert_gte(Engine.get_physics_frames() - start, 2)
+
+
+func test_wait_frames_rejects_bad_input() -> void:
+	for bad: Variant in [null, 0, -1, 3601, "x"]:
+		var result: Dictionary = await _api.wait_frames_async({"frames": bad})
+		assert_has(result, "error", "frames=%s 应报错" % [bad])
+		assert_eq(int(result.error.code), -32602)

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -1018,3 +1018,17 @@ func test_wait_signal_timeout_string_is_minus_32602() -> void:
 	assert_has(result, "error")
 	assert_eq(int(result.error.code), -32602,
 		"timeout='abc' 应报 -32602 INVALID_PARAMS，实际 code=%d" % [int(result.error.code)])
+
+
+func test_wait_property_tolerance_string_is_minus_32602() -> void:
+	## wait_property 传 tolerance="abc" 必须被拒绝（-32602），对齐 timeout 同款拒绝。
+	## tolerance 是 float 参数；字符串不应被静默当 0.0 使用。
+	var node := Node2D.new()
+	add_child_autofree(node)
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "visible", "value": true,
+		"tolerance": "abc", "timeout": 0.5,
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602,
+		"tolerance='abc' 应报 -32602 INVALID_PARAMS，实际 code=%d" % [int(result.error.code)])

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -992,3 +992,29 @@ func test_wait_signal_unknown_signal_is_1007() -> void:
 	})
 	assert_has(result, "error")
 	assert_eq(int(result.error.code), 1007)
+
+
+# ── issue #96 review fix：timeout/tolerance 非数字服务端拒绝 ──
+
+func test_wait_property_timeout_string_is_minus_32602() -> void:
+	## wait_property 传 timeout="abc" 必须被拒绝（-32602），不能静默转 0.0。
+	var result: Dictionary = await _api.wait_property_async({
+		"path": "/root", "property": "name", "value": "root", "timeout": "abc",
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602,
+		"timeout='abc' 应报 -32602 INVALID_PARAMS，实际 code=%d" % [int(result.error.code)])
+
+
+func test_wait_signal_timeout_string_is_minus_32602() -> void:
+	## wait_signal 传 timeout="abc" 必须被拒绝（-32602），节点和信号均合法。
+	var emitter := Node.new()
+	emitter.add_user_signal("test_sig_for_timeout_check")
+	add_child_autofree(emitter)
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "test_sig_for_timeout_check",
+		"timeout": "abc",
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602,
+		"timeout='abc' 应报 -32602 INVALID_PARAMS，实际 code=%d" % [int(result.error.code)])

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -864,3 +864,77 @@ func test_wait_frames_rejects_bad_input() -> void:
 		var result: Dictionary = await _api.wait_frames_async({"frames": bad})
 		assert_has(result, "error", "frames=%s 应报错" % [bad])
 		assert_eq(int(result.error.code), -32602)
+
+
+# ── issue #96：wait_property ──
+
+func test_wait_property_matches_immediately() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(5.0, 0.0)
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "position", "value": [5.0, 0.0], "timeout": 1.0,
+	})
+	assert_true(result["matched"])
+	assert_eq(result["value"], [5.0, 0.0])
+
+
+func test_wait_property_catches_later_change() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.visible = false
+	get_tree().create_timer(0.05).timeout.connect(func() -> void: node.visible = true)
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "visible", "value": true, "timeout": 2.0,
+	})
+	assert_true(result["matched"])
+
+
+func test_wait_property_gt_on_sub_path() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(0.0, 0.0)
+	get_tree().create_timer(0.05).timeout.connect(func() -> void: node.position = Vector2(600.0, 0.0))
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "position:x", "value": 500, "op": "gt", "timeout": 2.0,
+	})
+	assert_true(result["matched"])
+
+
+func test_wait_property_timeout_reports_reason_and_last_value() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.visible = false
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "visible", "value": true, "timeout": 0.1,
+	})
+	assert_false(result["matched"])
+	assert_eq(result["reason"], "timeout")
+	assert_eq(result["value"], false)
+
+
+func test_wait_property_node_not_found_reason() -> void:
+	var result: Dictionary = await _api.wait_property_async({
+		"path": "/root/__nope__", "property": "visible", "value": true, "timeout": 0.1,
+	})
+	assert_false(result["matched"])
+	assert_eq(result["reason"], "node_not_found")
+
+
+func test_wait_property_tolerance_eq() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(1.0001, 0.0)
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "position:x", "value": 1.0,
+		"tolerance": 0.001, "timeout": 0.5,
+	})
+	assert_true(result["matched"])
+
+
+func test_wait_property_rejects_ordering_op_with_non_numeric_value() -> void:
+	var result: Dictionary = await _api.wait_property_async({
+		"path": "/root", "property": "name", "value": [1, 2], "op": "gt", "timeout": 0.1,
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -938,3 +938,57 @@ func test_wait_property_rejects_ordering_op_with_non_numeric_value() -> void:
 	})
 	assert_has(result, "error")
 	assert_eq(int(result.error.code), -32602)
+
+
+# ── issue #96：wait_signal ──
+
+func test_wait_signal_captures_emission_and_args() -> void:
+	var emitter := Node.new()
+	emitter.add_user_signal("e2e_sig", [{"name": "v", "type": TYPE_INT}])
+	add_child_autofree(emitter)
+	get_tree().create_timer(0.05).timeout.connect(func() -> void: emitter.emit_signal("e2e_sig", 42))
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "e2e_sig", "timeout": 2.0,
+	})
+	assert_true(result["emitted"])
+	assert_eq(result["args"], [{"value": 42}])
+
+
+func test_wait_signal_zero_arg_signal() -> void:
+	var emitter := Node.new()
+	add_child_autofree(emitter)
+	get_tree().create_timer(0.05).timeout.connect(func() -> void: emitter.emit_signal("renamed"))
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "renamed", "timeout": 2.0,
+	})
+	assert_true(result["emitted"])
+	assert_eq(result["args"], [])
+
+
+func test_wait_signal_timeout_cleans_up_connection() -> void:
+	var emitter := Node.new()
+	emitter.add_user_signal("never_fires")
+	add_child_autofree(emitter)
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "never_fires", "timeout": 0.1,
+	})
+	assert_false(result["emitted"])
+	assert_eq(emitter.get_signal_connection_list("never_fires").size(), 0, "超时后连接必须清理")
+
+
+func test_wait_signal_node_missing_is_1001() -> void:
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": "/root/__nope__", "signal": "x", "timeout": 0.1,
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1001)
+
+
+func test_wait_signal_unknown_signal_is_1007() -> void:
+	var emitter := Node.new()
+	add_child_autofree(emitter)
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "__nope__", "timeout": 0.1,
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1007)

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -78,6 +78,26 @@ class GameBridge:
         """等待节点出现。"""
         return self._run(self._client.wait_for_node(path, timeout=timeout))
 
+    def wait_property(
+        self,
+        path: str,
+        prop: str,
+        value: Any,
+        op: str = "eq",
+        timeout: float = 5.0,
+        tolerance: float = 0.0,
+    ) -> dict:
+        """逐帧轮询直到属性满足条件（issue #96）。返回 {"matched": bool, ...}，超时不抛。"""
+        return self._run(self._client.wait_property(path, prop, value, op=op, timeout=timeout, tolerance=tolerance))
+
+    def wait_signal(self, path: str, signal: str, timeout: float = 5.0) -> dict:
+        """等信号发射（issue #96）。返回 {"emitted": bool, "args": [...]}，超时不抛。"""
+        return self._run(self._client.wait_signal(path, signal, timeout=timeout))
+
+    def wait_frames(self, frames: int, physics: bool = False) -> dict:
+        """等 N 帧（issue #96）。确定性帧推进，替代短 sleep。"""
+        return self._run(self._client.wait_frames(frames, physics=physics))
+
     # ── UI 交互 ──
 
     def click(self, path: str) -> dict:

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -243,6 +243,48 @@ def _read_combo_steps(ns: argparse.Namespace) -> list[dict]:
     return parsed
 
 
+_WAIT_PROP_OPS = ("eq", "ne", "gt", "lt", "ge", "le")
+
+
+def _require_float(raw: Any, cmd: str, field: str) -> float:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"{cmd}: {field} 必须是数字，收到 {raw!r}")
+
+
+def _preflight_wait_prop(ns: argparse.Namespace) -> None:
+    timeout = _require_float(ns.timeout, "wait-prop", "timeout")
+    if not 0 <= timeout <= 3600:
+        raise ValueError(f"wait-prop: timeout 必须在 0..3600 秒，收到 {timeout}")
+    tolerance = _require_float(ns.tolerance, "wait-prop", "tolerance")
+    if tolerance < 0:
+        raise ValueError(f"wait-prop: tolerance 必须 >= 0，收到 {tolerance}")
+    expected = _parse_json_arg(ns.value)
+    is_numeric = isinstance(expected, (int, float)) and not isinstance(expected, bool)
+    if ns.op not in ("eq", "ne") and not is_numeric:
+        raise ValueError(
+            f"wait-prop: --op {ns.op} 只支持数值比较；复合/字符串/bool 值只能用 eq/ne"
+        )
+
+
+def _preflight_wait_signal(ns: argparse.Namespace) -> None:
+    if ns.timeout is None:
+        return
+    timeout = _require_float(ns.timeout, "wait-signal", "timeout")
+    if not 0 <= timeout <= 3600:
+        raise ValueError(f"wait-signal: timeout 必须在 0..3600 秒，收到 {timeout}")
+
+
+def _preflight_wait_frames(ns: argparse.Namespace) -> None:
+    try:
+        frames = int(ns.frames)
+    except (TypeError, ValueError):
+        raise ValueError(f"wait-frames: frames 必须是整数，收到 {ns.frames!r}")
+    if not 1 <= frames <= 3600:
+        raise ValueError(f"wait-frames: frames 必须在 1..3600，收到 {frames}")
+
+
 def _combo_total_duration(steps: list[dict]) -> float:
     """combo 全部 step 的累计 game-time（给 ``--wait`` 算阻塞时长，issue #90）。
 
@@ -406,6 +448,23 @@ async def cmd_wait_time(
     return await client.wait_game_time(seconds)
 
 
+async def cmd_wait_prop(client: GameClient, ns: argparse.Namespace) -> dict:
+    expected = _parse_json_arg(ns.value)
+    return await client.wait_property(
+        ns.node_path, ns.prop, expected,
+        op=ns.op, timeout=float(ns.timeout), tolerance=float(ns.tolerance),
+    )
+
+
+async def cmd_wait_signal(client: GameClient, ns: argparse.Namespace) -> dict:
+    timeout = float(ns.timeout) if ns.timeout else 5.0
+    return await client.wait_signal(ns.node_path, ns.signal_name, timeout=timeout)
+
+
+async def cmd_wait_frames(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.wait_frames(int(ns.frames), physics=ns.physics)
+
+
 async def cmd_pressed(
     client: GameClient, ns: argparse.Namespace
 ) -> list[str]:
@@ -483,6 +542,27 @@ def _exit_from_wait_node(r: dict) -> int:
     return EXIT_OK if r.get("found") else EXIT_RPC_ERROR
 
 
+def _fmt_wait_prop_text(r: dict) -> str:
+    if r.get("matched"):
+        return f"matched (waited {r.get('waited', 0.0):.3f}s)"
+    return (
+        f"timeout (reason={r.get('reason', 'timeout')}, "
+        f"last={json.dumps(r.get('value'), ensure_ascii=False)})"
+    )
+
+
+def _fmt_wait_signal_text(r: dict) -> str:
+    return "emitted" if r.get("emitted") else "timeout"
+
+
+def _exit_from_wait_prop(r: dict) -> int:
+    return EXIT_OK if r.get("matched") else EXIT_RPC_ERROR
+
+
+def _exit_from_wait_signal(r: dict) -> int:
+    return EXIT_OK if r.get("emitted") else EXIT_RPC_ERROR
+
+
 # ── extra_args registrators ──
 
 
@@ -538,6 +618,21 @@ def _register_actions_flag(p: argparse.ArgumentParser) -> None:
         action="store_true",
         help="包含 ui_* 内置动作（默认仅项目自定义动作）",
     )
+
+
+def _register_wait_prop_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("node_path", help="绝对节点路径")
+    p.add_argument("prop", help="属性名（支持 sub-path 如 position:x）")
+    p.add_argument("value", help="期望值（JSON-or-string，同 set 的 value 规则）")
+    p.add_argument("--op", choices=_WAIT_PROP_OPS, default="eq",
+                   help="比较运算符，默认 eq；gt/lt/ge/le 仅数值")
+    p.add_argument("--timeout", default="5", help="超时秒（0..3600，默认 5）")
+    p.add_argument("--tolerance", default="0", help="float eq/ne 容差（默认 0=精确比较）")
+
+
+def _register_wait_frames_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("frames", help="等待帧数（1..3600）")
+    p.add_argument("--physics", action="store_true", help="等 physics_frame（默认 process_frame）")
 
 
 def _register_set_args(p: argparse.ArgumentParser) -> None:
@@ -804,6 +899,48 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
         ),
         example="wait-time 0.5",
         text_formatter=_fmt_wait_time_text,
+    ),
+    RpcSpec(
+        name="wait-prop",
+        handler=cmd_wait_prop,
+        description=(
+            "逐帧轮询直到属性满足条件（或 timeout）。退出码：0=命中, 1=超时, "
+            "2=infra error。超时返回 reason（timeout/node_not_found/property_not_found）"
+            "+ 最后读到的值，便于诊断 typo。"
+        ),
+        positionals=(),  # 由 extra_args 注册
+        example="wait-prop /root/Player position:x 500 --op gt --timeout 3",
+        extra_args=_register_wait_prop_args,
+        preflight=_preflight_wait_prop,
+        text_formatter=_fmt_wait_prop_text,
+        exit_code_from=_exit_from_wait_prop,
+    ),
+    RpcSpec(
+        name="wait-signal",
+        handler=cmd_wait_signal,
+        description=(
+            "等信号发射（或 timeout），命中带回编码后的信号参数。退出码：0=命中, "
+            "1=超时, 2=infra error。注意：必须先挂等待再触发动作（见 SKILL.md pitfall）。"
+        ),
+        positionals=(
+            Positional("node_path", None, "绝对节点路径"),
+            Positional("signal_name", None, "信号名，如 body_entered"),
+            Positional("timeout", "?", "超时秒（0..3600，默认 5）"),
+        ),
+        example="wait-signal /root/Area door_opened 3",
+        preflight=_preflight_wait_signal,
+        text_formatter=_fmt_wait_signal_text,
+        exit_code_from=_exit_from_wait_signal,
+    ),
+    RpcSpec(
+        name="wait-frames",
+        handler=cmd_wait_frames,
+        description="等 N 个 process 帧（--physics 等物理帧）。确定性帧推进，替代短 sleep。",
+        positionals=(),  # 由 extra_args 注册
+        example="wait-frames 3 --physics",
+        extra_args=_register_wait_frames_args,
+        preflight=_preflight_wait_frames,
+        text_formatter=lambda r: f"waited {r.get('frames')} frames",
     ),
     RpcSpec(
         name="pressed",

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -333,6 +333,41 @@ class GameClient:
         )
         return result.get("found", False)
 
+    async def wait_property(
+        self,
+        path: str,
+        prop: str,
+        value: Any,
+        op: str = "eq",
+        timeout: float = 5.0,
+        tolerance: float = 0.0,
+    ) -> dict:
+        """等属性满足条件（issue #96）。返回 {"matched": bool, ...}，超时不抛。"""
+        return await self.request(
+            "wait_property",
+            {
+                "path": path, "property": prop, "value": value,
+                "op": op, "timeout": timeout, "tolerance": tolerance,
+            },
+            timeout=timeout + 5.0,
+        )
+
+    async def wait_signal(self, path: str, signal: str, timeout: float = 5.0) -> dict:
+        """等信号发射（issue #96）。返回 {"emitted": bool, "args": [...]}，超时不抛。"""
+        return await self.request(
+            "wait_signal",
+            {"path": path, "signal": signal, "timeout": timeout},
+            timeout=timeout + 5.0,
+        )
+
+    async def wait_frames(self, frames: int, physics: bool = False) -> dict:
+        """等 N 帧（issue #96）。client wall-time 按最低 10fps 估算 + 10s grace。"""
+        return await self.request(
+            "wait_frames",
+            {"frames": frames, "physics": physics},
+            timeout=max(30.0, frames / 10.0 + 10.0),
+        )
+
     async def wait_game_time(self, seconds: float) -> dict:
         """按 Godot game time 等待 N 秒。
 

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -180,7 +180,7 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 **Wait:**
 - `wait-node <path> [timeout]` — block until node appears (exit 0=found, 1=timeout)
 - `wait-time <seconds>` — wait N in-game seconds (matters for `--write-movie`). Server bounds: `0 ≤ seconds ≤ 3600`; passing out-of-range gets `-32602 "seconds must be ..."`. Client short-circuits `seconds <= 0` without an RPC.
-- `wait-prop <path> <prop> <json-value> [--op eq|ne|gt|ge|lt|le] [--timeout N] [--tolerance N] [--physics]` — block until property satisfies condition (exit 0=matched, 1=timeout). Example: `wait-prop /root/Player position:x 500 --op gt`. Default `--op eq`, `--timeout 5.0`, `--tolerance 0.0`.
+- `wait-prop <path> <prop> <json-value> [--op eq|ne|gt|lt|ge|le] [--timeout N] [--tolerance N]` — block until property satisfies condition (exit 0=matched, 1=timeout). Example: `wait-prop /root/Player position:x 500 --op gt`. Default `--op eq`, `--timeout 5.0`, `--tolerance 0.0`.
 - `wait-signal <path> <signal> [--timeout N]` — block until signal fires (exit 0=emitted, 1=timeout). Result: `{"emitted": bool, "args": [...]}`.
 - `wait-frames <N> [--physics]` — advance exactly N process frames (or physics frames with `--physics`). Result: `{"success": true, "frames": N}`.
 

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -42,8 +42,8 @@ godot-cli-control daemon stop
 
 | Code | Meaning |
 |---|---|
-| 0 | Success (or, for `exists` / `visible` / `wait-node`, the boolean was true / found) |
-| 1 | RPC error (server returned `{"error":...}`); also `exists`/`visible`=false, `wait-node`=timeout, `daemon status`=stopped |
+| 0 | Success (or, for `exists` / `visible` / `wait-node` / `wait-prop` / `wait-signal`, the boolean was true / found / matched / emitted) |
+| 1 | RPC error (server returned `{"error":...}`); also `exists`/`visible`=false, `wait-node`/`wait-prop`/`wait-signal`=timeout, `daemon status`=stopped |
 | 2 | Connection / IO error (daemon not running, script path not found). Also: **`daemon stop` returns 2** when the daemon stopped cleanly but `ffmpeg` transcode of the recorded `.avi`→`.mp4` failed — the raw `.avi` is kept and `.cli_control/ffmpeg.log` has the details. `run <script>` propagates this: a successful script + failed transcode still exits 2. |
 | 3 | `daemon stop --all` partial failure: at least one daemon in the registry failed to stop. Per-record `rc` is in the JSON `result.stopped[]`. |
 | 64 | Usage error on an **RPC subcommand** — argparse, a pre-flight reject caught before connecting (`combo` with no steps / malformed `--steps-json` / `combo -` from a TTY, `hold` with a non-positive duration), **and** a bad runtime argument (`tap` / `wait-time` given a non-number, a `set`/`call` value that fails JSON parsing). For RPC subcommands these all carry client code `-1003` and now consistently exit 64 (a few previously exited 2 — fixed in #82). |
@@ -125,6 +125,7 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 | `1004` | Combo already in progress. Call `combo-cancel` (or `release-all`) and re-issue. Safe to retry after that. |
 | `1005` | Scene tree too large to serialize (default safety limit). Pass `--max-nodes` or query a subtree with `children` / `tree <subpath>`. Don't retry as-is. |
 | `1006` | Resource transiently unavailable (e.g. screenshot during scene transition / window resize). Rare under normal use: GameBridge waits for viewport first-frame before accepting connections, and `screenshot` retries internally up to ~30 frames (~500ms at 60 fps, ~1s at 30 fps, longer when `--write-movie` lowers the fixed fps). If you still see this, retry after `wait-time 0.05` or similar. |
+| `1007` | Signal not found on the node (`wait-signal` schema error — signal name typo or the node doesn't define it). Permanent — don't retry; inspect with `tree` to list available signals. |
 
 **JSON-RPC standard — negative integers `-32xxx`:**
 
@@ -179,6 +180,9 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 **Wait:**
 - `wait-node <path> [timeout]` — block until node appears (exit 0=found, 1=timeout)
 - `wait-time <seconds>` — wait N in-game seconds (matters for `--write-movie`). Server bounds: `0 ≤ seconds ≤ 3600`; passing out-of-range gets `-32602 "seconds must be ..."`. Client short-circuits `seconds <= 0` without an RPC.
+- `wait-prop <path> <prop> <json-value> [--op eq|ne|gt|ge|lt|le] [--timeout N] [--tolerance N] [--physics]` — block until property satisfies condition (exit 0=matched, 1=timeout). Example: `wait-prop /root/Player position:x 500 --op gt`. Default `--op eq`, `--timeout 5.0`, `--tolerance 0.0`.
+- `wait-signal <path> <signal> [--timeout N]` — block until signal fires (exit 0=emitted, 1=timeout). Result: `{"emitted": bool, "args": [...]}`.
+- `wait-frames <N> [--physics]` — advance exactly N process frames (or physics frames with `--physics`). Result: `{"success": true, "frames": N}`.
 
 **Render:**
 - `screenshot <path>` — write PNG (path is **required** as of 0.2.0)
@@ -337,6 +341,9 @@ Errors raise `RpcError(code, message)` (a `RuntimeError` subclass) that preserve
 | `await client.get_scene_tree(depth, max_nodes=None)` | `tree [depth] [--max-nodes N]` |
 | `await client.wait_for_node(path, timeout)` | `wait-node <path> [timeout]` |
 | `await client.wait_game_time(seconds)` | `wait-time <seconds>` |
+| `await client.wait_property(path, prop, value, op, timeout, tolerance)` | `wait-prop <path> <prop> <json-value> [--op ...] [--timeout N] [--tolerance N]` |
+| `await client.wait_signal(path, signal, timeout)` | `wait-signal <path> <signal> [--timeout N]` |
+| `await client.wait_frames(frames, physics)` | `wait-frames <N> [--physics]` |
 | `await client.action_press(action)` | `press <action>` |
 | `await client.action_release(action)` | `release <action>` |
 | `await client.action_tap(action, duration)` | `tap <action> [duration]` |
@@ -421,6 +428,8 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **`run <script>` opens a window even though stdout is piped** — by design. `run` grep's the script for `screenshot` and force-flips to GUI when found, so `bridge.screenshot(...)` doesn't 1006-fail under the dummy renderer. Pass `--no-gui-auto` to disable detection; explicit `--headless` always wins. See issue #65.
 - **`screenshot` used to fail with `1006` on the first call** — fixed. GameBridge now waits for the viewport's first frame before opening the port, so `connect succeeded` implies `viewport has rendered ≥ once`. The magic `bridge.wait(1.5)` before the first screenshot in older example scripts is no longer needed.
 - **`press`/`tap`/`hold`/`combo` inject `InputEventAction` (no mouse coordinates) — position-dependent `_gui_input` widgets need `click` instead.** These commands route through the engine's event pipeline, so `_input` / `_unhandled_input` callbacks receive the event; however, `InputEventAction` does not carry a screen position. UI controls that rely on cursor position (e.g. `TextureButton` with a custom shape, `TouchScreenButton`) won't fire `_gui_input` correctly — use `click <path>` for those.
+- **`wait-signal` must be armed before the action that fires it — each CLI call opens a new connection.** Every invocation of `godot-cli-control` is a fresh process that connects, makes the request, and disconnects. If you call `wait-signal` after the signal has already fired, you'll always timeout. Shell pattern: `godot-cli-control wait-signal /root/A my_signal & godot-cli-control tap jump; wait` — background the wait first, then trigger the action. If you need both on a single connection, use a `run` script (`def run(bridge): ...`) with `client.wait_signal(...)`.
+- **Replace magic `wait-time` sleeps with `wait-prop` or `wait-frames`.** Fixed `wait-time 0.3` guesses are fragile — they're too long when the game is fast, too short under load. Prefer: `wait-prop /root/Player on_floor true` (wait for state) or `wait-frames 4` (wait for a specific number of frames to render). These are more reliable and often 2-10× faster.
 - **`get` on a compound Variant returns an array + type — you can round-trip it straight into `set`.** `get /root/Player position` returns `{"value": [-2480.0, 1400.0], "type": "Vector2"}`. That `value` array is the exact format `set` accepts: `set /root/Player position '[-2480.0, 1400.0]'`. No conversion needed.
 - **Arrays/Dicts nested inside compound Variants encode as arrays but carry no `type` field — use a sub-path to read a typed leaf.** For example, a `Dictionary` property that happens to contain a `Vector3` will give you an untyped array. If you need the type, use `get <node> mydict:somekey` to read the leaf directly and get its type.
 - **Sub-path reading a non-existent leaf returns `null` — indistinguishable from a real `null` value (typo only detected at the top-level name).** `get /root/Node position:typo` returns `{"value": null}` with no error — the `":" `suffix is not validated beyond checking that `"position"` exists as a top-level property. Verify your leaf name carefully; the only error you'll get is `1002` if the part before `":"` itself doesn't exist.

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -114,6 +114,23 @@ class _StubClient:
     async def get_children(self, path: str, type_filter: str = "") -> list[dict]:
         return self._record("get_children", (path,), {"type_filter": type_filter})
 
+    async def wait_property(
+        self,
+        path: str,
+        prop: str,
+        value: Any,
+        op: str = "eq",
+        timeout: float = 5.0,
+        tolerance: float = 0.0,
+    ) -> dict:
+        return self._record("wait_property", (path, prop, value), {"op": op, "timeout": timeout, "tolerance": tolerance})
+
+    async def wait_signal(self, path: str, signal: str, timeout: float = 5.0) -> dict:
+        return self._record("wait_signal", (path, signal), {"timeout": timeout})
+
+    async def wait_frames(self, frames: int, physics: bool = False) -> dict:
+        return self._record("wait_frames", (frames,), {"physics": physics})
+
 
 @pytest.fixture
 def stub_client(monkeypatch: pytest.MonkeyPatch) -> _StubClient:
@@ -484,4 +501,49 @@ def test_runtime_error_propagates(stub_client: dict) -> None:
     c.raises["screenshot"] = RuntimeError("disconnected")
     with pytest.raises(RuntimeError, match="disconnected"):
         b.screenshot()
+    b.close()
+
+
+# ── issue #96: wait_property / wait_signal / wait_frames bridge 委托 ──
+
+
+def test_wait_property_delegates_all_params(stub_client: dict) -> None:
+    """bridge.wait_property 必须把所有参数（含 op/tolerance）委托给 client.wait_property。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["wait_property"] = {"matched": True, "value": 10, "waited": 0.05}
+    result = b.wait_property("/root/Player", "health", 100, op="ge", timeout=3.0, tolerance=0.1)
+    assert c.calls[-1] == (
+        "wait_property",
+        ("/root/Player", "health", 100),
+        {"op": "ge", "timeout": 3.0, "tolerance": 0.1},
+    )
+    assert result == {"matched": True, "value": 10, "waited": 0.05}
+    b.close()
+
+
+def test_wait_signal_delegates_params(stub_client: dict) -> None:
+    """bridge.wait_signal 把 path/signal/timeout 委托给 client.wait_signal。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["wait_signal"] = {"emitted": True, "args": [42]}
+    result = b.wait_signal("/root/Area", "door_opened", timeout=2.0)
+    assert c.calls[-1] == (
+        "wait_signal",
+        ("/root/Area", "door_opened"),
+        {"timeout": 2.0},
+    )
+    assert result == {"emitted": True, "args": [42]}
+    b.close()
+
+
+def test_wait_frames_delegates_params(stub_client: dict) -> None:
+    """bridge.wait_frames 把 frames/physics 委托给 client.wait_frames。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["wait_frames"] = {"success": True, "frames": 5}
+    result = b.wait_frames(5, physics=True)
+    assert c.calls[-1] == (
+        "wait_frames",
+        (5,),
+        {"physics": True},
+    )
+    assert result == {"success": True, "frames": 5}
     b.close()

--- a/python/tests/test_cli_helpers.py
+++ b/python/tests/test_cli_helpers.py
@@ -15,6 +15,7 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
 
 from godot_cli_control import cli
 
@@ -303,3 +304,239 @@ def test_exit_from_wait_node_uses_found_field() -> None:
     assert cli._exit_from_wait_node({"found": False}) == cli.EXIT_RPC_ERROR
     # 缺字段视为未找到
     assert cli._exit_from_wait_node({}) == cli.EXIT_RPC_ERROR
+
+
+# ── issue #96: wait-prop / wait-signal / wait-frames cmd_* + preflight ──
+
+
+def test_cmd_wait_prop_matched_passes_all_params() -> None:
+    """cmd_wait_prop 必须把 ns 上所有字段透传给 client.wait_property。"""
+    client = AsyncMock()
+    client.wait_property = AsyncMock(return_value={"matched": True, "value": 500, "waited": 0.12})
+    result = _run(cli.cmd_wait_prop(client, _ns(
+        node_path="/root/Player", prop="position:x", value="500",
+        op="gt", timeout="3", tolerance="0",
+    )))
+    client.wait_property.assert_awaited_once_with(
+        "/root/Player", "position:x", 500, op="gt", timeout=3.0, tolerance=0.0,
+    )
+    assert result["matched"] is True
+
+
+def test_cmd_wait_prop_false_result_returned() -> None:
+    client = AsyncMock()
+    client.wait_property = AsyncMock(return_value={"matched": False, "reason": "timeout", "value": 10})
+    result = _run(cli.cmd_wait_prop(client, _ns(
+        node_path="/root/X", prop="health", value="100",
+        op="eq", timeout="5", tolerance="0",
+    )))
+    assert result["matched"] is False
+
+
+def test_exit_from_wait_prop_true_is_0() -> None:
+    """exit 0 = 命中，exit 1 = 未命中（超时）。"""
+    assert cli._exit_from_wait_prop({"matched": True}) == cli.EXIT_OK
+    assert cli._exit_from_wait_prop({"matched": False}) == cli.EXIT_RPC_ERROR
+    assert cli._exit_from_wait_prop({}) == cli.EXIT_RPC_ERROR
+
+
+def test_cmd_wait_signal_matched_passes_timeout() -> None:
+    client = AsyncMock()
+    client.wait_signal = AsyncMock(return_value={"emitted": True, "args": []})
+    result = _run(cli.cmd_wait_signal(client, _ns(
+        node_path="/root/Area", signal_name="door_opened", timeout="3",
+    )))
+    client.wait_signal.assert_awaited_once_with("/root/Area", "door_opened", timeout=3.0)
+    assert result["emitted"] is True
+
+
+def test_cmd_wait_signal_default_timeout_5() -> None:
+    client = AsyncMock()
+    client.wait_signal = AsyncMock(return_value={"emitted": False})
+    _run(cli.cmd_wait_signal(client, _ns(
+        node_path="/root/A", signal_name="sig", timeout=None,
+    )))
+    client.wait_signal.assert_awaited_once_with("/root/A", "sig", timeout=5.0)
+
+
+def test_exit_from_wait_signal_emitted_is_0() -> None:
+    assert cli._exit_from_wait_signal({"emitted": True}) == cli.EXIT_OK
+    assert cli._exit_from_wait_signal({"emitted": False}) == cli.EXIT_RPC_ERROR
+    assert cli._exit_from_wait_signal({}) == cli.EXIT_RPC_ERROR
+
+
+def test_cmd_wait_frames_passes_physics_flag() -> None:
+    client = AsyncMock()
+    client.wait_frames = AsyncMock(return_value={"success": True, "frames": 3})
+    result = _run(cli.cmd_wait_frames(client, _ns(frames="3", physics=True)))
+    client.wait_frames.assert_awaited_once_with(3, physics=True)
+    assert result["frames"] == 3
+
+
+def test_cmd_wait_frames_default_physics_false() -> None:
+    client = AsyncMock()
+    client.wait_frames = AsyncMock(return_value={"success": True, "frames": 5})
+    _run(cli.cmd_wait_frames(client, _ns(frames="5", physics=False)))
+    client.wait_frames.assert_awaited_once_with(5, physics=False)
+
+
+# ── wait-prop preflight ──
+
+
+def test_preflight_wait_prop_timeout_non_number_raises() -> None:
+    ns = _ns(node_path="/X", prop="p", value="1", op="eq", timeout="abc", tolerance="0")
+    with pytest.raises(ValueError, match="timeout"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_timeout_out_of_range_raises() -> None:
+    ns = _ns(node_path="/X", prop="p", value="1", op="eq", timeout="9999", tolerance="0")
+    with pytest.raises(ValueError, match="timeout"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_tolerance_negative_raises() -> None:
+    ns = _ns(node_path="/X", prop="p", value="1", op="eq", timeout="5", tolerance="-1")
+    with pytest.raises(ValueError, match="tolerance"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_ordering_op_with_list_raises() -> None:
+    """gt + value=[1,2] は数値でない → ValueError。"""
+    ns = _ns(node_path="/X", prop="p", value="[1,2]", op="gt", timeout="5", tolerance="0")
+    with pytest.raises(ValueError, match="gt"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_ordering_op_with_string_raises() -> None:
+    ns = _ns(node_path="/X", prop="p", value='"hello"', op="gt", timeout="5", tolerance="0")
+    with pytest.raises(ValueError, match="gt"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_ordering_op_with_bool_raises() -> None:
+    """bool は数値扱いしない —— isinstance(True, int) は True だが bool は排除。"""
+    ns = _ns(node_path="/X", prop="p", value="true", op="gt", timeout="5", tolerance="0")
+    with pytest.raises(ValueError, match="gt"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_eq_with_bool_ok() -> None:
+    """eq/ne + bool は合法。"""
+    ns = _ns(node_path="/X", prop="visible", value="true", op="eq", timeout="5", tolerance="0")
+    cli._preflight_wait_prop(ns)  # should not raise
+
+
+def test_preflight_wait_prop_eq_with_numeric_ok() -> None:
+    ns = _ns(node_path="/X", prop="p", value="42", op="gt", timeout="5", tolerance="0")
+    cli._preflight_wait_prop(ns)  # should not raise
+
+
+# ── wait-signal preflight ──
+
+
+def test_preflight_wait_signal_timeout_non_number_raises() -> None:
+    ns = _ns(node_path="/X", signal_name="sig", timeout="abc")
+    with pytest.raises(ValueError, match="timeout"):
+        cli._preflight_wait_signal(ns)
+
+
+def test_preflight_wait_signal_timeout_out_of_range_raises() -> None:
+    ns = _ns(node_path="/X", signal_name="sig", timeout="9999")
+    with pytest.raises(ValueError, match="timeout"):
+        cli._preflight_wait_signal(ns)
+
+
+def test_preflight_wait_signal_none_timeout_ok() -> None:
+    """timeout=None（未传）时 preflight 不报错。"""
+    ns = _ns(node_path="/X", signal_name="sig", timeout=None)
+    cli._preflight_wait_signal(ns)  # should not raise
+
+
+# ── wait-frames preflight ──
+
+
+def test_preflight_wait_frames_non_integer_raises() -> None:
+    ns = _ns(frames="abc")
+    with pytest.raises(ValueError, match="frames"):
+        cli._preflight_wait_frames(ns)
+
+
+def test_preflight_wait_frames_zero_raises() -> None:
+    ns = _ns(frames="0")
+    with pytest.raises(ValueError, match="frames"):
+        cli._preflight_wait_frames(ns)
+
+
+def test_preflight_wait_frames_over_max_raises() -> None:
+    ns = _ns(frames="9999")
+    with pytest.raises(ValueError, match="frames"):
+        cli._preflight_wait_frames(ns)
+
+
+def test_preflight_wait_frames_valid_ok() -> None:
+    ns = _ns(frames="3")
+    cli._preflight_wait_frames(ns)  # should not raise
+
+
+# ── fmt helpers for wait-prop / wait-signal / wait-frames ──
+
+
+def test_fmt_wait_prop_matched() -> None:
+    out = cli._fmt_wait_prop_text({"matched": True, "waited": 0.123, "value": 500})
+    assert "matched" in out and "0.123" in out
+
+
+def test_fmt_wait_prop_timeout_has_reason_and_last_value() -> None:
+    out = cli._fmt_wait_prop_text({"matched": False, "reason": "timeout", "value": 10})
+    assert "timeout" in out and "10" in out
+
+
+def test_fmt_wait_signal_emitted() -> None:
+    assert cli._fmt_wait_signal_text({"emitted": True}) == "emitted"
+
+
+def test_fmt_wait_signal_timeout() -> None:
+    assert cli._fmt_wait_signal_text({"emitted": False}) == "timeout"
+    assert cli._fmt_wait_signal_text({}) == "timeout"
+
+
+def test_fmt_wait_frames_text() -> None:
+    """wait-frames 文本输出包含帧数。"""
+    # RpcSpec text_formatter is a lambda; test by calling it directly from spec
+    import importlib
+    importlib.reload(cli)  # ensure latest state
+    spec = cli.RPC_BY_NAME.get("wait-frames")
+    if spec is None:
+        pytest.skip("wait-frames spec not yet registered")
+    out = spec.text_formatter({"frames": 5, "success": True})
+    assert "5" in out and "frames" in out
+
+
+# ── argparse parser accepts wait-* subcommands ──
+
+
+def test_parser_accepts_wait_prop() -> None:
+    """wait-prop 必须被 build_parser 注册为子命令。"""
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["wait-prop", "/root/N", "visible", "true"])
+    assert ns.cmd == "wait-prop"
+    assert ns.node_path == "/root/N"
+    assert ns.prop == "visible"
+    assert ns.value == "true"
+
+
+def test_parser_accepts_wait_signal() -> None:
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["wait-signal", "/root/A", "fired"])
+    assert ns.cmd == "wait-signal"
+    assert ns.node_path == "/root/A"
+    assert ns.signal_name == "fired"
+
+
+def test_parser_accepts_wait_frames() -> None:
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["wait-frames", "3", "--physics"])
+    assert ns.cmd == "wait-frames"
+    assert ns.frames == "3"
+    assert ns.physics is True

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -595,3 +595,95 @@ async def test_connect_locks_ws_ping_keepalive() -> None:
             "GameClient.connect() must lock ping_interval (ws keepalive)"
         assert kwargs.get("ping_timeout") == 20, \
             "GameClient.connect() must lock ping_timeout (ws keepalive)"
+
+
+# ---- issue #96: wait_property / wait_signal / wait_frames client 包装 ----
+
+
+@pytest.mark.asyncio
+async def test_wait_property_sends_correct_rpc_params() -> None:
+    """wait_property 必须发出 method="wait_property"，参数全部透传（含 op/tolerance）。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        captured["timeout"] = timeout
+        return {"matched": True, "value": 500, "waited": 0.12}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.wait_property(
+            "/root/Player", "position:x", 500,
+            op="gt", timeout=3.0, tolerance=0.5,
+        )
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "wait_property"
+    assert captured["params"] == {
+        "path": "/root/Player", "property": "position:x", "value": 500,
+        "op": "gt", "timeout": 3.0, "tolerance": 0.5,
+    }
+    # client 侧 timeout = server timeout + 5s grace
+    assert captured["timeout"] == 3.0 + 5.0
+    assert result == {"matched": True, "value": 500, "waited": 0.12}
+
+
+@pytest.mark.asyncio
+async def test_wait_signal_sends_correct_rpc_params() -> None:
+    """wait_signal 必须发出 method="wait_signal"，超时 = server timeout + 5s。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        captured["timeout"] = timeout
+        return {"emitted": True, "args": []}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.wait_signal("/root/Area", "door_opened", timeout=4.0)
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "wait_signal"
+    assert captured["params"] == {"path": "/root/Area", "signal": "door_opened", "timeout": 4.0}
+    assert captured["timeout"] == 4.0 + 5.0
+    assert result == {"emitted": True, "args": []}
+
+
+@pytest.mark.asyncio
+async def test_wait_frames_sends_correct_rpc_params_and_calculates_timeout() -> None:
+    """wait_frames 的 client timeout = max(30, frames/10 + 10)。"""
+    import godot_cli_control.client as client_mod
+
+    captured: list = []
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured.append({"method": method, "params": params, "timeout": timeout})
+        return {"success": True, "frames": params.get("frames", 0)}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        # 3 frames: max(30, 3/10+10)=max(30, 10.3)=30
+        await client.wait_frames(3)
+        # 300 frames: max(30, 300/10+10)=max(30, 40)=40
+        await client.wait_frames(300, physics=True)
+    finally:
+        client_mod.GameClient.request = orig
+
+    assert captured[0]["method"] == "wait_frames"
+    assert captured[0]["params"] == {"frames": 3, "physics": False}
+    assert captured[0]["timeout"] == 30.0
+
+    assert captured[1]["params"] == {"frames": 300, "physics": True}
+    assert captured[1]["timeout"] == 40.0

--- a/python/tests/test_e2e_client_direct.py
+++ b/python/tests/test_e2e_client_direct.py
@@ -252,3 +252,53 @@ async def test_client_request_get_property_has_type_field(daemon_port: Any) -> N
         assert len(result["value"]) == 2, result
         # type 字段存在且是 "Vector2"
         assert result.get("type") == "Vector2", result
+
+
+@pytest.mark.asyncio
+async def test_client_wait_frames(daemon_port: Any) -> None:
+    """client.wait_frames(2) 返回 {"success": True, "frames": 2}（issue #96 直连覆盖）。"""
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        result = await client.wait_frames(2)
+        assert isinstance(result, dict), result
+        assert result.get("success") is True, result
+        assert result.get("frames") == 2, result
+
+
+@pytest.mark.asyncio
+async def test_client_wait_property_immediate_match_and_timeout(daemon_port: Any) -> None:
+    """wait_property 直连测试：立即命中路径 + 超时路径（issue #96）。
+
+    先 set_property 一个已知值，再 wait eq → matched=True（立即命中）。
+    然后等一个永远不成立的条件 timeout=0.5 → matched=False, reason='timeout'。
+    """
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        # 写 counter = 42，然后立即等 counter == 42 → 应立即命中
+        await client.set_property("/root/Main", "counter", 42)
+        result_match = await client.wait_property(
+            "/root/Main", "counter", 42, op="eq", timeout=2.0
+        )
+        assert isinstance(result_match, dict), result_match
+        assert result_match.get("matched") is True, result_match
+
+        # 等 counter > 9999（永远不成立）超时
+        result_timeout = await client.wait_property(
+            "/root/Main", "counter", 9999, op="gt", timeout=0.5
+        )
+        assert isinstance(result_timeout, dict), result_timeout
+        assert result_timeout.get("matched") is False, result_timeout
+        assert result_timeout.get("reason") == "timeout", result_timeout
+
+
+@pytest.mark.asyncio
+async def test_client_wait_signal_timeout_path(daemon_port: Any) -> None:
+    """wait_signal 超时路径：等一个不会发射的内置信号 renamed（issue #96）。
+
+    emitted=False 且超时时间合理（0.5s）。
+    """
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        result = await client.wait_signal("/root/Main/Player", "renamed", timeout=0.5)
+        assert isinstance(result, dict), result
+        assert result.get("emitted") is False, result


### PR DESCRIPTION
Closes #96。Stacked on #105（前序合并后 retarget）。

## 动机

bridge 的等待原语只有 `wait-node` / `wait-time`，下游 e2e 想等「某个状态生效」只能固定时长 sleep 猜（XGame 实测 0.15~0.3s 经验值 ×10+ 处）：慢、flaky、意图表达不出来（注释写「等 2 个物理帧」，API 只有秒）。

## 改动

| 命令 | RPC | 语义 |
|---|---|---|
| `wait-prop <path> <prop> <value> [--op eq\|ne\|gt\|lt\|ge\|le] [--timeout 5] [--tolerance 0]` | `wait_property` | 逐帧轮询直到属性满足条件；支持 sub-path（`position:x 500 --op gt`）；**超时不报错**——返回 `matched=false + reason(timeout/node_not_found/property_not_found) + 最后值`，容忍节点/属性中途出现，typo 靠 reason 诊断 |
| `wait-signal <path> <signal> [timeout]` | `wait_signal` | ONE_SHOT 连接 + 超时竞速；命中带回编码后信号参数（0..8 参 capture）；超时显式断连防悬挂；信号不存在 → **新错误码 1007** |
| `wait-frames <n> [--physics]` | `wait_frames` | 确定性帧推进（1..3600），`--physics` 等物理帧——「等 ~3 个物理帧」终于能直说 |

- 退出码与 wait-node 对齐：命中 0 / 超时 1，shell `if` 可用
- preflight 连接前拦 6 类用法错（timeout/tolerance 非法、ordering op + 非数值值含 bool）→ -1003 + exit 64
- 服务端 timeout/tolerance 类型双重校验（绕过 CLI 的直连 RPC 也兜住）
- client wall-timeout = server timeout + grace（与 LONG_OP 600s 生死线独立，已论证无冲突）
- SKILL.md：三命令 + 1007 + 退出码表 + 2 条新 pitfalls（**wait-signal 先挂等待再触发**：`wait-signal ... & tap jump; wait`；magic sleep 迁移指引）

## 验证

- GUT 139/139（命中/超时/op 矩阵/tolerance/信号参数编码/超时断连清理/类型校验）
- pytest 446 passed / 2 skipped（含 e2e 直连真跑三原语），coverage 96%
- ruff 全绿；SKILL.md 渲染 OK；preflight 退出码 64 实测、命中/超时 0/1 实测

🤖 Generated with [Claude Code](https://claude.com/claude-code)