### PR TITLE
fix(cli): 退出码语义统一 —— argparse 用法错归 64，daemon 前置失败换 -1006（#111 #92）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,8 @@
 3. **退出码语义化**
    - 0 = 成功 / 布尔 true / 节点存在 / wait 命中
    - 1 = RPC 错（含 `exists`/`visible`=false、`wait-node` timeout、`daemon status` stopped）
-   - 2 = 连接 / IO 错，或 `run`/`daemon` 前置失败（脚本路径不存在、daemon 起不来；这些仍带 `-1003`）
-   - 64 = 用法错：argparse + RPC 子命令的 preflight / 运行期参数解析失败，统一携带 `-1003`（issue #82：RPC 子命令的 `-1003` 恒等于 64，不再有 2/64 歧义）
+   - 2 = 连接 / IO 错，或 infra 前置失败（daemon 起不来、daemon stop 系统错误；这些带 `-1006`）；`daemon stop` ffmpeg 转码失败也是 2
+   - 64 = 用法错：argparse + RPC 子命令的 preflight / 运行期参数解析失败，以及 `run <script>` 脚本路径不存在或缺 `run(bridge)`；统一携带 `-1003`（#82 / #111：`-1003` 恒等于 64）
    - 3 = `daemon stop --all` 部分失败（专用，避免与 2 撞）
    - shell `if godot-cli-control exists /root/Foo; then …` 必须能用。
 

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed (BREAKING — exit code changes)
+
+- **#111 argparse 用法错 exit 2 → exit 64**: 所有 argparse 层错误（缺位置参数、非法 choices、未知子命令等）现在统一输出 `-1003` 信封并以 exit 64 退出。之前是 exit 2（argparse 默认）。影响：脚本若用 `[ $? -eq 2 ]` 判 argparse 错需改为 `[ $? -eq 64 ]`。
+- **#92 `run <script>` 前置错误拆分**:
+  - 脚本路径不存在 / 脚本缺 `run(bridge)` 函数：由旧的 exit 2（或 exit 1）改为 exit 64，错误码由 `-1003` 保持不变。这是用法错，应修正调用而非重试。
+  - `daemon start`（`run` 自动启停 / `daemon start` 命令）/ `daemon stop` 系统级失败（端口冲突、找不到 Godot binary、PID 文件丢失等）：错误码由 `-1003` 改为 **新码 `-1006` (PRECONDITION)**，exit code 保持 exit 2。影响：`run`/`daemon` 失败时，通过 `error.code` 区分用法错（`-1003` → 修调用）与基础设施错（`-1006` → 修环境）现在变得无歧义。
+
 ### Added
 - **feat(wait): `wait-prop` / `wait-signal` / `wait-frames` 条件等待原语 + 错误码 1007（#96）**: 三个新 CLI 子命令。`wait-prop <path> <prop> <value> [--op eq|ne|gt|lt|ge|le] [--timeout] [--tolerance]` 等属性满足条件（exit 0=matched, 1=timeout）；`wait-signal <path> <signal> [--timeout]` 等信号发射（exit 0=emitted, 1=timeout）；`wait-frames <N> [--physics]` 推进 N 帧。服务端错误码 1007 SIGNAL_NOT_FOUND（wait-signal 传未知信号名，永久性 schema 错，不应 retry）。Python `GameClient` 对应方法：`wait_property` / `wait_signal` / `wait_frames`。
 

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -134,9 +134,10 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements, or `hold` given `duration ≤ 0` — use `press` for an indefinite hold) |
 | `-1001` | client | Connection failure (daemon not running, port wrong, proxy hijacking localhost) |
 | `-1002` | client | Timeout waiting for response |
-| `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, a non-numeric `tap`/`wait-time` arg, a `set`/`call` value that fails JSON parsing, …). From an RPC subcommand this always exits **64** (#82); top-level `run`/`daemon` precondition failures also use `-1003` but exit 2. |
+| `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, a non-numeric `tap`/`wait-time` arg, a `set`/`call` value that fails JSON parsing, script path not found, or script missing `run(bridge)`). Always exits **64** (#82 / #111). |
 | `-1004` | client | Local file IO error (e.g. screenshot can't write the destination) |
 | `-1005` | client | `run <script>` user script raised an uncaught exception — fix the script |
+| `-1006` | client | Infra pre-condition failure (`daemon start`/`stop`/`run` auto-start failed at OS level — port conflict, Godot binary not found, etc.). Always exits **2** (#92). |
 | `-1099` | client | Internal CLI bug — please file an issue |
 
 For full retry guidance see the SKILL.md shipped by `godot-cli-control init` (`.claude/skills/godot-cli-control/SKILL.md` in the target project).
@@ -164,9 +165,9 @@ Semantic exit codes so `if godot-cli-control exists /root/Foo; then …` works i
 |---|---|
 | 0 | Success (or boolean true for `exists` / `visible`, node found for `wait-node`, condition matched for `wait-prop` / `wait-signal`) |
 | 1 | RPC error; also `exists`/`visible`=false, `wait-node`/`wait-prop`/`wait-signal` timeout, `daemon status`=stopped |
-| 2 | Connection / IO error, or `daemon stop` ffmpeg-transcode failure |
+| 2 | Connection / IO error, infra pre-condition failure (`daemon start`/`stop` system error, carry `-1006`), or `daemon stop` ffmpeg-transcode failure |
 | 3 | `daemon stop --all` partial failure (≥1 daemon failed to stop) |
-| 64 | Usage error on an RPC subcommand — bad argparse args, a pre-flight reject (`combo` with no steps / malformed `--steps-json`), a non-numeric `tap`/`wait-time` arg, or a `set`/`call` value that fails JSON parsing. These all carry client code `-1003` and now consistently exit 64 (#82; a few previously exited 2). |
+| 64 | Usage error — argparse parse failure, a pre-flight reject (`combo` with no steps / malformed `--steps-json`), a non-numeric `tap`/`wait-time` arg, a `set`/`call` value that fails JSON parsing, `run <script>` with a non-existent path or missing `run(bridge)`. All carry client code `-1003` and exit 64 (#82 / #111). |
 
 ## Activation Modes
 

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -57,6 +57,7 @@ CLIENT_CODE_TIMEOUT = -1002
 CLIENT_CODE_USAGE = -1003
 CLIENT_CODE_IO = -1004  # 本地文件 IO 错误（screenshot 写盘等），与连接错误分开
 CLIENT_CODE_SCRIPT_ERROR = -1005  # `run <script>` 用户脚本抛出未捕获异常（agent 错的是脚本，不是 CLI 框架）
+CLIENT_CODE_PRECONDITION = -1006  # infra 前置失败（daemon 起不来、脚本不可访问等），恒 exit 2；与「-1003 恒 64」双射互补
 CLIENT_CODE_INTERNAL = -1099  # 兜底：客户端内部异常（理论上不该到这里，但兜住契约）
 
 
@@ -1024,7 +1025,7 @@ def cmd_daemon_start(ns: argparse.Namespace) -> int:
             idle_timeout=idle_seconds,
         )
     except DaemonError as e:
-        _emit_top_error(ns, code=CLIENT_CODE_USAGE, message=str(e))
+        _emit_top_error(ns, code=CLIENT_CODE_PRECONDITION, message=str(e))  # infra 前置失败 → -1006（#92）
         return EXIT_INFRA_ERROR
     if _output_format(ns) == OUTPUT_JSON:
         # 跟 daemon status 的信封形状对齐，方便 agent 一套 jq 处理三个命令。
@@ -1094,7 +1095,7 @@ def cmd_daemon_stop(ns: argparse.Namespace) -> int:
     try:
         rc = daemon.stop()
     except DaemonError as e:
-        _emit_top_error(ns, code=CLIENT_CODE_USAGE, message=str(e))
+        _emit_top_error(ns, code=CLIENT_CODE_PRECONDITION, message=str(e))  # infra 前置失败 → -1006（#92）
         return EXIT_INFRA_ERROR
     if fmt == OUTPUT_JSON:
         # rc 0=正常停 / 2=ffmpeg 转码失败但 daemon 已停。两种都算"stopped"，
@@ -1215,14 +1216,13 @@ def cmd_run(ns: argparse.Namespace) -> int:
     try:
         script_path = Path(ns.script)
         if not script_path.exists():
-            # 用户传错路径属于"用法错" → EXIT_INFRA_ERROR(2)，
-            # 与 CLAUDE.md 契约 3 对齐，亦与 cmd_daemon_start 错误码一致。
+            # 用户传错路径属于"用法错" → -1003 + EXIT_USAGE(64)（#92）
             msg = f"找不到脚本: {script_path}"
             if fmt == OUTPUT_JSON:
                 _emit_error_payload(CLIENT_CODE_USAGE, msg)
             else:
                 print(f"错误：{msg}", file=sys.stderr)
-            return EXIT_INFRA_ERROR
+            return EXIT_USAGE
 
         try:
             idle_seconds = _resolve_idle_timeout(ns)
@@ -1252,10 +1252,10 @@ def cmd_run(ns: argparse.Namespace) -> int:
                     idle_timeout=idle_seconds,
                 )
             except DaemonError as e:
-                # daemon 起不来是基础设施错（端口冲突、godot bin 不可执行等），
-                # 走 EXIT_INFRA_ERROR(2) 与 cmd_daemon_start(line 734) 一致。
+                # daemon 起不来是 infra 前置失败（端口冲突、godot bin 不可执行等），
+                # → -1006 (PRECONDITION) + EXIT_INFRA_ERROR(2)（#92）
                 if fmt == OUTPUT_JSON:
-                    _emit_error_payload(CLIENT_CODE_USAGE, str(e))
+                    _emit_error_payload(CLIENT_CODE_PRECONDITION, str(e))
                 else:
                     print(f"错误：{e}", file=sys.stderr)
                 return EXIT_INFRA_ERROR
@@ -1445,7 +1445,7 @@ def _exec_user_script(
             return 1
         if missing_run:
             _emit_usage(f"脚本 {script_path} 中缺少 run(bridge) 函数")
-            return 1
+            return EXIT_USAGE  # 用法错，#92
         if connection_error is not None:
             if is_json:
                 _emit_error_payload(

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1687,12 +1687,12 @@ class _EnvelopeArgumentParser(argparse.ArgumentParser):
     时读同一份（类变量跨实例共享，整个 parse_args 栈只有一次顶层调用）。
     """
 
-    _last_argv: "list[str]" = []
+    _last_argv: list[str] = []
 
     def parse_args(  # type: ignore[override]
         self,
-        args: "list[str] | None" = None,
-        namespace: "argparse.Namespace | None" = None,
+        args: list[str] | None = None,
+        namespace: argparse.Namespace | None = None,
     ) -> argparse.Namespace:
         # 顶层 parse_args 调用时更新类变量；子 parser 不会再调用 parse_args，
         # 所以这里只会被根 parser 调到，子 parser error() 读的是同一份。
@@ -1703,8 +1703,19 @@ class _EnvelopeArgumentParser(argparse.ArgumentParser):
 
     def error(self, message: str) -> NoReturn:
         self.print_usage(sys.stderr)
-        # --text / --no-json 旁路：只打人类可读错误到 stderr，不打 JSON
-        if "--text" not in _EnvelopeArgumentParser._last_argv and "--no-json" not in _EnvelopeArgumentParser._last_argv:
+        # --text / --no-json 旁路判定：用 peek-parse 而非 token 扫描，
+        # 避免 `--` 之后的字面量 --text 被误判为 text 模式旗标。
+        # peek parser 是普通 ArgumentParser（非 _EnvelopeArgumentParser），避免递归。
+        _peek = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+        _add_output_format_flags(_peek)
+        _is_text_mode = False
+        try:
+            _opts, _ = _peek.parse_known_args(_EnvelopeArgumentParser._last_argv)
+            _is_text_mode = getattr(_opts, "output_format", OUTPUT_JSON) == OUTPUT_TEXT
+        except SystemExit:
+            # peek 解析异常（如 --text=x 等非法形式），保守回落到 JSON 信封（契约默认值）
+            _is_text_mode = False
+        if not _is_text_mode:
             _emit_error_payload(CLIENT_CODE_USAGE, f"{self.prog}: {message}")
         else:
             print(f"{self.prog}: error: {message}", file=sys.stderr)

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1203,8 +1203,8 @@ def cmd_run(ns: argparse.Namespace) -> int:
     退出码：
       0  脚本成功（且 daemon stop 成功）
       1  脚本运行失败（RPC 错语义；envelope `ok=false` 时也走这里）
-      2  基础设施 / 用法错（脚本路径不存在、daemon 起不来、idle_timeout 之外的解析）
-      64 argparse 用法错（idle_timeout 解析失败等"明显参数写错"）
+      2  基础设施前置失败（daemon 起不来等，code -1006 PRECONDITION）
+      64 用法错（脚本路径不存在、缺 run(bridge)、idle_timeout 解析失败等，code -1003）
     """
     from .daemon import Daemon, DaemonError
 

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1678,10 +1678,43 @@ def _add_output_format_flags(p: argparse.ArgumentParser) -> None:
     )
 
 
+class _EnvelopeArgumentParser(argparse.ArgumentParser):
+    """覆写 argparse 的 error() —— 把用法错统一进 JSON 信封 + exit 64。
+
+    不覆写 exit()，保住 --help 的 exit(0)。
+
+    在 parse_args 调用时把 argv 存入类变量 _last_argv，子 parser 调用 error()
+    时读同一份（类变量跨实例共享，整个 parse_args 栈只有一次顶层调用）。
+    """
+
+    _last_argv: "list[str]" = []
+
+    def parse_args(  # type: ignore[override]
+        self,
+        args: "list[str] | None" = None,
+        namespace: "argparse.Namespace | None" = None,
+    ) -> argparse.Namespace:
+        # 顶层 parse_args 调用时更新类变量；子 parser 不会再调用 parse_args，
+        # 所以这里只会被根 parser 调到，子 parser error() 读的是同一份。
+        _EnvelopeArgumentParser._last_argv = (
+            list(args) if args is not None else sys.argv[1:]
+        )
+        return super().parse_args(args, namespace)
+
+    def error(self, message: str) -> "NoReturn":
+        self.print_usage(sys.stderr)
+        # --text / --no-json 旁路：只打人类可读错误到 stderr，不打 JSON
+        if "--text" not in _EnvelopeArgumentParser._last_argv and "--no-json" not in _EnvelopeArgumentParser._last_argv:
+            _emit_error_payload(CLIENT_CODE_USAGE, f"{self.prog}: {message}")
+        else:
+            print(f"{self.prog}: error: {message}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+
+
 def build_parser() -> argparse.ArgumentParser:
     from . import _version
 
-    parser = argparse.ArgumentParser(
+    parser = _EnvelopeArgumentParser(
         prog="godot-cli-control",
         description="Godot CLI Control —— 通过命令行远程驱动 Godot 项目",
         epilog=_TOP_EPILOG,

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -31,7 +31,7 @@ import traceback
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 from .client import DEFAULT_PORT, GameClient, RpcError
 
@@ -1701,7 +1701,7 @@ class _EnvelopeArgumentParser(argparse.ArgumentParser):
         )
         return super().parse_args(args, namespace)
 
-    def error(self, message: str) -> "NoReturn":
+    def error(self, message: str) -> NoReturn:
         self.print_usage(sys.stderr)
         # --text / --no-json 旁路：只打人类可读错误到 stderr，不打 JSON
         if "--text" not in _EnvelopeArgumentParser._last_argv and "--no-json" not in _EnvelopeArgumentParser._last_argv:

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -44,9 +44,9 @@ godot-cli-control daemon stop
 |---|---|
 | 0 | Success (or, for `exists` / `visible` / `wait-node` / `wait-prop` / `wait-signal`, the boolean was true / found / matched / emitted) |
 | 1 | RPC error (server returned `{"error":...}`); also `exists`/`visible`=false, `wait-node`/`wait-prop`/`wait-signal`=timeout, `daemon status`=stopped |
-| 2 | Connection / IO error (daemon not running, script path not found). Also: **`daemon stop` returns 2** when the daemon stopped cleanly but `ffmpeg` transcode of the recorded `.avi`→`.mp4` failed — the raw `.avi` is kept and `.cli_control/ffmpeg.log` has the details. `run <script>` propagates this: a successful script + failed transcode still exits 2. |
+| 2 | Connection / IO error (daemon not running) or infra pre-condition failure (daemon failed to start, `daemon stop` encountered a system error — these carry client code `-1006`). Also: **`daemon stop` returns 2** when the daemon stopped cleanly but `ffmpeg` transcode of the recorded `.avi`→`.mp4` failed — the raw `.avi` is kept and `.cli_control/ffmpeg.log` has the details. `run <script>` propagates this: a successful script + failed transcode still exits 2. |
 | 3 | `daemon stop --all` partial failure: at least one daemon in the registry failed to stop. Per-record `rc` is in the JSON `result.stopped[]`. |
-| 64 | Usage error on an **RPC subcommand** — argparse, a pre-flight reject caught before connecting (`combo` with no steps / malformed `--steps-json` / `combo -` from a TTY, `hold` with a non-positive duration), **and** a bad runtime argument (`tap` / `wait-time` given a non-number, a `set`/`call` value that fails JSON parsing). For RPC subcommands these all carry client code `-1003` and now consistently exit 64 (a few previously exited 2 — fixed in #82). |
+| 64 | Usage error — argparse parse failure (missing / invalid args, unknown subcommand), a pre-flight reject caught before connecting (`combo` with no steps / malformed `--steps-json` / `combo -` from a TTY, `hold` with a non-positive duration), a bad runtime argument (`tap` / `wait-time` given a non-number, a `set`/`call` value that fails JSON parsing), **or** `run <script>` given a non-existent path / a script with no `run(bridge)` function. All carry client code `-1003` and consistently exit 64 (#82 / #111). |
 
 Shell-`if` works:
 
@@ -141,9 +141,10 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 |---|---|
 | `-1001` | Connection failure (daemon not running, port wrong, proxy hijacking localhost). Run `daemon status`. |
 | `-1002` | Timeout waiting for a response. Daemon may be hung mid-frame; check Godot stderr. |
-| `-1003` | Usage error (`combo` got no steps, malformed `--steps-json`, `combo -` from a TTY, a non-numeric `tap`/`wait-time` arg, **or** a `set`/`call` value that fails JSON parsing). From an RPC subcommand this always exits **64**. (Top-level `run`/`daemon` precondition failures — e.g. script path not found, daemon failed to start — also surface `-1003` but exit **2**.) Fix the invocation. |
+| `-1003` | Usage error (`combo` got no steps, malformed `--steps-json`, `combo -` from a TTY, a non-numeric `tap`/`wait-time` arg, a `set`/`call` value that fails JSON parsing, script path not found, or script missing `run(bridge)`). Always exits **64** (#111). Fix the invocation. |
 | `-1004` | Local file IO error (e.g. `screenshot` can't write the destination — bad path, no write permission). **Not** a daemon problem. |
 | `-1005` | `run <script>` user script raised an uncaught exception. The error message has the exception type + last-line summary; full traceback is on stderr. Fix the script, not the CLI. |
+| `-1006` | Infra pre-condition failure (`daemon start` / `daemon stop` / `run`'s auto-start failed at the OS level — port conflict, Godot binary not found, PID file missing, etc.). Always exits **2** (#92). Fix the environment, not the invocation. |
 | `-1099` | Internal client error (unforeseen exception). Bug in this CLI; please file an issue. Stderr has the full traceback. |
 
 Server vs client ranges never overlap, so a single `code` field is unambiguous.

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -82,16 +82,17 @@ def test_exec_user_script_registers_module_for_dataclass_lookup(
     assert rc == 0
 
 
-def test_exec_user_script_returns_1_on_missing_run(
+def test_exec_user_script_returns_usage_on_missing_run(
     tmp_path: Path, stub_bridge: None
 ) -> None:
+    """缺 run(bridge) 函数 → EXIT_USAGE(64)（#92 修复：用法错归 64）。"""
     script = tmp_path / "user_script.py"
     _write(script, "x = 1\n")
 
-    from godot_cli_control.cli import _exec_user_script
+    from godot_cli_control.cli import EXIT_USAGE, _exec_user_script
 
     rc = _exec_user_script(script, port=9999)
-    assert rc == 1
+    assert rc == EXIT_USAGE
 
 
 def test_exec_user_script_friendly_error_on_connection_failure(
@@ -440,17 +441,17 @@ def test_exec_user_script_json_error_on_runtime_exception(
 def test_exec_user_script_json_error_on_missing_run(
     tmp_path: Path, stub_bridge: None, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """缺 run() → ``-1003`` (CLIENT_CODE_USAGE) envelope。"""
+    """缺 run() → ``-1003`` (CLIENT_CODE_USAGE) envelope + EXIT_USAGE(64)（#92 修复）。"""
     import json as _json
 
-    from godot_cli_control.cli import _exec_user_script
+    from godot_cli_control.cli import EXIT_USAGE, _exec_user_script
 
     script = tmp_path / "user_script.py"
     _write(script, "x = 1\n")
 
     rc = _exec_user_script(script, port=9999, output_format="json")
     out = capsys.readouterr().out.strip()
-    assert rc == 1
+    assert rc == EXIT_USAGE
     payload = _json.loads(out)
     assert payload["ok"] is False
     assert payload["error"]["code"] == -1003
@@ -493,11 +494,11 @@ def test_cmd_run_emits_envelope_when_script_missing(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """``godot-cli-control run nonexistent.py --json`` → 单行 error envelope +
-    EXIT_INFRA_ERROR(2)。用户传错路径按 CLAUDE.md 契约 3 归入"用法错=2"。"""
+    EXIT_USAGE(64)。用户传错路径是"用法错"→ -1003 + 64（#92 修复）。"""
     import argparse
     import json as _json
 
-    from godot_cli_control.cli import EXIT_INFRA_ERROR, OUTPUT_JSON, cmd_run
+    from godot_cli_control.cli import EXIT_USAGE, OUTPUT_JSON, cmd_run
 
     ns = argparse.Namespace(
         script=str(tmp_path / "does-not-exist.py"),
@@ -512,7 +513,7 @@ def test_cmd_run_emits_envelope_when_script_missing(
     )
     rc = cmd_run(ns)
     out = capsys.readouterr().out.strip()
-    assert rc == EXIT_INFRA_ERROR
+    assert rc == EXIT_USAGE
     payload = _json.loads(out)
     assert payload["ok"] is False
     assert payload["error"]["code"] == -1003
@@ -616,8 +617,8 @@ def test_cmd_run_emits_envelope_on_daemon_start_failure(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """daemon.start raise DaemonError → envelope + EXIT_INFRA_ERROR(2)。
-    遗漏过的 review P2 #4 case：单测之前只覆盖了"脚本不存在""idle 解析失败"。"""
+    """daemon.start raise DaemonError → envelope (-1006 PRECONDITION) + EXIT_INFRA_ERROR(2)。
+    daemon 起不来是 infra 前置失败 → -1006 + exit 2（#92 修复）。"""
     import argparse
     import json as _json
 
@@ -651,7 +652,7 @@ def test_cmd_run_emits_envelope_on_daemon_start_failure(
     assert rc == EXIT_INFRA_ERROR
     payload = _json.loads(out)
     assert payload["ok"] is False
-    assert payload["error"]["code"] == -1003
+    assert payload["error"]["code"] == -1006
     assert "port already bound" in payload["error"]["message"]
 
 
@@ -2413,3 +2414,76 @@ def test_argparse_text_mode_error_no_json_on_stdout(
     assert not captured.out.strip(), f"--text 模式 stdout 不应有 JSON: {captured.out!r}"
     # stderr 应有错误信息
     assert captured.err.strip(), "stderr 应有错误信息"
+
+
+# ── Task A2: run/daemon 前置失败拆分 ─────────────────────────────────────────
+
+
+def test_cmd_daemon_start_daemonerror_exits_infra_with_1006(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """cmd_daemon_start DaemonError → -1006 (PRECONDITION) + EXIT_INFRA_ERROR(2)（#92）。"""
+    import json as _json
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control.cli import EXIT_INFRA_ERROR, OUTPUT_JSON, cmd_daemon_start
+
+    (tmp_path / "project.godot").write_text("", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    def _fake_start(self: Any, **__: Any) -> None:
+        raise daemon_mod.DaemonError("cannot find godot binary")
+
+    monkeypatch.setattr(daemon_mod.Daemon, "start", _fake_start)
+    monkeypatch.setattr("godot_cli_control.daemon.find_godot_binary", lambda: None)
+
+    ns = __import__("argparse").Namespace(
+        record=False,
+        movie_path=None,
+        headless=True,
+        gui=False,
+        fps=30,
+        port=0,
+        idle_timeout="0",
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_daemon_start(ns)
+    out = capsys.readouterr().out.strip()
+    assert rc == EXIT_INFRA_ERROR
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1006
+    assert "cannot find godot binary" in payload["error"]["message"]
+
+
+def test_cmd_daemon_stop_single_project_daemonerror_exits_infra_with_1006(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """cmd_daemon_stop 单项目 DaemonError → -1006 + EXIT_INFRA_ERROR(2)（#92）。"""
+    import json as _json
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control.cli import EXIT_INFRA_ERROR, OUTPUT_JSON, cmd_daemon_stop
+
+    def _fake_stop(self: Any) -> int:
+        raise daemon_mod.DaemonError("pid file not found")
+
+    monkeypatch.setattr(daemon_mod.Daemon, "stop", _fake_stop)
+
+    ns = __import__("argparse").Namespace(
+        all=False,
+        project=None,
+        output_format=OUTPUT_JSON,
+    )
+    monkeypatch.chdir(tmp_path)
+    rc = cmd_daemon_stop(ns)
+    out = capsys.readouterr().out.strip()
+    assert rc == EXIT_INFRA_ERROR
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1006
+    assert "pid file not found" in payload["error"]["message"]

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -2292,3 +2292,124 @@ def test_run_rpc_tree_truncated_envelope(
     assert envelope["result"]["tree"]["name"] == "root"
     # cmd_tree 应当把 ns.max_nodes 透传给 client.get_scene_tree
     mock_client.get_scene_tree.assert_awaited_once_with(depth=3, max_nodes=200)
+
+
+# ── Task A1: argparse 层用法错统一 -1003 + exit 64 ──────────────────────────
+
+
+def test_argparse_missing_required_positional_exits_64_with_envelope(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`get` 缺位置参数 → SystemExit code 64 + stdout 单行 {"ok": false, "error": {"code": -1003, ...}} + usage 在 stderr。"""
+    import json as _json
+
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["get"])
+    assert exc_info.value.code == 64
+
+    captured = capsys.readouterr()
+    # stdout 必须是单行 JSON 信封
+    out_lines = [ln for ln in captured.out.splitlines() if ln.strip()]
+    assert len(out_lines) == 1, f"stdout 不是单行: {captured.out!r}"
+    payload = _json.loads(out_lines[0])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    # usage 走 stderr
+    assert "usage" in captured.err.lower() or "get" in captured.err
+
+
+def test_argparse_invalid_choice_exits_64_with_envelope(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`wait-prop /n p 1 --op bogus`(非法 choices) → SystemExit code 64 + envelope。"""
+    import json as _json
+
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["wait-prop", "/root/Node", "scale", "1", "--op", "bogus"])
+    assert exc_info.value.code == 64
+
+    captured = capsys.readouterr()
+    out_lines = [ln for ln in captured.out.splitlines() if ln.strip()]
+    assert len(out_lines) == 1, f"stdout 不是单行: {captured.out!r}"
+    payload = _json.loads(out_lines[0])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+
+
+def test_argparse_unknown_subcommand_exits_64_with_envelope(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """未知子命令 → SystemExit code 64 + envelope。"""
+    import json as _json
+
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["nonexistent-command"])
+    assert exc_info.value.code == 64
+
+    captured = capsys.readouterr()
+    out_lines = [ln for ln in captured.out.splitlines() if ln.strip()]
+    assert len(out_lines) == 1, f"stdout 不是单行: {captured.out!r}"
+    payload = _json.loads(out_lines[0])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+
+
+def test_argparse_rpc_subcommand_missing_arg_exits_64_with_envelope(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`set` 只给一个参数(缺 value) → SystemExit code 64 + envelope。三层 subparser 继承。"""
+    import json as _json
+
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["set", "/root/Node"])
+    assert exc_info.value.code == 64
+
+    captured = capsys.readouterr()
+    out_lines = [ln for ln in captured.out.splitlines() if ln.strip()]
+    assert len(out_lines) == 1, f"stdout 不是单行: {captured.out!r}"
+    payload = _json.loads(out_lines[0])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+
+
+def test_argparse_help_exits_0(capsys: pytest.CaptureFixture[str]) -> None:
+    """`--help` → SystemExit 0（正常帮助，不是错误）。"""
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["--help"])
+    assert exc_info.value.code == 0
+
+
+def test_argparse_daemon_help_exits_0(capsys: pytest.CaptureFixture[str]) -> None:
+    """`daemon --help` → SystemExit 0。"""
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["daemon", "--help"])
+    assert exc_info.value.code == 0
+
+
+def test_argparse_text_mode_error_no_json_on_stdout(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--text` 模式用法错：stdout 无 JSON，人类可读错误走 stderr，仍 exit 64。"""
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["--text", "get"])
+    assert exc_info.value.code == 64
+
+    captured = capsys.readouterr()
+    # stdout 不应有 JSON
+    assert not captured.out.strip(), f"--text 模式 stdout 不应有 JSON: {captured.out!r}"
+    # stderr 应有错误信息
+    assert captured.err.strip(), "stderr 应有错误信息"

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -2416,6 +2416,46 @@ def test_argparse_text_mode_error_no_json_on_stdout(
     assert captured.err.strip(), "stderr 应有错误信息"
 
 
+def test_argparse_literal_text_after_dashdash_still_emits_json_envelope(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`combo -- --text extra`：`--text` 是 `--` 之后的位置参数值，不是旗标。
+
+    argparse 触发 unrecognized arguments 错误，此时 peek-parse 应把 `--text`
+    视为位置参数（`--` 终止符之后），故 _is_text_mode=False，
+    stdout 必须有单行 -1003 JSON 信封 + exit 64。
+    """
+    import json as _json
+
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["combo", "--", "--text", "extra"])
+    assert exc_info.value.code == 64
+
+    captured = capsys.readouterr()
+    out_lines = [ln for ln in captured.out.splitlines() if ln.strip()]
+    assert len(out_lines) == 1, f"stdout 应为单行 JSON 信封（字面 --text 不是旗标）: {captured.out!r}"
+    payload = _json.loads(out_lines[0])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+
+
+def test_argparse_text_mode_real_bypass_no_json_on_stdout(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`get --text`（缺参）：真 --text 旗路 → stdout 空 + stderr 有错 + exit 64。"""
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["--text", "get"])
+    assert exc_info.value.code == 64
+
+    captured = capsys.readouterr()
+    assert not captured.out.strip(), f"真 --text 旁路 stdout 不应有 JSON: {captured.out!r}"
+    assert captured.err.strip(), "stderr 应有错误信息"
+
+
 # ── Task A2: run/daemon 前置失败拆分 ─────────────────────────────────────────
 
 


### PR DESCRIPTION
## 改动

**#111 argparse 层用法错统一到 -1003 + exit 64**
- 新增 `_EnvelopeArgumentParser` 覆写 `error()`：usage 走 stderr，stdout 发单行 `{"ok": false, "error": {"code": -1003, ...}}` 信封，`SystemExit(64)`
- 三层 subparser（daemon 二级、RPC 三级）经 `parser_class` 继承自动生效；`--help` 仍 exit 0
- `--text`/`--no-json` 旁路用 peek-parse 判定（与真 parser 共用 `_add_output_format_flags`，尊重 `--` 终止符与 `--json` 后者胜出语义），杜绝字面量 `--text` 值误判

**#92 run/daemon 前置失败混合拆分**
- 新增 `CLIENT_CODE_PRECONDITION = -1006`（infra 前置失败，恒 exit 2）
- 用法错归 64：脚本路径不存在（原 2）、缺 `run(bridge)`（原 1）→ `-1003` + exit 64
- 真 infra 保持 2 换码：`cmd_run`/`cmd_daemon_start`/`cmd_daemon_stop` 的 `DaemonError` → `-1006` + exit 2
- `stop --all` 部分失败语义（EXIT_PARTIAL=3）不变

**契约结果：`-1003` ⇔ exit 64、`-1006` ⇔ exit 2 双射成立，单 code 字段无歧义。**

## BREAKING（对下游 agent 脚本）

- argparse 用法错（缺参/非法 choices/未知子命令）退出码 **2 → 64**
- `run` 脚本路径不存在 **2 → 64**；缺 `run(bridge)` **1 → 64**
- daemon 起不来等前置失败错误码 **-1003 → -1006**（退出码仍 2）
- SKILL.md / addon README / CLAUDE.md / CHANGELOG 已全家桶同步，含迁移指引

## 验证

- pytest 全量 455+ passed / 2 skipped（平台条件），覆盖率 96%；ruff 干净
- 两阶段评审（spec 合规 + 代码质量）各一轮修复后 Approved
- 手测矩阵：缺参/非法 choices/未知子命令/三层子命令缺参 → 64+信封；`--help` → 0；`--text` 旁路、`-- --text` 字面量、`--text --json` 胜出序全覆盖

Closes #111
Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)