### PR TITLE
chore: 将 #105/#106 已审内容落到 main（stacked 合并修正）

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Godot ships great tools for *playing* a scene, but very little for *programmatic
 
 One install, one daemon, one consistent API across your editor, your tests, your CI, and your agents.
 
+## Recent changes
+
+**BREAKING (unreleased):** `get` now returns compound Variants (Vector2, Color, etc.) as a structured object `{"value": [x, y], "type": "Vector2"}` instead of the old `"(x, y)"` string. The `value` array is the same layout `set` accepts, so round-trips work directly. Also new: `get <path> <prop1> <prop2>` reads multiple properties atomically in one frame (`get_properties` RPC, #100).
+
 ## Highlights
 
 | | |

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING** `get` 复合 Variant 返回从旧版 `"(x, y)"` 字符串改为 set-schema 数组 + type 字段；信封 result 从裸值变 `{"value": <array-or-scalar>, "type"?: "<GodotType>"}` 对象（#99）。写侧 `set` 接受的 Array layout 完全一致，get→set round-trip 无需转换。Python API `get_property` / `get_properties` 只返回裸 value（type 已剥离），要拿 type 字段走 CLI `get` 或底层 `client.request("get_property", ...)`。
+
+### Added
+- **feat: `get_properties` 多属性同帧原子读 + `get` 多属性形式（#100）**：`get <path> <prop1> <prop2>` 一次 RPC 同帧读取多个属性，不存在部分新鲜/部分旧数据的竞态；任一属性缺失整体失败（1002，message 点名所有缺失项）。sub-path 形式（`position:x`）在多属性列表中也支持。
+
 ### Fixed
 - **#52 `set` 走 JSON Array 喂 Vector/Color/Rect 时静默失败**：`set zoom '[1.8, 1.8]'` 等价于 `node.set("zoom", [1.8, 1.8])`，Godot 隐式构造失败 → 实际值是 `Vector2(0,0)` 或被 clamp 到 `0.00001`，但服务端仍返 `{success: true}`。`handle_set_property` 现在查 `get_property_list()` 拿声明类型，把 numeric Array 转成对应 Variant。长度不匹配或元素非数字时 fail-loud 返 `-32602 "value type mismatch ..."`，不再 silent corruption。
 - **sub-path 标量赋值现在真的会写入**：之前 `set <node> position:x 1.8` 调的是 `Object.set("position:x", 1.8)`，Godot 4 的 `Object.set` 把整串当字面属性名找不到就 silent no-op（依旧返 `{success: true}` 但 `position.x` 不变）。改用 `Object.set_indexed(NodePath, value)` 才会按 sub-path 写入。是 #54 review 阶段被新加的 `test_set_subpath_scalar_still_works` 捕获的隐藏 silent-fail。

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **feat(wait): `wait-prop` / `wait-signal` / `wait-frames` 条件等待原语 + 错误码 1007（#96）**: 三个新 CLI 子命令。`wait-prop <path> <prop> <value> [--op eq|ne|gt|ge|lt|le] [--timeout] [--tolerance] [--physics]` 等属性满足条件（exit 0=matched, 1=timeout）；`wait-signal <path> <signal> [--timeout]` 等信号发射（exit 0=emitted, 1=timeout）；`wait-frames <N> [--physics]` 推进 N 帧。服务端错误码 1007 SIGNAL_NOT_FOUND（wait-signal 传未知信号名，永久性 schema 错，不应 retry）。Python `GameClient` 对应方法：`wait_property` / `wait_signal` / `wait_frames`。
+
 ### Changed
 - **BREAKING** `get` 复合 Variant 返回从旧版 `"(x, y)"` 字符串改为 set-schema 数组 + type 字段；信封 result 从裸值变 `{"value": <array-or-scalar>, "type"?: "<GodotType>"}` 对象（#99）。写侧 `set` 接受的 Array layout 完全一致，get→set round-trip 无需转换。Python API `get_property` / `get_properties` 只返回裸 value（type 已剥离），要拿 type 字段走 CLI `get` 或底层 `client.request("get_property", ...)`。
 

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- **feat(wait): `wait-prop` / `wait-signal` / `wait-frames` 条件等待原语 + 错误码 1007（#96）**: 三个新 CLI 子命令。`wait-prop <path> <prop> <value> [--op eq|ne|gt|ge|lt|le] [--timeout] [--tolerance] [--physics]` 等属性满足条件（exit 0=matched, 1=timeout）；`wait-signal <path> <signal> [--timeout]` 等信号发射（exit 0=emitted, 1=timeout）；`wait-frames <N> [--physics]` 推进 N 帧。服务端错误码 1007 SIGNAL_NOT_FOUND（wait-signal 传未知信号名，永久性 schema 错，不应 retry）。Python `GameClient` 对应方法：`wait_property` / `wait_signal` / `wait_frames`。
+- **feat(wait): `wait-prop` / `wait-signal` / `wait-frames` 条件等待原语 + 错误码 1007（#96）**: 三个新 CLI 子命令。`wait-prop <path> <prop> <value> [--op eq|ne|gt|lt|ge|le] [--timeout] [--tolerance]` 等属性满足条件（exit 0=matched, 1=timeout）；`wait-signal <path> <signal> [--timeout]` 等信号发射（exit 0=emitted, 1=timeout）；`wait-frames <N> [--physics]` 推进 N 帧。服务端错误码 1007 SIGNAL_NOT_FOUND（wait-signal 传未知信号名，永久性 schema 错，不应 retry）。Python `GameClient` 对应方法：`wait_property` / `wait_signal` / `wait_frames`。
 
 ### Changed
 - **BREAKING** `get` 复合 Variant 返回从旧版 `"(x, y)"` 字符串改为 set-schema 数组 + type 字段；信封 result 从裸值变 `{"value": <array-or-scalar>, "type"?: "<GodotType>"}` 对象（#99）。写侧 `set` 接受的 Array layout 完全一致，get→set round-trip 无需转换。Python API `get_property` / `get_properties` 只返回裸 value（type 已剥离），要拿 type 字段走 CLI `get` 或底层 `client.request("get_property", ...)`。

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -83,7 +83,8 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 | Method | Example |
 |---|---|
 | `click(path)` | `await client.click("/root/MyScene/Button")` |
-| `get_property(path, property)` | `await client.get_property("/root/Player", "position")` |
+| `get_property(path, property)` | `await client.get_property("/root/Player", "position")` — returns bare value; CLI `get` returns `{"value": ..., "type"?: ...}` shape |
+| `get_properties(path, properties)` | `await client.get_properties("/root/Player", ["position", "health"])` — multi-property atomic read; returns `{prop: bare_value, ...}` dict |
 | `set_property(path, property, value)` | `await client.set_property("/root/Player", "visible", False)` |
 | `call_method(path, method, args)` | `await client.call_method("/root/Player", "take_damage", [10])` |
 | `get_text(path)` | `await client.get_text("/root/UI/Label")` |

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -95,6 +95,9 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 | `screenshot()` | `png_bytes = await client.screenshot()` |
 | `wait_for_node(path, timeout)` | `await client.wait_for_node("/root/Boss", timeout=10.0)` |
 | `wait_game_time(seconds)` | `await client.wait_game_time(2.5)` |
+| `wait_property(path, prop, value, op, timeout, tolerance)` | `await client.wait_property("/root/Player", "position:x", 500, op="gt", timeout=3.0)` |
+| `wait_signal(path, signal, timeout)` | `await client.wait_signal("/root/Game", "level_complete", timeout=10.0)` |
+| `wait_frames(frames, physics)` | `await client.wait_frames(4)` |
 | `action_press(action)` | `await client.action_press("jump")` |
 | `action_release(action)` | `await client.action_release("jump")` |
 | `action_tap(action, duration)` | `await client.action_tap("attack", 0.1)` |
@@ -125,6 +128,7 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `1004` | server | Combo already in progress (call `combo-cancel` to retry) |
 | `1005` | server | Scene tree too large (lower `depth` or pass `--max-nodes`) |
 | `1006` | server | Resource transiently unavailable (e.g. screenshot during scene transition). Rare under normal use — GameBridge waits for viewport first-frame before listening, and `screenshot` retries internally. Safe to retry if you do hit it. |
+| `1007` | server | Signal not found on the node (`wait-signal` schema error — signal name typo or the node doesn't define it). Permanent — don't retry; inspect with `tree` or `children` to find valid signals. |
 | `-32600` | server | Malformed JSON-RPC request |
 | `-32601` | server | Unknown method name |
 | `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements, or `hold` given `duration ≤ 0` — use `press` for an indefinite hold) |
@@ -158,8 +162,8 @@ Semantic exit codes so `if godot-cli-control exists /root/Foo; then …` works i
 
 | Code | Meaning |
 |---|---|
-| 0 | Success (or boolean true for `exists` / `visible`, node found for `wait-node`) |
-| 1 | RPC error; also `exists`/`visible`=false, `wait-node` timeout, `daemon status`=stopped |
+| 0 | Success (or boolean true for `exists` / `visible`, node found for `wait-node`, condition matched for `wait-prop` / `wait-signal`) |
+| 1 | RPC error; also `exists`/`visible`=false, `wait-node`/`wait-prop`/`wait-signal` timeout, `daemon status`=stopped |
 | 2 | Connection / IO error, or `daemon stop` ffmpeg-transcode failure |
 | 3 | `daemon stop --all` partial failure (≥1 daemon failed to stop) |
 | 64 | Usage error on an RPC subcommand — bad argparse args, a pre-flight reject (`combo` with no steps / malformed `--steps-json`), a non-numeric `tap`/`wait-time` arg, or a `set`/`call` value that fails JSON parsing. These all carry client code `-1003` and now consistently exit 64 (#82; a few previously exited 2). |

--- a/addons/godot_cli_control/bridge/error_codes.gd
+++ b/addons/godot_cli_control/bridge/error_codes.gd
@@ -22,6 +22,8 @@ const SCENE_TREE_TOO_LARGE: int = 1005
 # client 必须保留对 1006 的处理（不要假设它消失），未来若改为 fail-loud
 # 会让 scene 切换瞬间的截图变成硬错。
 const RESOURCE_UNAVAILABLE: int = 1006
+# 信号不存在（wait_signal 的 schema 错，永久性——与 1003 method、1002 property 同族）
+const SIGNAL_NOT_FOUND: int = 1007
 
 const INVALID_PARAMS: int = -32602
 const INVALID_REQUEST: int = -32600

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -189,6 +189,7 @@ func _register_methods() -> void:
 	_methods["wait_game_time"] = {"callable": _low_level_api.wait_game_time_async, "kind": "async"}
 	_methods["wait_frames"] = {"callable": _low_level_api.wait_frames_async, "kind": "async"}
 	_methods["wait_property"] = {"callable": _low_level_api.wait_property_async, "kind": "async"}
+	_methods["wait_signal"] = {"callable": _low_level_api.wait_signal_async, "kind": "async"}
 	_methods["screenshot"] = {"callable": _wrap_screenshot, "kind": "async"}
 	# 输入模拟（同步）
 	_methods["input_action_press"] = {

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -176,6 +176,7 @@ func _register_methods() -> void:
 	# 低层 API（同步）
 	_methods["click"] = {"callable": _low_level_api.handle_click, "kind": "sync"}
 	_methods["get_property"] = {"callable": _low_level_api.handle_get_property, "kind": "sync"}
+	_methods["get_properties"] = {"callable": _low_level_api.handle_get_properties, "kind": "sync"}
 	_methods["set_property"] = {"callable": _low_level_api.handle_set_property, "kind": "sync"}
 	_methods["call_method"] = {"callable": _low_level_api.handle_call_method, "kind": "sync"}
 	_methods["get_text"] = {"callable": _low_level_api.handle_get_text, "kind": "sync"}

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -187,6 +187,7 @@ func _register_methods() -> void:
 	# 低层 API（异步）
 	_methods["wait_for_node"] = {"callable": _low_level_api.wait_for_node_async, "kind": "async"}
 	_methods["wait_game_time"] = {"callable": _low_level_api.wait_game_time_async, "kind": "async"}
+	_methods["wait_frames"] = {"callable": _low_level_api.wait_frames_async, "kind": "async"}
 	_methods["screenshot"] = {"callable": _wrap_screenshot, "kind": "async"}
 	# 输入模拟（同步）
 	_methods["input_action_press"] = {

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -188,6 +188,7 @@ func _register_methods() -> void:
 	_methods["wait_for_node"] = {"callable": _low_level_api.wait_for_node_async, "kind": "async"}
 	_methods["wait_game_time"] = {"callable": _low_level_api.wait_game_time_async, "kind": "async"}
 	_methods["wait_frames"] = {"callable": _low_level_api.wait_frames_async, "kind": "async"}
+	_methods["wait_property"] = {"callable": _low_level_api.wait_property_async, "kind": "async"}
 	_methods["screenshot"] = {"callable": _wrap_screenshot, "kind": "async"}
 	# 输入模拟（同步）
 	_methods["input_action_press"] = {

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -115,11 +115,27 @@ func handle_get_property(params: Dictionary) -> Dictionary:
 	var node: Node = _get_node_or_error(params)
 	if node == null:
 		return _node_not_found(params.get("path", "") as String)
-	var property: String = params.get("property", "") as String
+	var read: Dictionary = _read_property(node, params.get("property", "") as String)
+	if read.has("error"):
+		return read
+	# issue #99：复合 Variant 走 codec 编码（与 set 侧 array schema 对称），
+	# 返回 {"value": ..., "type": <仅复合类型>}，round-trip 闭环。
+	return CliControlVariantCodec.encode(read["value"])
+
+
+## 读单个属性，支持 sub-path（"position:x"，与 set 侧对称走 get_indexed）。
+## 返回 {"value": Variant} 或 {"error": ...}。
+## sub-path 的 leaf 非法时 get_indexed 返回 null——与「真 null 值」无法区分，
+## SKILL.md 已声明该边界；这里只校验 ":" 前的 top-level 名存在（1002 兜底 typo）。
+func _read_property(node: Node, property: String) -> Dictionary:
 	if property.is_empty():
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'property' parameter")
-	if not _has_property(node, property):
-		return _err(CliControlErrorCodes.PROPERTY_NOT_FOUND, "Property not found: %s" % property)
+	var is_sub_path: bool = ":" in property
+	var top_level: String = property.split(":", true, 1)[0] if is_sub_path else property
+	if not _has_property(node, top_level):
+		return _err(CliControlErrorCodes.PROPERTY_NOT_FOUND, "Property not found: %s" % top_level)
+	if is_sub_path:
+		return {"value": node.get_indexed(NodePath(property))}
 	return {"value": node.get(property)}
 
 

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -126,7 +126,8 @@ func handle_get_property(params: Dictionary) -> Dictionary:
 ## 读单个属性，支持 sub-path（"position:x"，与 set 侧对称走 get_indexed）。
 ## 返回 {"value": Variant} 或 {"error": ...}。
 ## sub-path 的 leaf 非法时 get_indexed 返回 null——与「真 null 值」无法区分，
-## SKILL.md 已声明该边界；这里只校验 ":" 前的 top-level 名存在（1002 兜底 typo）。
+## SKILL.md 已声明该边界（pitfalls 中「Sub-path reading a non-existent leaf」一条）；
+## 这里只校验 ":" 前的 top-level 名存在（1002 兜底 typo）。
 func _read_property(node: Node, property: String) -> Dictionary:
 	if property.is_empty():
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'property' parameter")

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -562,10 +562,16 @@ func wait_property_async(params: Dictionary) -> Dictionary:
 	var op: String = params.get("op", "eq") as String
 	if not op in _WAIT_PROP_OPS:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "op must be one of: %s" % ", ".join(_WAIT_PROP_OPS))
-	var timeout: float = params.get("timeout", 5.0) as float
+	var timeout_raw: Variant = params.get("timeout", 5.0)
+	if not (timeout_raw is int or timeout_raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'timeout' must be a number")
+	var timeout: float = float(timeout_raw)
 	if timeout < 0.0 or timeout > _MAX_WAIT_SECONDS:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "timeout must be 0..%s" % _MAX_WAIT_SECONDS)
-	var tolerance: float = params.get("tolerance", 0.0) as float
+	var tolerance_raw: Variant = params.get("tolerance", 0.0)
+	if not (tolerance_raw is int or tolerance_raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'tolerance' must be a number")
+	var tolerance: float = float(tolerance_raw)
 	if tolerance < 0.0:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "tolerance must be >= 0")
 	var expected: Variant = params.get("value", null)
@@ -666,7 +672,10 @@ func wait_signal_async(params: Dictionary) -> Dictionary:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'signal' parameter")
 	if not node.has_signal(signal_name):
 		return _err(CliControlErrorCodes.SIGNAL_NOT_FOUND, "Signal not found: %s" % signal_name)
-	var timeout: float = params.get("timeout", 5.0) as float
+	var timeout_raw2: Variant = params.get("timeout", 5.0)
+	if not (timeout_raw2 is int or timeout_raw2 is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'timeout' must be a number")
+	var timeout: float = float(timeout_raw2)
 	if timeout < 0.0 or timeout > _MAX_WAIT_SECONDS:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "timeout must be 0..%s" % _MAX_WAIT_SECONDS)
 	var argc: int = 0

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -15,6 +15,8 @@ const _BUILD_TREE_DEFAULT_MAX_DEPTH: int = 50
 const _BUILD_TREE_MAX_NODES: int = 5000
 # wait_game_time_async 防呆上限：防止误传 1e9 之类的数值挂死 session
 const _MAX_WAIT_SECONDS: float = 3600.0
+# wait_frames 防呆上限：60fps 下 1 分钟。要等更久用 wait_game_time / wait_property。
+const _MAX_WAIT_FRAMES: int = 3600
 # take_screenshot_async 循环上限：常态下 GameBridge 启动 gate 已保证 viewport
 # ready（issue #61 H 部分），这个循环只兜动态 transient（scene transition、
 # 窗口 resize 一瞬）。30 帧 ~500ms @ 60fps，超时报 1006 给 client 兜底。
@@ -505,6 +507,23 @@ func wait_game_time_async(params: Dictionary) -> Dictionary:
 		return {"success": true}
 	await get_tree().create_timer(seconds).timeout
 	return {"success": true}
+
+
+## issue #96：等 N 帧（确定性帧推进）。physics=true 等 physics_frame。
+func wait_frames_async(params: Dictionary) -> Dictionary:
+	var frames_raw: Variant = params.get("frames", null)
+	if not (frames_raw is int or frames_raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'frames' must be an integer")
+	var frames: int = int(frames_raw)
+	if frames < 1 or frames > _MAX_WAIT_FRAMES:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "frames must be 1..%d (got %d)" % [_MAX_WAIT_FRAMES, frames])
+	var physics: bool = bool(params.get("physics", false))
+	for _i in frames:
+		if physics:
+			await get_tree().physics_frame
+		else:
+			await get_tree().process_frame
+	return {"success": true, "frames": frames}
 
 
 func _get_node_or_error(params: Dictionary) -> Node:

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -139,6 +139,36 @@ func _read_property(node: Node, property: String) -> Dictionary:
 	return {"value": node.get(property)}
 
 
+## issue #100：多属性同帧原子读。sync handler 无 await——所有读取天然同一帧。
+## 原子语义：任一属性缺失整体失败（1002 点名全部缺失项），不返回半新半旧组合。
+func handle_get_properties(params: Dictionary) -> Dictionary:
+	var node: Node = _get_node_or_error(params)
+	if node == null:
+		return _node_not_found(params.get("path", "") as String)
+	var props_raw: Variant = params.get("properties", null)
+	if not props_raw is Array or (props_raw as Array).is_empty():
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'properties' must be a non-empty array of strings")
+	var props: Array = props_raw as Array
+	var missing: PackedStringArray = []
+	for raw_prop: Variant in props:
+		if not raw_prop is String or (raw_prop as String).is_empty():
+			return _err(CliControlErrorCodes.INVALID_PARAMS, "'properties' must be a non-empty array of strings")
+		var prop_name: String = raw_prop as String
+		var top_level: String = prop_name.split(":", true, 1)[0] if ":" in prop_name else prop_name
+		if not _has_property(node, top_level):
+			missing.append(prop_name)
+	if not missing.is_empty():
+		return _err(CliControlErrorCodes.PROPERTY_NOT_FOUND, "Properties not found: %s" % ", ".join(missing))
+	var values: Dictionary = {}
+	for raw_prop2: Variant in props:
+		var prop_name2: String = raw_prop2 as String
+		var read: Dictionary = _read_property(node, prop_name2)
+		if read.has("error"):
+			return read  # 防御纵深：上面已全量校验，理论到不了这里
+		values[prop_name2] = CliControlVariantCodec.encode(read["value"])
+	return {"values": values}
+
+
 func handle_set_property(params: Dictionary) -> Dictionary:
 	var node: Node = _get_node_or_error(params)
 	if node == null:

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -17,6 +17,8 @@ const _BUILD_TREE_MAX_NODES: int = 5000
 const _MAX_WAIT_SECONDS: float = 3600.0
 # wait_frames 防呆上限：60fps 下 1 分钟。要等更久用 wait_game_time / wait_property。
 const _MAX_WAIT_FRAMES: int = 3600
+# wait_property 支持的比较操作符列表
+const _WAIT_PROP_OPS: PackedStringArray = ["eq", "ne", "gt", "lt", "ge", "le"]
 # take_screenshot_async 循环上限：常态下 GameBridge 启动 gate 已保证 viewport
 # ready（issue #61 H 部分），这个循环只兜动态 transient（scene transition、
 # 窗口 resize 一瞬）。30 帧 ~500ms @ 60fps，超时报 1006 给 client 兜底。
@@ -507,6 +509,92 @@ func wait_game_time_async(params: Dictionary) -> Dictionary:
 		return {"success": true}
 	await get_tree().create_timer(seconds).timeout
 	return {"success": true}
+
+
+## issue #96：逐帧轮询等属性满足条件。超时不报错——返回 matched=false +
+## reason（timeout / node_not_found / property_not_found，按最后一次轮询状态）
+## + value（最后一次读到的编码值），容忍节点/属性中途出现，typo 靠 reason 诊断。
+func wait_property_async(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "") as String
+	var property: String = params.get("property", "") as String
+	if property.is_empty():
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'property' parameter")
+	var op: String = params.get("op", "eq") as String
+	if not op in _WAIT_PROP_OPS:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "op must be one of: %s" % ", ".join(_WAIT_PROP_OPS))
+	var timeout: float = params.get("timeout", 5.0) as float
+	if timeout < 0.0 or timeout > _MAX_WAIT_SECONDS:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "timeout must be 0..%s" % _MAX_WAIT_SECONDS)
+	var tolerance: float = params.get("tolerance", 0.0) as float
+	if tolerance < 0.0:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "tolerance must be >= 0")
+	var expected: Variant = params.get("value", null)
+	if not (expected is int or expected is float) and not op in ["eq", "ne"]:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "op '%s' requires a numeric value; compound/string values only support eq/ne" % op)
+	var start_ms: int = Time.get_ticks_msec()
+	var reason: String = "timeout"
+	var last_value: Variant = null
+	while true:
+		var node: Node = get_tree().root.get_node_or_null(path)
+		if node == null:
+			reason = "node_not_found"
+			last_value = null
+		else:
+			var read: Dictionary = _read_property(node, property)
+			if read.has("error"):
+				reason = "property_not_found"
+				last_value = null
+			else:
+				reason = "timeout"
+				last_value = CliControlVariantCodec.encode_value(read["value"])
+				if _wait_compare(last_value, expected, op, tolerance):
+					return {
+						"matched": true,
+						"value": last_value,
+						"waited": float(Time.get_ticks_msec() - start_ms) / 1000.0,
+					}
+		if float(Time.get_ticks_msec() - start_ms) / 1000.0 >= timeout:
+			break
+		await get_tree().process_frame
+	return {"matched": false, "reason": reason, "value": last_value}
+
+
+## 编码后值比较。数值走 6 op（eq/ne 带 tolerance）；其余类型仅 eq/ne 深比较
+## （数组逐元素，数值元素同样吃 tolerance）。ordering op + 非数值 actual →
+## false（继续轮询直到 timeout，reason 诊断）。
+func _wait_compare(actual: Variant, expected: Variant, op: String, tolerance: float) -> bool:
+	if (actual is int or actual is float) and (expected is int or expected is float):
+		var a: float = float(actual)
+		var b: float = float(expected)
+		match op:
+			"eq": return absf(a - b) <= tolerance
+			"ne": return absf(a - b) > tolerance
+			"gt": return a > b
+			"lt": return a < b
+			"ge": return a >= b
+			"le": return a <= b
+		return false
+	var equal: bool = _deep_equal(actual, expected, tolerance)
+	if op == "eq":
+		return equal
+	if op == "ne":
+		return not equal
+	return false
+
+
+func _deep_equal(a: Variant, b: Variant, tolerance: float) -> bool:
+	if (a is int or a is float) and (b is int or b is float):
+		return absf(float(a) - float(b)) <= tolerance
+	if a is Array and b is Array:
+		var aa: Array = a as Array
+		var ba: Array = b as Array
+		if aa.size() != ba.size():
+			return false
+		for i in aa.size():
+			if not _deep_equal(aa[i], ba[i], tolerance):
+				return false
+		return true
+	return a == b  # String / bool / null / Dictionary（引擎深比较）
 
 
 ## issue #96：等 N 帧（确定性帧推进）。physics=true 等 physics_frame。

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -69,6 +69,46 @@ const _ARRAY_PASSTHROUGH_SAFE_TYPES: Array[int] = [
 ]
 
 
+## wait_signal 的参数捕获器（issue #96）。GDScript 无变参 Callable，
+## 按信号声明 argc（get_signal_list）从 0..MAX_ARGS 选对应 cap 函数。
+class _SignalCapture:
+	extends RefCounted
+
+	const MAX_ARGS: int = 8
+
+	var fired: bool = false
+	var args: Array = []
+
+	func cap0() -> void: _hit([])
+	func cap1(a1: Variant) -> void: _hit([a1])
+	func cap2(a1: Variant, a2: Variant) -> void: _hit([a1, a2])
+	func cap3(a1: Variant, a2: Variant, a3: Variant) -> void: _hit([a1, a2, a3])
+	func cap4(a1: Variant, a2: Variant, a3: Variant, a4: Variant) -> void: _hit([a1, a2, a3, a4])
+	func cap5(a1: Variant, a2: Variant, a3: Variant, a4: Variant, a5: Variant) -> void: _hit([a1, a2, a3, a4, a5])
+	func cap6(a1: Variant, a2: Variant, a3: Variant, a4: Variant, a5: Variant, a6: Variant) -> void: _hit([a1, a2, a3, a4, a5, a6])
+	func cap7(a1: Variant, a2: Variant, a3: Variant, a4: Variant, a5: Variant, a6: Variant, a7: Variant) -> void: _hit([a1, a2, a3, a4, a5, a6, a7])
+	func cap8(a1: Variant, a2: Variant, a3: Variant, a4: Variant, a5: Variant, a6: Variant, a7: Variant, a8: Variant) -> void: _hit([a1, a2, a3, a4, a5, a6, a7, a8])
+
+	func callable_for(argc: int) -> Callable:
+		match argc:
+			0: return cap0
+			1: return cap1
+			2: return cap2
+			3: return cap3
+			4: return cap4
+			5: return cap5
+			6: return cap6
+			7: return cap7
+			8: return cap8
+		return Callable()
+
+	func _hit(captured: Array) -> void:
+		if fired:
+			return
+		fired = true
+		args = captured
+
+
 func _ready() -> void:
 	_property_blacklist = _merge_extra(_property_blacklist, SETTING_PROPERTY_BLACKLIST_EXTRA)
 	_method_blacklist = _merge_extra(_method_blacklist, SETTING_METHOD_BLACKLIST_EXTRA)
@@ -612,6 +652,52 @@ func wait_frames_async(params: Dictionary) -> Dictionary:
 		else:
 			await get_tree().process_frame
 	return {"success": true, "frames": frames}
+
+
+## issue #96：等信号发射（带超时）。竞态注意（SKILL.md pitfall）：必须先挂
+## 等待再触发动作——信号在 connect 之前发射不会被捕获。
+func wait_signal_async(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "") as String
+	var node: Node = get_tree().root.get_node_or_null(path)
+	if node == null:
+		return _node_not_found(path)
+	var signal_name: String = params.get("signal", "") as String
+	if signal_name.is_empty():
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'signal' parameter")
+	if not node.has_signal(signal_name):
+		return _err(CliControlErrorCodes.SIGNAL_NOT_FOUND, "Signal not found: %s" % signal_name)
+	var timeout: float = params.get("timeout", 5.0) as float
+	if timeout < 0.0 or timeout > _MAX_WAIT_SECONDS:
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "timeout must be 0..%s" % _MAX_WAIT_SECONDS)
+	var argc: int = 0
+	for sig: Dictionary in node.get_signal_list():
+		if sig["name"] == signal_name:
+			argc = (sig["args"] as Array).size()
+			break
+	if argc > _SignalCapture.MAX_ARGS:
+		return _err(
+			CliControlErrorCodes.INVALID_PARAMS,
+			"signal '%s' has %d args (max %d supported)" % [signal_name, argc, _SignalCapture.MAX_ARGS],
+		)
+	var capture: _SignalCapture = _SignalCapture.new()
+	var cb: Callable = capture.callable_for(argc)
+	node.connect(signal_name, cb, CONNECT_ONE_SHOT)
+	var start_ms: int = Time.get_ticks_msec()
+	while not capture.fired:
+		if float(Time.get_ticks_msec() - start_ms) / 1000.0 >= timeout:
+			break
+		await get_tree().process_frame
+		if not is_instance_valid(node):
+			break  # 节点被释放：连接随之失效，按未命中处理
+	if not capture.fired:
+		# one-shot 未触发时连接仍挂着，必须显式清理（防悬挂 Callable 泄漏）
+		if is_instance_valid(node) and node.is_connected(signal_name, cb):
+			node.disconnect(signal_name, cb)
+		return {"emitted": false}
+	var encoded_args: Array = []
+	for arg: Variant in capture.args:
+		encoded_args.append(CliControlVariantCodec.encode(arg))
+	return {"emitted": true, "args": encoded_args}
 
 
 func _get_node_or_error(params: Dictionary) -> Node:

--- a/addons/godot_cli_control/bridge/variant_codec.gd
+++ b/addons/godot_cli_control/bridge/variant_codec.gd
@@ -1,0 +1,141 @@
+class_name CliControlVariantCodec
+extends RefCounted
+## Variant → JSON-safe 编码（issue #99）。
+##
+## 与 set 侧 low_level_api.gd::_coerce_array_to_declared_type 的 array schema
+## **完全对称**（axis-vector 顺序，见该函数 docstring 的 schema 表）：
+## get 输出的 value 数组可原样灌回 set，round-trip 闭环。
+## Color 不对称提示：set 接受 3 或 4 元，这里恒输出 4 元（4 灌 4 成立）。
+##
+## 全函数：任何 Variant 都有确定输出、不报错——杜绝「响应永远不发出」类挂死。
+## type 字段只在 encode() 顶层出现；嵌套（Array/Dictionary 内）复合类型由
+## encode_value() 递归编码为数组但不带 type（spec 声明的取舍）。
+
+const _COMPOUND_TYPE_NAMES: Dictionary = {
+	TYPE_VECTOR2: "Vector2", TYPE_VECTOR2I: "Vector2i",
+	TYPE_VECTOR3: "Vector3", TYPE_VECTOR3I: "Vector3i",
+	TYPE_VECTOR4: "Vector4", TYPE_VECTOR4I: "Vector4i",
+	TYPE_RECT2: "Rect2", TYPE_RECT2I: "Rect2i",
+	TYPE_COLOR: "Color", TYPE_PLANE: "Plane",
+	TYPE_QUATERNION: "Quaternion", TYPE_AABB: "AABB",
+	TYPE_BASIS: "Basis", TYPE_TRANSFORM2D: "Transform2D",
+	TYPE_TRANSFORM3D: "Transform3D", TYPE_PROJECTION: "Projection",
+}
+
+# 递归编码深度上限：防病态深树 / 自引用容器爆栈挂死 daemon
+# （与 low_level_api.gd _BUILD_TREE_DEFAULT_MAX_DEPTH 同源精神）。
+# 超限降级为哨兵字符串而非报错——保住「全函数」承诺。
+const _MAX_ENCODE_DEPTH: int = 64
+const _DEPTH_SENTINEL: String = "<max-depth-exceeded>"
+
+
+## 顶层编码：返回 {"value": <json-safe>}，复合类型 / StringName / NodePath /
+## Object 额外带 "type" 字段。
+## Object / StringName / NodePath 是诊断性单向编码（不参与 round-trip 闭环），
+## 与 Vector/Color/Array 等复合类型的无损 round-trip 严格区分。
+## 深度上限：容器嵌套超过 _MAX_ENCODE_DEPTH 层时以哨兵字符串降级，保住全函数承诺。
+static func encode(v: Variant) -> Dictionary:
+	var t: int = typeof(v)
+	if _COMPOUND_TYPE_NAMES.has(t):
+		return {"value": encode_value(v), "type": _COMPOUND_TYPE_NAMES[t]}
+	match t:
+		TYPE_STRING_NAME:
+			return {"value": String(v), "type": "StringName"}
+		TYPE_NODE_PATH:
+			return {"value": String(v), "type": "NodePath"}
+		TYPE_OBJECT:
+			return {"value": str(v), "type": "Object"}
+	return {"value": encode_value(v)}
+
+
+## 递归值编码（无 type 信息）。JSON 原生类型原样；复合 → set-schema 数组；
+## 非有限 float → "inf"/"-inf"/"nan" 字符串（JSON.stringify 对 inf/nan 产非法 JSON）。
+## depth 超过 _MAX_ENCODE_DEPTH 时返回哨兵字符串，不报错——保住全函数承诺。
+static func encode_value(v: Variant, depth: int = 0) -> Variant:
+	if depth > _MAX_ENCODE_DEPTH:
+		return _DEPTH_SENTINEL
+	match typeof(v):
+		TYPE_FLOAT:
+			return _f(v)
+		TYPE_VECTOR2:
+			return [_f(v.x), _f(v.y)]
+		TYPE_VECTOR2I:
+			return [v.x, v.y]
+		TYPE_VECTOR3:
+			return [_f(v.x), _f(v.y), _f(v.z)]
+		TYPE_VECTOR3I:
+			return [v.x, v.y, v.z]
+		TYPE_VECTOR4:
+			return [_f(v.x), _f(v.y), _f(v.z), _f(v.w)]
+		TYPE_VECTOR4I:
+			return [v.x, v.y, v.z, v.w]
+		TYPE_RECT2:
+			return [_f(v.position.x), _f(v.position.y), _f(v.size.x), _f(v.size.y)]
+		TYPE_RECT2I:
+			return [v.position.x, v.position.y, v.size.x, v.size.y]
+		TYPE_COLOR:
+			return [_f(v.r), _f(v.g), _f(v.b), _f(v.a)]
+		TYPE_PLANE:
+			return [_f(v.normal.x), _f(v.normal.y), _f(v.normal.z), _f(v.d)]
+		TYPE_QUATERNION:
+			return [_f(v.x), _f(v.y), _f(v.z), _f(v.w)]
+		TYPE_AABB:
+			return [
+				_f(v.position.x), _f(v.position.y), _f(v.position.z),
+				_f(v.size.x), _f(v.size.y), _f(v.size.z),
+			]
+		TYPE_BASIS:
+			return _basis_to_array(v)
+		TYPE_TRANSFORM2D:
+			return [_f(v.x.x), _f(v.x.y), _f(v.y.x), _f(v.y.y), _f(v.origin.x), _f(v.origin.y)]
+		TYPE_TRANSFORM3D:
+			var t3_out: Array = _basis_to_array(v.basis)
+			t3_out.append_array([_f(v.origin.x), _f(v.origin.y), _f(v.origin.z)])
+			return t3_out
+		TYPE_PROJECTION:
+			return [
+				_f(v.x.x), _f(v.x.y), _f(v.x.z), _f(v.x.w),
+				_f(v.y.x), _f(v.y.y), _f(v.y.z), _f(v.y.w),
+				_f(v.z.x), _f(v.z.y), _f(v.z.z), _f(v.z.w),
+				_f(v.w.x), _f(v.w.y), _f(v.w.z), _f(v.w.w),
+			]
+		TYPE_STRING_NAME, TYPE_NODE_PATH:
+			return String(v)
+		TYPE_OBJECT:
+			return str(v)
+		TYPE_ARRAY:
+			var arr_out: Array = []
+			for item: Variant in (v as Array):
+				arr_out.append(encode_value(item, depth + 1))
+			return arr_out
+		TYPE_DICTIONARY:
+			var dict_out: Dictionary = {}
+			var dict_in: Dictionary = v as Dictionary
+			for key: Variant in dict_in:
+				dict_out[str(key)] = encode_value(dict_in[key], depth + 1)
+			return dict_out
+		TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY, TYPE_PACKED_STRING_ARRAY:
+			return Array(v)
+		TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY, TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, TYPE_PACKED_COLOR_ARRAY, TYPE_PACKED_VECTOR4_ARRAY:
+			var packed_out: Array = []
+			for item: Variant in v:
+				packed_out.append(encode_value(item, depth + 1))
+			return packed_out
+	return v  # bool / int / String / null
+
+
+## axis-vector 顺序：x/y/z 轴各 3 floats，与 set 侧 Basis(x_axis, y_axis, z_axis) 一致
+static func _basis_to_array(b: Basis) -> Array:
+	return [
+		_f(b.x.x), _f(b.x.y), _f(b.x.z),
+		_f(b.y.x), _f(b.y.y), _f(b.y.z),
+		_f(b.z.x), _f(b.z.y), _f(b.z.z),
+	]
+
+
+static func _f(f: float) -> Variant:
+	if is_nan(f):
+		return "nan"
+	if is_inf(f):
+		return "inf" if f > 0.0 else "-inf"
+	return f

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -841,3 +841,26 @@ func test_get_properties_duplicate_property_deduped_by_dict() -> void:
 	var values: Dictionary = result["values"]
 	# Dictionary 赋值重复 key 只保留最后一次，故 values 恰好有 1 个 key
 	assert_eq(values.size(), 1, "重复 key 在 Dictionary 语义下去重为 1 条（有意行为）")
+
+
+# ── issue #96：wait_frames ──
+
+func test_wait_frames_advances_n_process_frames() -> void:
+	var start: int = Engine.get_process_frames()
+	var result: Dictionary = await _api.wait_frames_async({"frames": 3})
+	assert_eq(result, {"success": true, "frames": 3})
+	assert_gte(Engine.get_process_frames() - start, 3)
+
+
+func test_wait_frames_physics_mode() -> void:
+	var start: int = Engine.get_physics_frames()
+	var result: Dictionary = await _api.wait_frames_async({"frames": 2, "physics": true})
+	assert_eq(result, {"success": true, "frames": 2})
+	assert_gte(Engine.get_physics_frames() - start, 2)
+
+
+func test_wait_frames_rejects_bad_input() -> void:
+	for bad: Variant in [null, 0, -1, 3601, "x"]:
+		var result: Dictionary = await _api.wait_frames_async({"frames": bad})
+		assert_has(result, "error", "frames=%s 应报错" % [bad])
+		assert_eq(int(result.error.code), -32602)

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -1018,3 +1018,17 @@ func test_wait_signal_timeout_string_is_minus_32602() -> void:
 	assert_has(result, "error")
 	assert_eq(int(result.error.code), -32602,
 		"timeout='abc' 应报 -32602 INVALID_PARAMS，实际 code=%d" % [int(result.error.code)])
+
+
+func test_wait_property_tolerance_string_is_minus_32602() -> void:
+	## wait_property 传 tolerance="abc" 必须被拒绝（-32602），对齐 timeout 同款拒绝。
+	## tolerance 是 float 参数；字符串不应被静默当 0.0 使用。
+	var node := Node2D.new()
+	add_child_autofree(node)
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "visible", "value": true,
+		"tolerance": "abc", "timeout": 0.5,
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602,
+		"tolerance='abc' 应报 -32602 INVALID_PARAMS，实际 code=%d" % [int(result.error.code)])

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -766,3 +766,43 @@ func test_get_set_round_trip_vector2() -> void:
 	assert_false(set_result.has("error"))
 	var got2: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "position"})
 	assert_eq(got2["value"], got["value"])
+
+
+# ── issue #100：get_properties 同帧原子读 ──
+
+func test_get_properties_returns_all_encoded() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(1.0, 2.0)
+	node.visible = true
+	var result: Dictionary = _api.handle_get_properties({
+		"path": str(node.get_path()), "properties": ["position", "visible", "position:y"],
+	})
+	assert_false(result.has("error"))
+	var values: Dictionary = result["values"]
+	assert_eq(values["position"], {"value": [1.0, 2.0], "type": "Vector2"})
+	assert_eq(values["visible"], {"value": true})
+	assert_eq(values["position:y"], {"value": 2.0})
+
+
+func test_get_properties_missing_prop_fails_atomically_naming_all() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	var result: Dictionary = _api.handle_get_properties({
+		"path": str(node.get_path()), "properties": ["position", "nope1", "nope2"],
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1002)
+	assert_string_contains(str(result.error.message), "nope1")
+	assert_string_contains(str(result.error.message), "nope2")
+
+
+func test_get_properties_rejects_empty_or_non_string() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	for bad: Variant in [[], null, [1], [""]]:
+		var result: Dictionary = _api.handle_get_properties({
+			"path": str(node.get_path()), "properties": bad,
+		})
+		assert_has(result, "error", "properties=%s 应报错" % [bad])
+		assert_eq(int(result.error.code), -32602)

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -717,3 +717,52 @@ func test_screenshot_returns_image_or_1006_under_headless() -> void:
 func test_screenshot_max_frames_constant_is_positive() -> void:
 	# 防回归：常量被改成 0 或负数会让循环立刻退出 → 等同未修。
 	assert_gt(LowLevelApiScript.SCREENSHOT_MAX_FRAMES, 0)
+
+
+# ── issue #99：get 编码 + sub-path 读 ──
+
+func test_get_property_encodes_vector2_with_type() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(1.5, -2.0)
+	var result: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "position"})
+	assert_eq(result.get("value"), [1.5, -2.0])
+	assert_eq(result.get("type"), "Vector2")
+
+
+func test_get_property_primitive_has_no_type_field() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.visible = false
+	var result: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "visible"})
+	assert_eq(result, {"value": false})
+
+
+func test_get_property_sub_path_reads_leaf() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(7.0, 9.0)
+	var result: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "position:x"})
+	assert_eq(result, {"value": 7.0})
+
+
+func test_get_property_sub_path_bogus_top_level_is_1002() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	var result: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "nope:x"})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1002)
+
+
+func test_get_set_round_trip_vector2() -> void:
+	# round-trip 闭环：get 输出的数组原样灌回 set，再 get 等值
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(3.25, -4.5)
+	var got: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "position"})
+	var set_result: Dictionary = _api.handle_set_property({
+		"path": str(node.get_path()), "property": "position", "value": got["value"],
+	})
+	assert_false(set_result.has("error"))
+	var got2: Dictionary = _api.handle_get_property({"path": str(node.get_path()), "property": "position"})
+	assert_eq(got2["value"], got["value"])

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -992,3 +992,29 @@ func test_wait_signal_unknown_signal_is_1007() -> void:
 	})
 	assert_has(result, "error")
 	assert_eq(int(result.error.code), 1007)
+
+
+# ── issue #96 review fix：timeout/tolerance 非数字服务端拒绝 ──
+
+func test_wait_property_timeout_string_is_minus_32602() -> void:
+	## wait_property 传 timeout="abc" 必须被拒绝（-32602），不能静默转 0.0。
+	var result: Dictionary = await _api.wait_property_async({
+		"path": "/root", "property": "name", "value": "root", "timeout": "abc",
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602,
+		"timeout='abc' 应报 -32602 INVALID_PARAMS，实际 code=%d" % [int(result.error.code)])
+
+
+func test_wait_signal_timeout_string_is_minus_32602() -> void:
+	## wait_signal 传 timeout="abc" 必须被拒绝（-32602），节点和信号均合法。
+	var emitter := Node.new()
+	emitter.add_user_signal("test_sig_for_timeout_check")
+	add_child_autofree(emitter)
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "test_sig_for_timeout_check",
+		"timeout": "abc",
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602,
+		"timeout='abc' 应报 -32602 INVALID_PARAMS，实际 code=%d" % [int(result.error.code)])

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -864,3 +864,77 @@ func test_wait_frames_rejects_bad_input() -> void:
 		var result: Dictionary = await _api.wait_frames_async({"frames": bad})
 		assert_has(result, "error", "frames=%s 应报错" % [bad])
 		assert_eq(int(result.error.code), -32602)
+
+
+# ── issue #96：wait_property ──
+
+func test_wait_property_matches_immediately() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(5.0, 0.0)
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "position", "value": [5.0, 0.0], "timeout": 1.0,
+	})
+	assert_true(result["matched"])
+	assert_eq(result["value"], [5.0, 0.0])
+
+
+func test_wait_property_catches_later_change() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.visible = false
+	get_tree().create_timer(0.05).timeout.connect(func() -> void: node.visible = true)
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "visible", "value": true, "timeout": 2.0,
+	})
+	assert_true(result["matched"])
+
+
+func test_wait_property_gt_on_sub_path() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(0.0, 0.0)
+	get_tree().create_timer(0.05).timeout.connect(func() -> void: node.position = Vector2(600.0, 0.0))
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "position:x", "value": 500, "op": "gt", "timeout": 2.0,
+	})
+	assert_true(result["matched"])
+
+
+func test_wait_property_timeout_reports_reason_and_last_value() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.visible = false
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "visible", "value": true, "timeout": 0.1,
+	})
+	assert_false(result["matched"])
+	assert_eq(result["reason"], "timeout")
+	assert_eq(result["value"], false)
+
+
+func test_wait_property_node_not_found_reason() -> void:
+	var result: Dictionary = await _api.wait_property_async({
+		"path": "/root/__nope__", "property": "visible", "value": true, "timeout": 0.1,
+	})
+	assert_false(result["matched"])
+	assert_eq(result["reason"], "node_not_found")
+
+
+func test_wait_property_tolerance_eq() -> void:
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(1.0001, 0.0)
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "position:x", "value": 1.0,
+		"tolerance": 0.001, "timeout": 0.5,
+	})
+	assert_true(result["matched"])
+
+
+func test_wait_property_rejects_ordering_op_with_non_numeric_value() -> void:
+	var result: Dictionary = await _api.wait_property_async({
+		"path": "/root", "property": "name", "value": [1, 2], "op": "gt", "timeout": 0.1,
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -806,3 +806,38 @@ func test_get_properties_rejects_empty_or_non_string() -> void:
 		})
 		assert_has(result, "error", "properties=%s 应报错" % [bad])
 		assert_eq(int(result.error.code), -32602)
+
+
+# ── get_properties 边界：sub-path 缺失项 + 重复属性（review 遗留）──
+
+func test_get_properties_missing_sub_path_names_full_key() -> void:
+	# 缺失项是 sub-path 形式时，1002 error message 必须点全名（含 ":"）。
+	# 回归：早期实现只校验 top-level 名，message 里丢掉了 sub-path 后半部分，
+	# 让 agent 无法直接从 message 得知是哪个完整 key 出了问题。
+	var node := Node2D.new()
+	add_child_autofree(node)
+	var result: Dictionary = _api.handle_get_properties({
+		"path": str(node.get_path()),
+		"properties": ["position", "nope:x"],
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1002)
+	# message 必须含完整的 "nope:x"，而不是只有 "nope"
+	assert_string_contains(str(result.error.message), "nope:x")
+
+
+func test_get_properties_duplicate_property_deduped_by_dict() -> void:
+	# 重复属性（["position", "position"]）行为锁定：Dictionary key 语义去重，
+	# values 里 "position" 只有一个 entry（有意行为，和 JSON Dict 的 key-uniqueness 对齐）。
+	# 注意：这是锁定已有行为，而非新增功能——改动此断言前请确认变更是有意而为之。
+	var node := Node2D.new()
+	add_child_autofree(node)
+	node.position = Vector2(5.0, 6.0)
+	var result: Dictionary = _api.handle_get_properties({
+		"path": str(node.get_path()),
+		"properties": ["position", "position"],
+	})
+	assert_false(result.has("error"), "重复属性不应报错")
+	var values: Dictionary = result["values"]
+	# Dictionary 赋值重复 key 只保留最后一次，故 values 恰好有 1 个 key
+	assert_eq(values.size(), 1, "重复 key 在 Dictionary 语义下去重为 1 条（有意行为）")

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -938,3 +938,57 @@ func test_wait_property_rejects_ordering_op_with_non_numeric_value() -> void:
 	})
 	assert_has(result, "error")
 	assert_eq(int(result.error.code), -32602)
+
+
+# ── issue #96：wait_signal ──
+
+func test_wait_signal_captures_emission_and_args() -> void:
+	var emitter := Node.new()
+	emitter.add_user_signal("e2e_sig", [{"name": "v", "type": TYPE_INT}])
+	add_child_autofree(emitter)
+	get_tree().create_timer(0.05).timeout.connect(func() -> void: emitter.emit_signal("e2e_sig", 42))
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "e2e_sig", "timeout": 2.0,
+	})
+	assert_true(result["emitted"])
+	assert_eq(result["args"], [{"value": 42}])
+
+
+func test_wait_signal_zero_arg_signal() -> void:
+	var emitter := Node.new()
+	add_child_autofree(emitter)
+	get_tree().create_timer(0.05).timeout.connect(func() -> void: emitter.emit_signal("renamed"))
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "renamed", "timeout": 2.0,
+	})
+	assert_true(result["emitted"])
+	assert_eq(result["args"], [])
+
+
+func test_wait_signal_timeout_cleans_up_connection() -> void:
+	var emitter := Node.new()
+	emitter.add_user_signal("never_fires")
+	add_child_autofree(emitter)
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "never_fires", "timeout": 0.1,
+	})
+	assert_false(result["emitted"])
+	assert_eq(emitter.get_signal_connection_list("never_fires").size(), 0, "超时后连接必须清理")
+
+
+func test_wait_signal_node_missing_is_1001() -> void:
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": "/root/__nope__", "signal": "x", "timeout": 0.1,
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1001)
+
+
+func test_wait_signal_unknown_signal_is_1007() -> void:
+	var emitter := Node.new()
+	add_child_autofree(emitter)
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "__nope__", "timeout": 0.1,
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1007)

--- a/addons/godot_cli_control/tests/gut/test_variant_codec.gd
+++ b/addons/godot_cli_control/tests/gut/test_variant_codec.gd
@@ -1,0 +1,115 @@
+## GUT：CliControlVariantCodec —— Variant → JSON-safe 编码（issue #99）
+## 关键不变量：编码输出与 set 侧 _coerce_array_to_declared_type 的 array schema
+## 完全对称（axis-vector 顺序），get 输出可原样灌回 set。
+extends GutTest
+
+const Codec := preload("res://addons/godot_cli_control/bridge/variant_codec.gd")
+
+
+func test_primitives_pass_through_without_type() -> void:
+	assert_eq(Codec.encode(true), {"value": true})
+	assert_eq(Codec.encode(42), {"value": 42})
+	assert_eq(Codec.encode(1.5), {"value": 1.5})
+	assert_eq(Codec.encode("hi"), {"value": "hi"})
+	assert_eq(Codec.encode(null), {"value": null})
+
+
+func test_compound_types_table() -> void:
+	# [输入 Variant, 期望 value, 期望 type]
+	var cases: Array = [
+		[Vector2(1.5, -2.0), [1.5, -2.0], "Vector2"],
+		[Vector2i(1, 2), [1, 2], "Vector2i"],
+		[Vector3(1, 2, 3), [1.0, 2.0, 3.0], "Vector3"],
+		[Vector3i(1, 2, 3), [1, 2, 3], "Vector3i"],
+		[Vector4(1, 2, 3, 4), [1.0, 2.0, 3.0, 4.0], "Vector4"],
+		[Vector4i(1, 2, 3, 4), [1, 2, 3, 4], "Vector4i"],
+		[Rect2(1, 2, 3, 4), [1.0, 2.0, 3.0, 4.0], "Rect2"],
+		[Rect2i(1, 2, 3, 4), [1, 2, 3, 4], "Rect2i"],
+		[Color(0.1, 0.2, 0.3), [Color(0.1, 0.2, 0.3).r, Color(0.1, 0.2, 0.3).g, Color(0.1, 0.2, 0.3).b, 1.0], "Color"],
+		[Plane(0, 1, 0, 5), [0.0, 1.0, 0.0, 5.0], "Plane"],
+		[Quaternion(0, 0, 0, 1), [0.0, 0.0, 0.0, 1.0], "Quaternion"],
+		[AABB(Vector3(1, 2, 3), Vector3(4, 5, 6)), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], "AABB"],
+		[Basis.IDENTITY, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0], "Basis"],
+		[Transform2D.IDENTITY, [1.0, 0.0, 0.0, 1.0, 0.0, 0.0], "Transform2D"],
+		[Transform3D.IDENTITY, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0], "Transform3D"],
+		[Projection.IDENTITY, [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0], "Projection"],
+	]
+	for case: Array in cases:
+		var encoded: Dictionary = Codec.encode(case[0])
+		assert_eq(encoded.get("type"), case[2], "type for %s" % [case[0]])
+		assert_eq(encoded.get("value"), case[1], "value for %s" % [case[0]])
+
+
+func test_string_name_node_path_object() -> void:
+	assert_eq(Codec.encode(&"sn"), {"value": "sn", "type": "StringName"})
+	assert_eq(Codec.encode(NodePath("/root/A")), {"value": "/root/A", "type": "NodePath"})
+	var node := Node.new()
+	var encoded: Dictionary = Codec.encode(node)
+	assert_eq(encoded.get("type"), "Object")
+	assert_true(encoded.get("value") is String)
+	node.free()
+
+
+func test_nested_compound_encodes_without_type() -> void:
+	# 嵌套复合类型：递归编码为数组但不带 type（spec 已声明的取舍）
+	var encoded: Dictionary = Codec.encode([Vector2(1, 2), {"p": Vector3(3, 4, 5)}])
+	assert_false(encoded.has("type"))
+	assert_eq(encoded["value"], [[1.0, 2.0], {"p": [3.0, 4.0, 5.0]}])
+
+
+func test_non_finite_floats_become_strings() -> void:
+	assert_eq(Codec.encode(INF), {"value": "inf"})
+	assert_eq(Codec.encode(-INF), {"value": "-inf"})
+	assert_eq(Codec.encode(NAN), {"value": "nan"})
+	assert_eq(Codec.encode(Vector2(INF, 1.0)), {"value": ["inf", 1.0], "type": "Vector2"})
+
+
+func test_packed_arrays_become_plain_arrays() -> void:
+	assert_eq(Codec.encode(PackedInt32Array([1, 2])), {"value": [1, 2]})
+	assert_eq(Codec.encode(PackedFloat64Array([1.5])), {"value": [1.5]})
+	assert_eq(Codec.encode(PackedStringArray(["a"])), {"value": ["a"]})
+	assert_eq(
+		Codec.encode(PackedVector2Array([Vector2(1, 2)])),
+		{"value": [[1.0, 2.0]]}
+	)
+
+
+func test_deep_nesting_truncates_at_max_depth() -> void:
+	# 超过 _MAX_ENCODE_DEPTH 的深树降级为哨兵，不爆栈
+	var deep: Array = []
+	var cursor: Array = deep
+	for _i in 100:
+		var inner: Array = []
+		cursor.append(inner)
+		cursor = inner
+	cursor.append(42)
+	var encoded: Dictionary = Codec.encode(deep)
+	assert_true(JSON.stringify(encoded["value"]).contains("<max-depth-exceeded>"))
+
+
+func test_self_referential_array_terminates() -> void:
+	var a: Array = [1]
+	a.append(a)
+	var encoded: Dictionary = Codec.encode(a)
+	assert_true(JSON.stringify(encoded["value"]).contains("<max-depth-exceeded>"))
+	a.clear()  # 解开自引用，避免 Godot 退出时 ObjectDB 泄漏警告
+
+
+func test_self_referential_dictionary_terminates() -> void:
+	var d: Dictionary = {"x": 1}
+	d["self"] = d
+	var encoded: Dictionary = Codec.encode(d)
+	assert_true(JSON.stringify(encoded["value"]).contains("<max-depth-exceeded>"))
+	d.clear()  # 解开自引用，避免 Godot 退出时 ObjectDB 泄漏警告
+
+
+func test_packed_byte_array_minor() -> void:
+	assert_eq(Codec.encode(PackedByteArray([1, 2])), {"value": [1, 2]})
+
+
+func test_packed_int64_array_minor() -> void:
+	assert_eq(Codec.encode(PackedInt64Array([9])), {"value": [9]})
+
+
+func test_int_key_dictionary_minor() -> void:
+	assert_eq(Codec.encode({1: "a"}), {"value": {"1": "a"}})

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -143,6 +143,10 @@ class GameBridge:
         """获取节点属性。"""
         return self._run(self._client.get_property(path, prop))
 
+    def get_properties(self, path: str, props: list[str]) -> dict[str, Any]:
+        """同帧原子读多个属性（issue #100），返回 {prop: value} 映射。"""
+        return self._run(self._client.get_properties(path, props))
+
     def set_property(self, path: str, prop: str, value: Any) -> None:
         """设置节点属性。"""
         self._run(self._client.set_property(path, prop, value))

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -78,6 +78,26 @@ class GameBridge:
         """等待节点出现。"""
         return self._run(self._client.wait_for_node(path, timeout=timeout))
 
+    def wait_property(
+        self,
+        path: str,
+        prop: str,
+        value: Any,
+        op: str = "eq",
+        timeout: float = 5.0,
+        tolerance: float = 0.0,
+    ) -> dict:
+        """逐帧轮询直到属性满足条件（issue #96）。返回 {"matched": bool, ...}，超时不抛。"""
+        return self._run(self._client.wait_property(path, prop, value, op=op, timeout=timeout, tolerance=tolerance))
+
+    def wait_signal(self, path: str, signal: str, timeout: float = 5.0) -> dict:
+        """等信号发射（issue #96）。返回 {"emitted": bool, "args": [...]}，超时不抛。"""
+        return self._run(self._client.wait_signal(path, signal, timeout=timeout))
+
+    def wait_frames(self, frames: int, physics: bool = False) -> dict:
+        """等 N 帧（issue #96）。确定性帧推进，替代短 sleep。"""
+        return self._run(self._client.wait_frames(frames, physics=physics))
+
     # ── UI 交互 ──
 
     def click(self, path: str) -> dict:

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -341,9 +341,21 @@ async def cmd_release_all(client: GameClient, ns: argparse.Namespace) -> dict:
 # ── 新增的 12 个 AI 友好命令 ──
 
 
-async def cmd_get(client: GameClient, ns: argparse.Namespace) -> Any:
-    """读节点属性，返回原值（字符串/数字/数组/对象/null）。"""
-    return await client.get_property(ns.node_path, ns.prop)
+async def cmd_get(client: GameClient, ns: argparse.Namespace) -> dict:
+    """读节点属性（1 个或多个，支持 sub-path 如 position:x）。
+
+    透传 RPC result（带 type 字段）——client.get_property 的裸 value 是给
+    Python 脚本的便捷层；CLI 信封必须带 type 给 agent 消歧（issue #99/#100）。
+    单属性 result={"value", "type"?}；多属性 result={"values": {...}}。
+    """
+    props: list[str] = ns.props
+    if len(props) == 1:
+        return await client.request(
+            "get_property", {"path": ns.node_path, "property": props[0]}
+        )
+    return await client.request(
+        "get_properties", {"path": ns.node_path, "properties": props}
+    )
 
 
 async def cmd_set(client: GameClient, ns: argparse.Namespace) -> dict:
@@ -432,6 +444,16 @@ def _fmt_get_text(value: Any) -> str:
     if isinstance(value, str):
         return value
     return json.dumps(value, ensure_ascii=False)
+
+
+def _fmt_get_result_text(r: dict) -> str:
+    """get 的文本渲染：单属性打印 value；多属性每行 ``prop = value``。"""
+    if "values" in r:
+        return "\n".join(
+            f"{prop} = {_fmt_get_text(entry.get('value'))}"
+            for prop, entry in r["values"].items()
+        )
+    return _fmt_get_text(r.get("value"))
 
 
 def _fmt_tree_text(tree: Any) -> str:
@@ -676,13 +698,17 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
     RpcSpec(
         name="get",
         handler=cmd_get,
-        description="读节点属性。",
+        description=(
+            "读节点属性（1 个或多个；多个时服务端同帧原子读，issue #100）。"
+            "复合类型（Vector2 等）返回与 set 同 schema 的数组 + type 字段，"
+            "可直接回灌 set（issue #99）。支持 sub-path：position:x。"
+        ),
         positionals=(
             Positional("node_path", None, "绝对节点路径，如 /root/Main"),
-            Positional("prop", None, "属性名，如 position / text / visible"),
+            Positional("props", "+", "属性名，1 个或多个；支持 sub-path 如 position:x"),
         ),
-        example="get /root/Main/Score text",
-        text_formatter=_fmt_get_text,
+        example="get /root/Player position visible",
+        text_formatter=_fmt_get_result_text,
     ),
     RpcSpec(
         name="set",

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -243,6 +243,48 @@ def _read_combo_steps(ns: argparse.Namespace) -> list[dict]:
     return parsed
 
 
+_WAIT_PROP_OPS = ("eq", "ne", "gt", "lt", "ge", "le")
+
+
+def _require_float(raw: Any, cmd: str, field: str) -> float:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"{cmd}: {field} 必须是数字，收到 {raw!r}")
+
+
+def _preflight_wait_prop(ns: argparse.Namespace) -> None:
+    timeout = _require_float(ns.timeout, "wait-prop", "timeout")
+    if not 0 <= timeout <= 3600:
+        raise ValueError(f"wait-prop: timeout 必须在 0..3600 秒，收到 {timeout}")
+    tolerance = _require_float(ns.tolerance, "wait-prop", "tolerance")
+    if tolerance < 0:
+        raise ValueError(f"wait-prop: tolerance 必须 >= 0，收到 {tolerance}")
+    expected = _parse_json_arg(ns.value)
+    is_numeric = isinstance(expected, (int, float)) and not isinstance(expected, bool)
+    if ns.op not in ("eq", "ne") and not is_numeric:
+        raise ValueError(
+            f"wait-prop: --op {ns.op} 只支持数值比较；复合/字符串/bool 值只能用 eq/ne"
+        )
+
+
+def _preflight_wait_signal(ns: argparse.Namespace) -> None:
+    if ns.timeout is None:
+        return
+    timeout = _require_float(ns.timeout, "wait-signal", "timeout")
+    if not 0 <= timeout <= 3600:
+        raise ValueError(f"wait-signal: timeout 必须在 0..3600 秒，收到 {timeout}")
+
+
+def _preflight_wait_frames(ns: argparse.Namespace) -> None:
+    try:
+        frames = int(ns.frames)
+    except (TypeError, ValueError):
+        raise ValueError(f"wait-frames: frames 必须是整数，收到 {ns.frames!r}")
+    if not 1 <= frames <= 3600:
+        raise ValueError(f"wait-frames: frames 必须在 1..3600，收到 {frames}")
+
+
 def _combo_total_duration(steps: list[dict]) -> float:
     """combo 全部 step 的累计 game-time（给 ``--wait`` 算阻塞时长，issue #90）。
 
@@ -406,6 +448,23 @@ async def cmd_wait_time(
     return await client.wait_game_time(seconds)
 
 
+async def cmd_wait_prop(client: GameClient, ns: argparse.Namespace) -> dict:
+    expected = _parse_json_arg(ns.value)
+    return await client.wait_property(
+        ns.node_path, ns.prop, expected,
+        op=ns.op, timeout=float(ns.timeout), tolerance=float(ns.tolerance),
+    )
+
+
+async def cmd_wait_signal(client: GameClient, ns: argparse.Namespace) -> dict:
+    timeout = float(ns.timeout) if ns.timeout else 5.0
+    return await client.wait_signal(ns.node_path, ns.signal_name, timeout=timeout)
+
+
+async def cmd_wait_frames(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.wait_frames(int(ns.frames), physics=ns.physics)
+
+
 async def cmd_pressed(
     client: GameClient, ns: argparse.Namespace
 ) -> list[str]:
@@ -483,6 +542,27 @@ def _exit_from_wait_node(r: dict) -> int:
     return EXIT_OK if r.get("found") else EXIT_RPC_ERROR
 
 
+def _fmt_wait_prop_text(r: dict) -> str:
+    if r.get("matched"):
+        return f"matched (waited {r.get('waited', 0.0):.3f}s)"
+    return (
+        f"timeout (reason={r.get('reason', 'timeout')}, "
+        f"last={json.dumps(r.get('value'), ensure_ascii=False)})"
+    )
+
+
+def _fmt_wait_signal_text(r: dict) -> str:
+    return "emitted" if r.get("emitted") else "timeout"
+
+
+def _exit_from_wait_prop(r: dict) -> int:
+    return EXIT_OK if r.get("matched") else EXIT_RPC_ERROR
+
+
+def _exit_from_wait_signal(r: dict) -> int:
+    return EXIT_OK if r.get("emitted") else EXIT_RPC_ERROR
+
+
 # ── extra_args registrators ──
 
 
@@ -538,6 +618,21 @@ def _register_actions_flag(p: argparse.ArgumentParser) -> None:
         action="store_true",
         help="包含 ui_* 内置动作（默认仅项目自定义动作）",
     )
+
+
+def _register_wait_prop_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("node_path", help="绝对节点路径")
+    p.add_argument("prop", help="属性名（支持 sub-path 如 position:x）")
+    p.add_argument("value", help="期望值（JSON-or-string，同 set 的 value 规则）")
+    p.add_argument("--op", choices=_WAIT_PROP_OPS, default="eq",
+                   help="比较运算符，默认 eq；gt/lt/ge/le 仅数值")
+    p.add_argument("--timeout", default="5", help="超时秒（0..3600，默认 5）")
+    p.add_argument("--tolerance", default="0", help="float eq/ne 容差（默认 0=精确比较）")
+
+
+def _register_wait_frames_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("frames", help="等待帧数（1..3600）")
+    p.add_argument("--physics", action="store_true", help="等 physics_frame（默认 process_frame）")
 
 
 def _register_set_args(p: argparse.ArgumentParser) -> None:
@@ -804,6 +899,48 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
         ),
         example="wait-time 0.5",
         text_formatter=_fmt_wait_time_text,
+    ),
+    RpcSpec(
+        name="wait-prop",
+        handler=cmd_wait_prop,
+        description=(
+            "逐帧轮询直到属性满足条件（或 timeout）。退出码：0=命中, 1=超时, "
+            "2=infra error。超时返回 reason（timeout/node_not_found/property_not_found）"
+            "+ 最后读到的值，便于诊断 typo。"
+        ),
+        positionals=(),  # 由 extra_args 注册
+        example="wait-prop /root/Player position:x 500 --op gt --timeout 3",
+        extra_args=_register_wait_prop_args,
+        preflight=_preflight_wait_prop,
+        text_formatter=_fmt_wait_prop_text,
+        exit_code_from=_exit_from_wait_prop,
+    ),
+    RpcSpec(
+        name="wait-signal",
+        handler=cmd_wait_signal,
+        description=(
+            "等信号发射（或 timeout），命中带回编码后的信号参数。退出码：0=命中, "
+            "1=超时, 2=infra error。注意：必须先挂等待再触发动作（见 SKILL.md pitfall）。"
+        ),
+        positionals=(
+            Positional("node_path", None, "绝对节点路径"),
+            Positional("signal_name", None, "信号名，如 body_entered"),
+            Positional("timeout", "?", "超时秒（0..3600，默认 5）"),
+        ),
+        example="wait-signal /root/Area door_opened 3",
+        preflight=_preflight_wait_signal,
+        text_formatter=_fmt_wait_signal_text,
+        exit_code_from=_exit_from_wait_signal,
+    ),
+    RpcSpec(
+        name="wait-frames",
+        handler=cmd_wait_frames,
+        description="等 N 个 process 帧（--physics 等物理帧）。确定性帧推进，替代短 sleep。",
+        positionals=(),  # 由 extra_args 注册
+        example="wait-frames 3 --physics",
+        extra_args=_register_wait_frames_args,
+        preflight=_preflight_wait_frames,
+        text_formatter=lambda r: f"waited {r.get('frames')} frames",
     ),
     RpcSpec(
         name="pressed",

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -450,7 +450,7 @@ def _fmt_get_result_text(r: dict) -> str:
     """get 的文本渲染：单属性打印 value；多属性每行 ``prop = value``。"""
     if "values" in r:
         return "\n".join(
-            f"{prop} = {_fmt_get_text(entry.get('value'))}"
+            f"{prop} = {_fmt_get_text(entry.get('value') if isinstance(entry, dict) else entry)}"
             for prop, entry in r["values"].items()
         )
     return _fmt_get_text(r.get("value"))

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -258,6 +258,20 @@ class GameClient:
         )
         return result.get("value")
 
+    async def get_properties(self, path: str, props: list[str]) -> dict[str, Any]:
+        """同帧原子读多个属性（issue #100），返回 {prop: 裸 value} 映射。
+
+        type 字段是给 CLI JSON 信封的（agent 消费）；Python 层要 type 时直接
+        ``await client.request("get_properties", ...)`` 拿原始 result。
+        """
+        result = await self.request(
+            "get_properties", {"path": path, "properties": list(props)}
+        )
+        return {
+            k: (v.get("value") if isinstance(v, dict) else v)
+            for k, v in result.get("values", {}).items()
+        }
+
     async def set_property(self, path: str, prop: str, value: Any) -> dict:
         return await self.request(
             "set_property", {"path": path, "property": prop, "value": value}

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -333,6 +333,41 @@ class GameClient:
         )
         return result.get("found", False)
 
+    async def wait_property(
+        self,
+        path: str,
+        prop: str,
+        value: Any,
+        op: str = "eq",
+        timeout: float = 5.0,
+        tolerance: float = 0.0,
+    ) -> dict:
+        """等属性满足条件（issue #96）。返回 {"matched": bool, ...}，超时不抛。"""
+        return await self.request(
+            "wait_property",
+            {
+                "path": path, "property": prop, "value": value,
+                "op": op, "timeout": timeout, "tolerance": tolerance,
+            },
+            timeout=timeout + 5.0,
+        )
+
+    async def wait_signal(self, path: str, signal: str, timeout: float = 5.0) -> dict:
+        """等信号发射（issue #96）。返回 {"emitted": bool, "args": [...]}，超时不抛。"""
+        return await self.request(
+            "wait_signal",
+            {"path": path, "signal": signal, "timeout": timeout},
+            timeout=timeout + 5.0,
+        )
+
+    async def wait_frames(self, frames: int, physics: bool = False) -> dict:
+        """等 N 帧（issue #96）。client wall-time 按最低 10fps 估算 + 10s grace。"""
+        return await self.request(
+            "wait_frames",
+            {"frames": frames, "physics": physics},
+            timeout=max(30.0, frames / 10.0 + 10.0),
+        )
+
     async def wait_game_time(self, seconds: float) -> dict:
         """按 Godot game time 等待 N 秒。
 

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -84,6 +84,18 @@ $ godot-cli-control click /root/DoesNotExist
 $ godot-cli-control --text exists /root/Main
 true
 
+$ godot-cli-control get /root/Player position
+{"ok": true, "result": {"value": [-2480.0, 1400.0], "type": "Vector2"}}
+
+$ godot-cli-control get /root/Player visible
+{"ok": true, "result": {"value": true}}
+
+$ godot-cli-control get /root/Player position:x
+{"ok": true, "result": {"value": -2480.0}}
+
+$ godot-cli-control get /root/Player position health
+{"ok": true, "result": {"values": {"position": {"value": [-2480.0, 1400.0], "type": "Vector2"}, "health": {"value": 80}}}}
+
 $ godot-cli-control init
 {"ok": true, "result": {"project_root": "/path/to/proj", "plugin_copied": true, "plugin_overwritten": false, "project_godot_changes": ["autoload/GameBridgeNode", "editor_plugins/enabled"], "godot_bin": "/usr/bin/godot", "skills_written": [".../SKILL.md", ".../SKILL.md"], "gitignore_added": [".cli_control/"], "skills_only": false, "write_skills": true}}
 
@@ -138,7 +150,7 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 ## Command catalogue
 
 **Read:**
-- `get <path> <prop>` — read a node property
+- `get <path> <prop> [<prop2> ...]` — read one or more node properties in a single atomic frame. Single-property result: `{"value": <encoded>, "type": "<GodotType>"}` (type field present only for compound Variants — Vector2, Color, etc.; absent for primitives like `bool`/`int`/`float`/`String`). Multi-property result: `{"values": {"<prop>": {"value": ..., "type"?: ...}, ...}}`. Sub-path form: `get <path> position:x` reads a scalar leaf of a compound Variant (e.g. returns `{"value": 1.5}` with no type field). Security note: sub-path reading can reach write-blacklisted nested attributes (e.g. `script:source_code`) — read-only diagnostic capability, intentional under localhost-only + debug-build gate.
 - `text <path>` — read Label / Button text
 - `exists <path>` — boolean existence check (exit-code-as-result)
 - `visible <path>` — boolean visibility check (exit-code-as-result)
@@ -313,7 +325,8 @@ Errors raise `RpcError(code, message)` (a `RuntimeError` subclass) that preserve
 | Method | CLI equivalent |
 |---|---|
 | `await client.click(path)` | `click <path>` |
-| `await client.get_property(path, prop)` | `get <path> <prop>` |
+| `await client.get_property(path, prop)` | `get <path> <prop>` — returns bare value only (no type field); use `client.request("get_property", ...)` to get `{"value", "type"}` shape |
+| `await client.get_properties(path, props)` | `get <path> <prop1> <prop2> ...` — returns `{prop: bare_value, ...}` dict (no type fields); use `client.request("get_properties", ...)` for full shape |
 | `await client.set_property(path, prop, value)` | `set <path> <prop> <json-value>` |
 | `await client.call_method(path, method, args)` | `call <path> <method> [json-args...]` |
 | `await client.get_text(path)` | `text <path>` |
@@ -408,6 +421,10 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **`run <script>` opens a window even though stdout is piped** — by design. `run` grep's the script for `screenshot` and force-flips to GUI when found, so `bridge.screenshot(...)` doesn't 1006-fail under the dummy renderer. Pass `--no-gui-auto` to disable detection; explicit `--headless` always wins. See issue #65.
 - **`screenshot` used to fail with `1006` on the first call** — fixed. GameBridge now waits for the viewport's first frame before opening the port, so `connect succeeded` implies `viewport has rendered ≥ once`. The magic `bridge.wait(1.5)` before the first screenshot in older example scripts is no longer needed.
 - **`press`/`tap`/`hold`/`combo` inject `InputEventAction` (no mouse coordinates) — position-dependent `_gui_input` widgets need `click` instead.** These commands route through the engine's event pipeline, so `_input` / `_unhandled_input` callbacks receive the event; however, `InputEventAction` does not carry a screen position. UI controls that rely on cursor position (e.g. `TextureButton` with a custom shape, `TouchScreenButton`) won't fire `_gui_input` correctly — use `click <path>` for those.
+- **`get` on a compound Variant returns an array + type — you can round-trip it straight into `set`.** `get /root/Player position` returns `{"value": [-2480.0, 1400.0], "type": "Vector2"}`. That `value` array is the exact format `set` accepts: `set /root/Player position '[-2480.0, 1400.0]'`. No conversion needed.
+- **Arrays/Dicts nested inside compound Variants encode as arrays but carry no `type` field — use a sub-path to read a typed leaf.** For example, a `Dictionary` property that happens to contain a `Vector3` will give you an untyped array. If you need the type, use `get <node> mydict:somekey` to read the leaf directly and get its type.
+- **Sub-path reading a non-existent leaf returns `null` — indistinguishable from a real `null` value (typo only detected at the top-level name).** `get /root/Node position:typo` returns `{"value": null}` with no error — the `":" `suffix is not validated beyond checking that `"position"` exists as a top-level property. Verify your leaf name carefully; the only error you'll get is `1002` if the part before `":"` itself doesn't exist.
+- **Python API (`bridge.get_property` / `bridge.get_properties`) returns bare values only — no `type` field.** These convenience methods strip the `type` from the server response to reduce boilerplate. When you need the `type` field (e.g. to distinguish `Vector2` from a plain 2-element array), go through `client.request("get_property", {"path": ..., "property": ...})` directly.
 
 ---
 

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -180,7 +180,7 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 **Wait:**
 - `wait-node <path> [timeout]` — block until node appears (exit 0=found, 1=timeout)
 - `wait-time <seconds>` — wait N in-game seconds (matters for `--write-movie`). Server bounds: `0 ≤ seconds ≤ 3600`; passing out-of-range gets `-32602 "seconds must be ..."`. Client short-circuits `seconds <= 0` without an RPC.
-- `wait-prop <path> <prop> <json-value> [--op eq|ne|gt|ge|lt|le] [--timeout N] [--tolerance N] [--physics]` — block until property satisfies condition (exit 0=matched, 1=timeout). Example: `wait-prop /root/Player position:x 500 --op gt`. Default `--op eq`, `--timeout 5.0`, `--tolerance 0.0`.
+- `wait-prop <path> <prop> <json-value> [--op eq|ne|gt|lt|ge|le] [--timeout N] [--tolerance N]` — block until property satisfies condition (exit 0=matched, 1=timeout). Example: `wait-prop /root/Player position:x 500 --op gt`. Default `--op eq`, `--timeout 5.0`, `--tolerance 0.0`.
 - `wait-signal <path> <signal> [--timeout N]` — block until signal fires (exit 0=emitted, 1=timeout). Result: `{"emitted": bool, "args": [...]}`.
 - `wait-frames <N> [--physics]` — advance exactly N process frames (or physics frames with `--physics`). Result: `{"success": true, "frames": N}`.
 

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -42,8 +42,8 @@ godot-cli-control daemon stop
 
 | Code | Meaning |
 |---|---|
-| 0 | Success (or, for `exists` / `visible` / `wait-node`, the boolean was true / found) |
-| 1 | RPC error (server returned `{"error":...}`); also `exists`/`visible`=false, `wait-node`=timeout, `daemon status`=stopped |
+| 0 | Success (or, for `exists` / `visible` / `wait-node` / `wait-prop` / `wait-signal`, the boolean was true / found / matched / emitted) |
+| 1 | RPC error (server returned `{"error":...}`); also `exists`/`visible`=false, `wait-node`/`wait-prop`/`wait-signal`=timeout, `daemon status`=stopped |
 | 2 | Connection / IO error (daemon not running, script path not found). Also: **`daemon stop` returns 2** when the daemon stopped cleanly but `ffmpeg` transcode of the recorded `.avi`→`.mp4` failed — the raw `.avi` is kept and `.cli_control/ffmpeg.log` has the details. `run <script>` propagates this: a successful script + failed transcode still exits 2. |
 | 3 | `daemon stop --all` partial failure: at least one daemon in the registry failed to stop. Per-record `rc` is in the JSON `result.stopped[]`. |
 | 64 | Usage error on an **RPC subcommand** — argparse, a pre-flight reject caught before connecting (`combo` with no steps / malformed `--steps-json` / `combo -` from a TTY, `hold` with a non-positive duration), **and** a bad runtime argument (`tap` / `wait-time` given a non-number, a `set`/`call` value that fails JSON parsing). For RPC subcommands these all carry client code `-1003` and now consistently exit 64 (a few previously exited 2 — fixed in #82). |
@@ -125,6 +125,7 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 | `1004` | Combo already in progress. Call `combo-cancel` (or `release-all`) and re-issue. Safe to retry after that. |
 | `1005` | Scene tree too large to serialize (default safety limit). Pass `--max-nodes` or query a subtree with `children` / `tree <subpath>`. Don't retry as-is. |
 | `1006` | Resource transiently unavailable (e.g. screenshot during scene transition / window resize). Rare under normal use: GameBridge waits for viewport first-frame before accepting connections, and `screenshot` retries internally up to ~30 frames (~500ms at 60 fps, ~1s at 30 fps, longer when `--write-movie` lowers the fixed fps). If you still see this, retry after `wait-time 0.05` or similar. |
+| `1007` | Signal not found on the node (`wait-signal` schema error — signal name typo or the node doesn't define it). Permanent — don't retry; inspect with `tree` to list available signals. |
 
 **JSON-RPC standard — negative integers `-32xxx`:**
 
@@ -179,6 +180,9 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 **Wait:**
 - `wait-node <path> [timeout]` — block until node appears (exit 0=found, 1=timeout)
 - `wait-time <seconds>` — wait N in-game seconds (matters for `--write-movie`). Server bounds: `0 ≤ seconds ≤ 3600`; passing out-of-range gets `-32602 "seconds must be ..."`. Client short-circuits `seconds <= 0` without an RPC.
+- `wait-prop <path> <prop> <json-value> [--op eq|ne|gt|ge|lt|le] [--timeout N] [--tolerance N] [--physics]` — block until property satisfies condition (exit 0=matched, 1=timeout). Example: `wait-prop /root/Player position:x 500 --op gt`. Default `--op eq`, `--timeout 5.0`, `--tolerance 0.0`.
+- `wait-signal <path> <signal> [--timeout N]` — block until signal fires (exit 0=emitted, 1=timeout). Result: `{"emitted": bool, "args": [...]}`.
+- `wait-frames <N> [--physics]` — advance exactly N process frames (or physics frames with `--physics`). Result: `{"success": true, "frames": N}`.
 
 **Render:**
 - `screenshot <path>` — write PNG (path is **required** as of 0.2.0)
@@ -337,6 +341,9 @@ Errors raise `RpcError(code, message)` (a `RuntimeError` subclass) that preserve
 | `await client.get_scene_tree(depth, max_nodes=None)` | `tree [depth] [--max-nodes N]` |
 | `await client.wait_for_node(path, timeout)` | `wait-node <path> [timeout]` |
 | `await client.wait_game_time(seconds)` | `wait-time <seconds>` |
+| `await client.wait_property(path, prop, value, op, timeout, tolerance)` | `wait-prop <path> <prop> <json-value> [--op ...] [--timeout N] [--tolerance N]` |
+| `await client.wait_signal(path, signal, timeout)` | `wait-signal <path> <signal> [--timeout N]` |
+| `await client.wait_frames(frames, physics)` | `wait-frames <N> [--physics]` |
 | `await client.action_press(action)` | `press <action>` |
 | `await client.action_release(action)` | `release <action>` |
 | `await client.action_tap(action, duration)` | `tap <action> [duration]` |
@@ -421,6 +428,8 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **`run <script>` opens a window even though stdout is piped** — by design. `run` grep's the script for `screenshot` and force-flips to GUI when found, so `bridge.screenshot(...)` doesn't 1006-fail under the dummy renderer. Pass `--no-gui-auto` to disable detection; explicit `--headless` always wins. See issue #65.
 - **`screenshot` used to fail with `1006` on the first call** — fixed. GameBridge now waits for the viewport's first frame before opening the port, so `connect succeeded` implies `viewport has rendered ≥ once`. The magic `bridge.wait(1.5)` before the first screenshot in older example scripts is no longer needed.
 - **`press`/`tap`/`hold`/`combo` inject `InputEventAction` (no mouse coordinates) — position-dependent `_gui_input` widgets need `click` instead.** These commands route through the engine's event pipeline, so `_input` / `_unhandled_input` callbacks receive the event; however, `InputEventAction` does not carry a screen position. UI controls that rely on cursor position (e.g. `TextureButton` with a custom shape, `TouchScreenButton`) won't fire `_gui_input` correctly — use `click <path>` for those.
+- **`wait-signal` must be armed before the action that fires it — each CLI call opens a new connection.** Every invocation of `godot-cli-control` is a fresh process that connects, makes the request, and disconnects. If you call `wait-signal` after the signal has already fired, you'll always timeout. Shell pattern: `godot-cli-control wait-signal /root/A my_signal & godot-cli-control tap jump; wait` — background the wait first, then trigger the action. If you need both on a single connection, use a `run` script (`def run(bridge): ...`) with `client.wait_signal(...)`.
+- **Replace magic `wait-time` sleeps with `wait-prop` or `wait-frames`.** Fixed `wait-time 0.3` guesses are fragile — they're too long when the game is fast, too short under load. Prefer: `wait-prop /root/Player on_floor true` (wait for state) or `wait-frames 4` (wait for a specific number of frames to render). These are more reliable and often 2-10× faster.
 - **`get` on a compound Variant returns an array + type — you can round-trip it straight into `set`.** `get /root/Player position` returns `{"value": [-2480.0, 1400.0], "type": "Vector2"}`. That `value` array is the exact format `set` accepts: `set /root/Player position '[-2480.0, 1400.0]'`. No conversion needed.
 - **Arrays/Dicts nested inside compound Variants encode as arrays but carry no `type` field — use a sub-path to read a typed leaf.** For example, a `Dictionary` property that happens to contain a `Vector3` will give you an untyped array. If you need the type, use `get <node> mydict:somekey` to read the leaf directly and get its type.
 - **Sub-path reading a non-existent leaf returns `null` — indistinguishable from a real `null` value (typo only detected at the top-level name).** `get /root/Node position:typo` returns `{"value": null}` with no error — the `":" `suffix is not validated beyond checking that `"position"` exists as a top-level property. Verify your leaf name carefully; the only error you'll get is `1002` if the part before `":"` itself doesn't exist.

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -100,6 +100,9 @@ class _StubClient:
     async def get_property(self, path: str, prop: str) -> Any:
         return self._record("get_property", (path, prop), {})
 
+    async def get_properties(self, path: str, props: list) -> dict:
+        return self._record("get_properties", (path, props), {})
+
     async def set_property(self, path: str, prop: str, value: Any) -> dict:
         return self._record("set_property", (path, prop, value), {})
 
@@ -401,6 +404,16 @@ def test_get_property(stub_client: dict) -> None:
     c.returns["get_property"] = 42
     assert b.get_property("/root/X", "value") == 42
     assert c.calls[-1] == ("get_property", ("/root/X", "value"), {})
+    b.close()
+
+
+def test_get_properties_delegates_to_client(stub_client: dict) -> None:
+    """``bridge.get_properties`` 必须委托到 ``client.get_properties``，参数透传，返回值透传。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["get_properties"] = {"position": [1, 2], "visible": True}
+    result = b.get_properties("/root/Player", ["position", "visible"])
+    assert c.calls[-1] == ("get_properties", ("/root/Player", ["position", "visible"]), {})
+    assert result == {"position": [1, 2], "visible": True}
     b.close()
 
 

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -114,6 +114,23 @@ class _StubClient:
     async def get_children(self, path: str, type_filter: str = "") -> list[dict]:
         return self._record("get_children", (path,), {"type_filter": type_filter})
 
+    async def wait_property(
+        self,
+        path: str,
+        prop: str,
+        value: Any,
+        op: str = "eq",
+        timeout: float = 5.0,
+        tolerance: float = 0.0,
+    ) -> dict:
+        return self._record("wait_property", (path, prop, value), {"op": op, "timeout": timeout, "tolerance": tolerance})
+
+    async def wait_signal(self, path: str, signal: str, timeout: float = 5.0) -> dict:
+        return self._record("wait_signal", (path, signal), {"timeout": timeout})
+
+    async def wait_frames(self, frames: int, physics: bool = False) -> dict:
+        return self._record("wait_frames", (frames,), {"physics": physics})
+
 
 @pytest.fixture
 def stub_client(monkeypatch: pytest.MonkeyPatch) -> _StubClient:
@@ -484,4 +501,49 @@ def test_runtime_error_propagates(stub_client: dict) -> None:
     c.raises["screenshot"] = RuntimeError("disconnected")
     with pytest.raises(RuntimeError, match="disconnected"):
         b.screenshot()
+    b.close()
+
+
+# ── issue #96: wait_property / wait_signal / wait_frames bridge 委托 ──
+
+
+def test_wait_property_delegates_all_params(stub_client: dict) -> None:
+    """bridge.wait_property 必须把所有参数（含 op/tolerance）委托给 client.wait_property。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["wait_property"] = {"matched": True, "value": 10, "waited": 0.05}
+    result = b.wait_property("/root/Player", "health", 100, op="ge", timeout=3.0, tolerance=0.1)
+    assert c.calls[-1] == (
+        "wait_property",
+        ("/root/Player", "health", 100),
+        {"op": "ge", "timeout": 3.0, "tolerance": 0.1},
+    )
+    assert result == {"matched": True, "value": 10, "waited": 0.05}
+    b.close()
+
+
+def test_wait_signal_delegates_params(stub_client: dict) -> None:
+    """bridge.wait_signal 把 path/signal/timeout 委托给 client.wait_signal。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["wait_signal"] = {"emitted": True, "args": [42]}
+    result = b.wait_signal("/root/Area", "door_opened", timeout=2.0)
+    assert c.calls[-1] == (
+        "wait_signal",
+        ("/root/Area", "door_opened"),
+        {"timeout": 2.0},
+    )
+    assert result == {"emitted": True, "args": [42]}
+    b.close()
+
+
+def test_wait_frames_delegates_params(stub_client: dict) -> None:
+    """bridge.wait_frames 把 frames/physics 委托给 client.wait_frames。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["wait_frames"] = {"success": True, "frames": 5}
+    result = b.wait_frames(5, physics=True)
+    assert c.calls[-1] == (
+        "wait_frames",
+        (5,),
+        {"physics": True},
+    )
+    assert result == {"success": True, "frames": 5}
     b.close()

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -321,8 +321,8 @@ def test_init_subcommand_accepts_skills_no_clobber() -> None:
 @pytest.mark.parametrize(
     "argv,expected_attrs",
     [
-        # 读
-        (["get", "/root/Main", "position"], {"node_path": "/root/Main", "prop": "position"}),
+        # 读（get props 改为 nargs='+'，ns.props 是 list）
+        (["get", "/root/Main", "position"], {"node_path": "/root/Main", "props": ["position"]}),
         (["text", "/root/Main/Title"], {"node_path": "/root/Main/Title"}),
         (["exists", "/root/Foo"], {"node_path": "/root/Foo"}),
         (["visible", "/root/Hud"], {"node_path": "/root/Hud"}),
@@ -1536,6 +1536,169 @@ def test_run_rpc_text_mode_uses_text_formatter(
 
     assert rc == 0
     assert capsys.readouterr().out.strip() == "true"
+
+
+# ── get 命令：多属性 + 信封透传（issue #99 / #100）──
+
+
+def test_get_single_prop_envelope_passthrough(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """单属性 get 必须透传 RPC result（含 type），不拆包裸值。
+
+    信封 result = {"value": [...], "type": "Vector2"}。
+    agent 用 type 字段消歧，这是 issue #99 的核心契约。
+    """
+    import json as _json
+
+    from godot_cli_control.cli import OUTPUT_JSON, RPC_BY_NAME, _run_rpc
+    from unittest.mock import AsyncMock, patch
+
+    spec = RPC_BY_NAME["get"]
+    ns = __import__("argparse").Namespace(
+        node_path="/root/Player", props=["position"]
+    )
+
+    mock_client = AsyncMock()
+    # client.request 直接返回服务端 result dict（{"value": ..., "type": ...}）
+    mock_client.request = AsyncMock(
+        return_value={"value": [1.0, 2.0], "type": "Vector2"}
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_JSON))
+
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload == {
+        "ok": True,
+        "result": {"value": [1.0, 2.0], "type": "Vector2"},
+    }
+    # 必须走 client.request，不走 client.get_property（裸值便捷层）
+    mock_client.request.assert_awaited_once_with(
+        "get_property", {"path": "/root/Player", "property": "position"}
+    )
+
+
+def test_get_multi_prop_envelope_passthrough(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """多属性 get 必须发 get_properties，信封 result = {"values": {...}}。
+
+    这是 issue #100 的原子读契约。
+    """
+    import json as _json
+
+    from godot_cli_control.cli import OUTPUT_JSON, RPC_BY_NAME, _run_rpc
+    from unittest.mock import AsyncMock, patch
+
+    spec = RPC_BY_NAME["get"]
+    ns = __import__("argparse").Namespace(
+        node_path="/root/Enemy", props=["position", "health"]
+    )
+
+    mock_result = {
+        "values": {
+            "position": {"value": [3.0, 4.0], "type": "Vector2"},
+            "health": {"value": 80, "type": "int"},
+        }
+    }
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=mock_result)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_JSON))
+
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload == {"ok": True, "result": mock_result}
+    mock_client.request.assert_awaited_once_with(
+        "get_properties",
+        {"path": "/root/Enemy", "properties": ["position", "health"]},
+    )
+
+
+def test_get_single_prop_text_mode(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--text 下单属性打印裸 value（保持旧 text 行为，只把 value 取出渲染）。"""
+    from godot_cli_control.cli import OUTPUT_TEXT, RPC_BY_NAME, _run_rpc
+    from unittest.mock import AsyncMock, patch
+
+    spec = RPC_BY_NAME["get"]
+    ns = __import__("argparse").Namespace(
+        node_path="/root/Player", props=["position"]
+    )
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(
+        return_value={"value": [1.5, -2.0], "type": "Vector2"}
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_TEXT))
+
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    # value 是 list → JSON 序列化
+    assert out == "[1.5, -2.0]"
+
+
+def test_get_multi_prop_text_mode(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--text 下多属性每行输出 ``prop = value``。"""
+    from godot_cli_control.cli import OUTPUT_TEXT, RPC_BY_NAME, _run_rpc
+    from unittest.mock import AsyncMock, patch
+
+    spec = RPC_BY_NAME["get"]
+    ns = __import__("argparse").Namespace(
+        node_path="/root/Enemy", props=["position", "health"]
+    )
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(
+        return_value={
+            "values": {
+                "position": {"value": [3.0, 4.0], "type": "Vector2"},
+                "health": {"value": 80, "type": "int"},
+            }
+        }
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_TEXT))
+
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert "position = [3.0, 4.0]" in out
+    assert "health = 80" in out
+
+
+def test_get_parses_multiple_props_from_argv() -> None:
+    """argparse 层面 props nargs='+' 能解析 2+ 属性。"""
+    from godot_cli_control.cli import build_parser
+
+    ns = build_parser().parse_args(["get", "/root/Node", "position", "visible"])
+    assert ns.cmd == "get"
+    assert ns.node_path == "/root/Node"
+    assert ns.props == ["position", "visible"]
+
+
+def test_get_parses_single_prop_from_argv() -> None:
+    """argparse 层面 props nargs='+' 能解析单个属性。"""
+    from godot_cli_control.cli import build_parser
+
+    ns = build_parser().parse_args(["get", "/root/Node", "health"])
+    assert ns.props == ["health"]
 
 
 def test_daemon_ls_empty(

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1932,6 +1932,62 @@ def test_set_default_still_json_parses() -> None:
     assert _resolve_value_for_set(ns) is True
 
 
+# ── _fmt_get_result_text 防御 + 文本渲染补测（review 遗留）──
+
+
+def test_fmt_get_result_text_nested_compound_value(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """嵌套复合 value（Array 内含 dict）在 --text 模式下渲染成 JSON 串，不崩。
+
+    info：client.request("get_property") 返回 {"value": [[1.0, 2.0], {"p": [3.0, 4.0, 5.0]}]}；
+    这种结构在普通 Python 属性里少见，但 agent 可能读到 custom Variant / Rect2 等。
+    """
+    from godot_cli_control.cli import OUTPUT_TEXT, RPC_BY_NAME, _run_rpc
+    from unittest.mock import AsyncMock, patch
+
+    import json as _json
+
+    spec = RPC_BY_NAME["get"]
+    ns = __import__("argparse").Namespace(
+        node_path="/root/Node", props=["weird"]
+    )
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(
+        return_value={"value": [[1.0, 2.0], {"p": [3.0, 4.0, 5.0]}]}
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("godot_cli_control.cli.GameClient", return_value=mock_client):
+        rc = asyncio.run(_run_rpc(spec, ns, port=9999, fmt=OUTPUT_TEXT))
+
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    # 必须是合法 JSON 串（value 是复合类型，走 json.dumps 分支）
+    parsed = _json.loads(out)
+    assert parsed == [[1.0, 2.0], {"p": [3.0, 4.0, 5.0]}]
+
+
+def test_fmt_get_result_text_multi_prop_non_dict_entry_does_not_crash(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """多属性 result 中 entry 不是 dict（防御性非 dict 分支）不崩，打印为 str(entry)。
+
+    正常路径下服务端总是返回 dict，但防御性代码必须能接受非 dict 的 entry
+    （如 result.values["weird"] = 42 这种裸值，对齐 client 侧 guard）。
+    """
+    from godot_cli_control.cli import _fmt_get_result_text
+
+    # 多属性 result，values 里有一个非 dict 的裸值 42
+    r = {"values": {"weird": 42}}
+    out = _fmt_get_result_text(r)
+    # 不抛；渲染出来包含 key 和值
+    assert "weird" in out
+    assert "42" in out
+
+
 def test_call_text_value_disables_arg_parse() -> None:
     from godot_cli_control.cli import build_parser, _resolve_args_for_call
 

--- a/python/tests/test_cli_helpers.py
+++ b/python/tests/test_cli_helpers.py
@@ -15,6 +15,7 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
 
 from godot_cli_control import cli
 
@@ -303,3 +304,239 @@ def test_exit_from_wait_node_uses_found_field() -> None:
     assert cli._exit_from_wait_node({"found": False}) == cli.EXIT_RPC_ERROR
     # 缺字段视为未找到
     assert cli._exit_from_wait_node({}) == cli.EXIT_RPC_ERROR
+
+
+# ── issue #96: wait-prop / wait-signal / wait-frames cmd_* + preflight ──
+
+
+def test_cmd_wait_prop_matched_passes_all_params() -> None:
+    """cmd_wait_prop 必须把 ns 上所有字段透传给 client.wait_property。"""
+    client = AsyncMock()
+    client.wait_property = AsyncMock(return_value={"matched": True, "value": 500, "waited": 0.12})
+    result = _run(cli.cmd_wait_prop(client, _ns(
+        node_path="/root/Player", prop="position:x", value="500",
+        op="gt", timeout="3", tolerance="0",
+    )))
+    client.wait_property.assert_awaited_once_with(
+        "/root/Player", "position:x", 500, op="gt", timeout=3.0, tolerance=0.0,
+    )
+    assert result["matched"] is True
+
+
+def test_cmd_wait_prop_false_result_returned() -> None:
+    client = AsyncMock()
+    client.wait_property = AsyncMock(return_value={"matched": False, "reason": "timeout", "value": 10})
+    result = _run(cli.cmd_wait_prop(client, _ns(
+        node_path="/root/X", prop="health", value="100",
+        op="eq", timeout="5", tolerance="0",
+    )))
+    assert result["matched"] is False
+
+
+def test_exit_from_wait_prop_true_is_0() -> None:
+    """exit 0 = 命中，exit 1 = 未命中（超时）。"""
+    assert cli._exit_from_wait_prop({"matched": True}) == cli.EXIT_OK
+    assert cli._exit_from_wait_prop({"matched": False}) == cli.EXIT_RPC_ERROR
+    assert cli._exit_from_wait_prop({}) == cli.EXIT_RPC_ERROR
+
+
+def test_cmd_wait_signal_matched_passes_timeout() -> None:
+    client = AsyncMock()
+    client.wait_signal = AsyncMock(return_value={"emitted": True, "args": []})
+    result = _run(cli.cmd_wait_signal(client, _ns(
+        node_path="/root/Area", signal_name="door_opened", timeout="3",
+    )))
+    client.wait_signal.assert_awaited_once_with("/root/Area", "door_opened", timeout=3.0)
+    assert result["emitted"] is True
+
+
+def test_cmd_wait_signal_default_timeout_5() -> None:
+    client = AsyncMock()
+    client.wait_signal = AsyncMock(return_value={"emitted": False})
+    _run(cli.cmd_wait_signal(client, _ns(
+        node_path="/root/A", signal_name="sig", timeout=None,
+    )))
+    client.wait_signal.assert_awaited_once_with("/root/A", "sig", timeout=5.0)
+
+
+def test_exit_from_wait_signal_emitted_is_0() -> None:
+    assert cli._exit_from_wait_signal({"emitted": True}) == cli.EXIT_OK
+    assert cli._exit_from_wait_signal({"emitted": False}) == cli.EXIT_RPC_ERROR
+    assert cli._exit_from_wait_signal({}) == cli.EXIT_RPC_ERROR
+
+
+def test_cmd_wait_frames_passes_physics_flag() -> None:
+    client = AsyncMock()
+    client.wait_frames = AsyncMock(return_value={"success": True, "frames": 3})
+    result = _run(cli.cmd_wait_frames(client, _ns(frames="3", physics=True)))
+    client.wait_frames.assert_awaited_once_with(3, physics=True)
+    assert result["frames"] == 3
+
+
+def test_cmd_wait_frames_default_physics_false() -> None:
+    client = AsyncMock()
+    client.wait_frames = AsyncMock(return_value={"success": True, "frames": 5})
+    _run(cli.cmd_wait_frames(client, _ns(frames="5", physics=False)))
+    client.wait_frames.assert_awaited_once_with(5, physics=False)
+
+
+# ── wait-prop preflight ──
+
+
+def test_preflight_wait_prop_timeout_non_number_raises() -> None:
+    ns = _ns(node_path="/X", prop="p", value="1", op="eq", timeout="abc", tolerance="0")
+    with pytest.raises(ValueError, match="timeout"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_timeout_out_of_range_raises() -> None:
+    ns = _ns(node_path="/X", prop="p", value="1", op="eq", timeout="9999", tolerance="0")
+    with pytest.raises(ValueError, match="timeout"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_tolerance_negative_raises() -> None:
+    ns = _ns(node_path="/X", prop="p", value="1", op="eq", timeout="5", tolerance="-1")
+    with pytest.raises(ValueError, match="tolerance"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_ordering_op_with_list_raises() -> None:
+    """gt + value=[1,2] は数値でない → ValueError。"""
+    ns = _ns(node_path="/X", prop="p", value="[1,2]", op="gt", timeout="5", tolerance="0")
+    with pytest.raises(ValueError, match="gt"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_ordering_op_with_string_raises() -> None:
+    ns = _ns(node_path="/X", prop="p", value='"hello"', op="gt", timeout="5", tolerance="0")
+    with pytest.raises(ValueError, match="gt"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_ordering_op_with_bool_raises() -> None:
+    """bool は数値扱いしない —— isinstance(True, int) は True だが bool は排除。"""
+    ns = _ns(node_path="/X", prop="p", value="true", op="gt", timeout="5", tolerance="0")
+    with pytest.raises(ValueError, match="gt"):
+        cli._preflight_wait_prop(ns)
+
+
+def test_preflight_wait_prop_eq_with_bool_ok() -> None:
+    """eq/ne + bool は合法。"""
+    ns = _ns(node_path="/X", prop="visible", value="true", op="eq", timeout="5", tolerance="0")
+    cli._preflight_wait_prop(ns)  # should not raise
+
+
+def test_preflight_wait_prop_eq_with_numeric_ok() -> None:
+    ns = _ns(node_path="/X", prop="p", value="42", op="gt", timeout="5", tolerance="0")
+    cli._preflight_wait_prop(ns)  # should not raise
+
+
+# ── wait-signal preflight ──
+
+
+def test_preflight_wait_signal_timeout_non_number_raises() -> None:
+    ns = _ns(node_path="/X", signal_name="sig", timeout="abc")
+    with pytest.raises(ValueError, match="timeout"):
+        cli._preflight_wait_signal(ns)
+
+
+def test_preflight_wait_signal_timeout_out_of_range_raises() -> None:
+    ns = _ns(node_path="/X", signal_name="sig", timeout="9999")
+    with pytest.raises(ValueError, match="timeout"):
+        cli._preflight_wait_signal(ns)
+
+
+def test_preflight_wait_signal_none_timeout_ok() -> None:
+    """timeout=None（未传）时 preflight 不报错。"""
+    ns = _ns(node_path="/X", signal_name="sig", timeout=None)
+    cli._preflight_wait_signal(ns)  # should not raise
+
+
+# ── wait-frames preflight ──
+
+
+def test_preflight_wait_frames_non_integer_raises() -> None:
+    ns = _ns(frames="abc")
+    with pytest.raises(ValueError, match="frames"):
+        cli._preflight_wait_frames(ns)
+
+
+def test_preflight_wait_frames_zero_raises() -> None:
+    ns = _ns(frames="0")
+    with pytest.raises(ValueError, match="frames"):
+        cli._preflight_wait_frames(ns)
+
+
+def test_preflight_wait_frames_over_max_raises() -> None:
+    ns = _ns(frames="9999")
+    with pytest.raises(ValueError, match="frames"):
+        cli._preflight_wait_frames(ns)
+
+
+def test_preflight_wait_frames_valid_ok() -> None:
+    ns = _ns(frames="3")
+    cli._preflight_wait_frames(ns)  # should not raise
+
+
+# ── fmt helpers for wait-prop / wait-signal / wait-frames ──
+
+
+def test_fmt_wait_prop_matched() -> None:
+    out = cli._fmt_wait_prop_text({"matched": True, "waited": 0.123, "value": 500})
+    assert "matched" in out and "0.123" in out
+
+
+def test_fmt_wait_prop_timeout_has_reason_and_last_value() -> None:
+    out = cli._fmt_wait_prop_text({"matched": False, "reason": "timeout", "value": 10})
+    assert "timeout" in out and "10" in out
+
+
+def test_fmt_wait_signal_emitted() -> None:
+    assert cli._fmt_wait_signal_text({"emitted": True}) == "emitted"
+
+
+def test_fmt_wait_signal_timeout() -> None:
+    assert cli._fmt_wait_signal_text({"emitted": False}) == "timeout"
+    assert cli._fmt_wait_signal_text({}) == "timeout"
+
+
+def test_fmt_wait_frames_text() -> None:
+    """wait-frames 文本输出包含帧数。"""
+    # RpcSpec text_formatter is a lambda; test by calling it directly from spec
+    import importlib
+    importlib.reload(cli)  # ensure latest state
+    spec = cli.RPC_BY_NAME.get("wait-frames")
+    if spec is None:
+        pytest.skip("wait-frames spec not yet registered")
+    out = spec.text_formatter({"frames": 5, "success": True})
+    assert "5" in out and "frames" in out
+
+
+# ── argparse parser accepts wait-* subcommands ──
+
+
+def test_parser_accepts_wait_prop() -> None:
+    """wait-prop 必须被 build_parser 注册为子命令。"""
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["wait-prop", "/root/N", "visible", "true"])
+    assert ns.cmd == "wait-prop"
+    assert ns.node_path == "/root/N"
+    assert ns.prop == "visible"
+    assert ns.value == "true"
+
+
+def test_parser_accepts_wait_signal() -> None:
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["wait-signal", "/root/A", "fired"])
+    assert ns.cmd == "wait-signal"
+    assert ns.node_path == "/root/A"
+    assert ns.signal_name == "fired"
+
+
+def test_parser_accepts_wait_frames() -> None:
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["wait-frames", "3", "--physics"])
+    assert ns.cmd == "wait-frames"
+    assert ns.frames == "3"
+    assert ns.physics is True

--- a/python/tests/test_cli_helpers.py
+++ b/python/tests/test_cli_helpers.py
@@ -94,11 +94,18 @@ def test_cmd_release_all() -> None:
 
 
 def test_cmd_get_returns_value_directly() -> None:
+    """cmd_get 单属性透传 client.request("get_property") 的完整 result（含 type 字段）。
+
+    注：cmd_get 自 #99 改为走 client.request 而非 client.get_property，
+    透传带 type 字段的 RPC result 给 agent 消歧；get_property 是裸 value 便捷层。
+    """
     client = AsyncMock()
-    client.get_property = AsyncMock(return_value=42)
-    result = _run(cli.cmd_get(client, _ns(node_path="/X", prop="value")))
-    assert result == 42
-    client.get_property.assert_awaited_once_with("/X", "value")
+    client.request = AsyncMock(return_value={"value": 42})
+    result = _run(cli.cmd_get(client, _ns(node_path="/X", props=["value"])))
+    assert result == {"value": 42}
+    client.request.assert_awaited_once_with(
+        "get_property", {"path": "/X", "property": "value"}
+    )
 
 
 def test_cmd_set_parses_json_value() -> None:

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -595,3 +595,95 @@ async def test_connect_locks_ws_ping_keepalive() -> None:
             "GameClient.connect() must lock ping_interval (ws keepalive)"
         assert kwargs.get("ping_timeout") == 20, \
             "GameClient.connect() must lock ping_timeout (ws keepalive)"
+
+
+# ---- issue #96: wait_property / wait_signal / wait_frames client 包装 ----
+
+
+@pytest.mark.asyncio
+async def test_wait_property_sends_correct_rpc_params() -> None:
+    """wait_property 必须发出 method="wait_property"，参数全部透传（含 op/tolerance）。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        captured["timeout"] = timeout
+        return {"matched": True, "value": 500, "waited": 0.12}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.wait_property(
+            "/root/Player", "position:x", 500,
+            op="gt", timeout=3.0, tolerance=0.5,
+        )
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "wait_property"
+    assert captured["params"] == {
+        "path": "/root/Player", "property": "position:x", "value": 500,
+        "op": "gt", "timeout": 3.0, "tolerance": 0.5,
+    }
+    # client 侧 timeout = server timeout + 5s grace
+    assert captured["timeout"] == 3.0 + 5.0
+    assert result == {"matched": True, "value": 500, "waited": 0.12}
+
+
+@pytest.mark.asyncio
+async def test_wait_signal_sends_correct_rpc_params() -> None:
+    """wait_signal 必须发出 method="wait_signal"，超时 = server timeout + 5s。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        captured["timeout"] = timeout
+        return {"emitted": True, "args": []}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.wait_signal("/root/Area", "door_opened", timeout=4.0)
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "wait_signal"
+    assert captured["params"] == {"path": "/root/Area", "signal": "door_opened", "timeout": 4.0}
+    assert captured["timeout"] == 4.0 + 5.0
+    assert result == {"emitted": True, "args": []}
+
+
+@pytest.mark.asyncio
+async def test_wait_frames_sends_correct_rpc_params_and_calculates_timeout() -> None:
+    """wait_frames 的 client timeout = max(30, frames/10 + 10)。"""
+    import godot_cli_control.client as client_mod
+
+    captured: list = []
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured.append({"method": method, "params": params, "timeout": timeout})
+        return {"success": True, "frames": params.get("frames", 0)}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        # 3 frames: max(30, 3/10+10)=max(30, 10.3)=30
+        await client.wait_frames(3)
+        # 300 frames: max(30, 300/10+10)=max(30, 40)=40
+        await client.wait_frames(300, physics=True)
+    finally:
+        client_mod.GameClient.request = orig
+
+    assert captured[0]["method"] == "wait_frames"
+    assert captured[0]["params"] == {"frames": 3, "physics": False}
+    assert captured[0]["timeout"] == 30.0
+
+    assert captured[1]["params"] == {"frames": 300, "physics": True}
+    assert captured[1]["timeout"] == 40.0

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -525,6 +525,54 @@ async def test_combo_client_timeout_decoupled_from_steps_total() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_properties_sends_correct_rpc_params() -> None:
+    """``get_properties`` 必须发出 method="get_properties"、params={"path": ..., "properties": [...]}。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        return {"values": {}}
+
+    client = client_mod.GameClient(port=1)
+    monkeypatch_target = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        await client.get_properties("/root/Player", ["position", "visible"])
+    finally:
+        client_mod.GameClient.request = monkeypatch_target
+    assert captured["method"] == "get_properties"
+    assert captured["params"] == {"path": "/root/Player", "properties": ["position", "visible"]}
+
+
+@pytest.mark.asyncio
+async def test_get_properties_unwraps_values_to_bare_value_map() -> None:
+    """服务端 ``{"values": {prop: {"value": ..., "type"?: ...}}}`` 必须被解包成
+    ``{prop: 裸value}`` 映射；非 dict 容错分支（如 ``"weird": 42``）也需透传。"""
+    import godot_cli_control.client as client_mod
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        return {
+            "values": {
+                "position": {"value": [1, 2], "type": "Vector2"},
+                "visible": {"value": True},
+                "weird": 42,  # 非 dict，容错：直接透传
+            }
+        }
+
+    client = client_mod.GameClient(port=1)
+    monkeypatch_target = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.get_properties("/root/Player", ["position", "visible", "weird"])
+    finally:
+        client_mod.GameClient.request = monkeypatch_target
+    assert result == {"position": [1, 2], "visible": True, "weird": 42}
+
+
+@pytest.mark.asyncio
 async def test_connect_locks_ws_ping_keepalive() -> None:
     """issue #45 治本依赖：去掉 wall 上限后，死连接靠 ws ping/pong 检测。
 

--- a/python/tests/test_e2e_client_direct.py
+++ b/python/tests/test_e2e_client_direct.py
@@ -252,3 +252,53 @@ async def test_client_request_get_property_has_type_field(daemon_port: Any) -> N
         assert len(result["value"]) == 2, result
         # type 字段存在且是 "Vector2"
         assert result.get("type") == "Vector2", result
+
+
+@pytest.mark.asyncio
+async def test_client_wait_frames(daemon_port: Any) -> None:
+    """client.wait_frames(2) 返回 {"success": True, "frames": 2}（issue #96 直连覆盖）。"""
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        result = await client.wait_frames(2)
+        assert isinstance(result, dict), result
+        assert result.get("success") is True, result
+        assert result.get("frames") == 2, result
+
+
+@pytest.mark.asyncio
+async def test_client_wait_property_immediate_match_and_timeout(daemon_port: Any) -> None:
+    """wait_property 直连测试：立即命中路径 + 超时路径（issue #96）。
+
+    先 set_property 一个已知值，再 wait eq → matched=True（立即命中）。
+    然后等一个永远不成立的条件 timeout=0.5 → matched=False, reason='timeout'。
+    """
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        # 写 counter = 42，然后立即等 counter == 42 → 应立即命中
+        await client.set_property("/root/Main", "counter", 42)
+        result_match = await client.wait_property(
+            "/root/Main", "counter", 42, op="eq", timeout=2.0
+        )
+        assert isinstance(result_match, dict), result_match
+        assert result_match.get("matched") is True, result_match
+
+        # 等 counter > 9999（永远不成立）超时
+        result_timeout = await client.wait_property(
+            "/root/Main", "counter", 9999, op="gt", timeout=0.5
+        )
+        assert isinstance(result_timeout, dict), result_timeout
+        assert result_timeout.get("matched") is False, result_timeout
+        assert result_timeout.get("reason") == "timeout", result_timeout
+
+
+@pytest.mark.asyncio
+async def test_client_wait_signal_timeout_path(daemon_port: Any) -> None:
+    """wait_signal 超时路径：等一个不会发射的内置信号 renamed（issue #96）。
+
+    emitted=False 且超时时间合理（0.5s）。
+    """
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        result = await client.wait_signal("/root/Main/Player", "renamed", timeout=0.5)
+        assert isinstance(result, dict), result
+        assert result.get("emitted") is False, result

--- a/python/tests/test_e2e_client_direct.py
+++ b/python/tests/test_e2e_client_direct.py
@@ -215,3 +215,40 @@ async def test_client_autodiscovers_port_from_control_dir(
     monkeypatch.chdir(project)
     async with GameClient() as client:  # 无 port → auto-discover
         assert await client.node_exists("/root/Main") is True
+
+
+@pytest.mark.asyncio
+async def test_client_get_properties_multi(daemon_port: Any) -> None:
+    """client.get_properties(path, props) 原子读——返回 dict，key 齐，每项是裸 value
+    （不含 type 字段）。覆盖 client.py get_properties 方法体（issue #100 direct-connect）。"""
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        result = await client.get_properties("/root/Main", ["counter", "name"])
+        assert isinstance(result, dict), result
+        # 两个 key 都在
+        assert "counter" in result, result
+        assert "name" in result, result
+        # Python API 只给裸 value（不含 type），counter 是 int，name 是 str
+        assert isinstance(result["counter"], int), result
+        assert isinstance(result["name"], str), result
+
+
+@pytest.mark.asyncio
+async def test_client_request_get_property_has_type_field(daemon_port: Any) -> None:
+    """client.request('get_property', {...}) 对 Node2D.position 返回带 type 字段的对象。
+
+    Python API (get_property) 只给裸 value；要拿 type + value 必须走底层 request()。
+    这里直接断言 shape: {"value": [x, y], "type": "Vector2"}。
+    覆盖 issue #99 的服务端编码 + client.request 直通路径。"""
+    _, port = daemon_port
+    async with GameClient(port=port) as client:
+        result = await client.request(
+            "get_property", {"path": "/root/Main/Player", "property": "position"}
+        )
+        assert isinstance(result, dict), result
+        # value 是 list（Vector2 编码为数组）
+        assert "value" in result, result
+        assert isinstance(result["value"], list), result
+        assert len(result["value"]) == 2, result
+        # type 字段存在且是 "Vector2"
+        assert result.get("type") == "Vector2", result

--- a/python/tests/test_e2e_example.py
+++ b/python/tests/test_e2e_example.py
@@ -113,11 +113,12 @@ def test_demo_drives_jump_and_move(daemon: Any) -> None:
 
     jump = _run_cli(project, "get", "/root/Main/World/Player", "jump_count")
     assert jump["ok"] is True, jump
-    assert jump["result"] == 1, f"期望恰好跳 1 次，实际 {jump['result']}"
+    # PR2 后 get result 透传 RPC shape: {"value": ..., "type": ...}
+    assert jump["result"]["value"] == 1, f"期望恰好跳 1 次，实际 {jump['result']}"
 
     # 向右跑 1s，moved_right 应被置真。
     assert _run_cli(project, "hold", "move_right", "1.0")["ok"]
     _run_cli(project, "wait-time", "0.2")
     moved = _run_cli(project, "get", "/root/Main/World/Player", "moved_right")
     assert moved["ok"] is True, moved
-    assert moved["result"] is True, f"期望 moved_right=true，实际 {moved['result']}"
+    assert moved["result"]["value"] is True, f"期望 moved_right=true，实际 {moved['result']}"

--- a/python/tests/test_e2e_input.py
+++ b/python/tests/test_e2e_input.py
@@ -232,8 +232,8 @@ def test_press_reaches_unhandled_input_callback(probe_project: Path) -> None:
 
         payload = _run_cli(probe_project, "get", "/root/Main", "saw_jump_event")
         assert payload["ok"] is True, payload
-        # PR1 阶段 get 仍是旧编码（裸值）；PR2 落地后此断言改 result["value"]
-        assert payload["result"] is True, (
+        # PR2 已迁移：get 信封透传 RPC result，result["value"] 取裸值
+        assert payload["result"]["value"] is True, (
             f"_unhandled_input 应收到 press 事件并置 saw_jump_event=true，实际 result={payload['result']!r}"
         )
     finally:


### PR DESCRIPTION
## 背景

#104 → #105 → #106 是 stacked PR 链。正确合并流程应为「合一个 → retarget 下一个 base 到 main → 再合」，但三个 PR 被按原 base 直接合并，导致：

- #104（feat/97 → main）✅ 内容已进 main
- #105（feat/99-100 → feat/97）❌ 合进了 feat/97 **分支**，未达 main
- #106（feat/96 → feat/99-100）❌ 合进了 feat/99-100 **分支**，未达 main

## 本 PR 做了什么

把 `origin/feat/99-100-get-codec`（已含 #106 合入内容）上 **main 缺失的 17 个 commit** 通过 `git rebase --onto main f9cb3f3` 干净重放到 main 之上（#97 的 3 个 commit main 已有，自动排除）。

- rebase 后树内容与 `origin/feat/99-100-get-codec` **逐字节一致**（`git diff` 为空）
- 内容即 #105（Variant 编码对称化 + get_properties 原子读）与 #106（wait 条件等待原语）的全部已审代码，无任何新增改动

Closes #99
Closes #100
Closes #96

## 本地验证

- GUT：139/139 通过（410 断言）
- pytest 全量（含 e2e 真跑）：446 passed / 2 skipped（平台条件跳过），覆盖率 96%（门槛 80%）

🤖 Generated with [Claude Code](https://claude.com/claude-code)