### PR TITLE
chore: 遗留小杂项批次 —— wait_signal reason / get 打磨 / codec 哨兵文档 / fixture scope（#110 #112 #107 #113）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,4 +85,4 @@ release.sh                  # 发版脚本
 
 ## 已知遗留 issue（PR 路过时顺手修）
 
-*（截至 2026-05-16，AI 友好性 review 列出的 7 项 + SKILL/-h vs 代码对齐 review（退出码 3、daemon ls / stop --all / status stopped 字段、1003 含 InputMap action、wait-time 0..3600、ffmpeg 失败传染、screenshot retry 帧数等）已全部 land。下次 review 发现新坑请补到这里。）*
+*（截至 2026-06-04，已 land：#96/#97/#99/#100 三连 PR（wait 原语/codec/多属性读）、#111/#92 退出码语义统一、#108 wait_api 拆分、#110 wait_signal reason 字段、#112 get 路径打磨、#107 codec 深度哨兵文档、#113 probe fixture scope。仍 open：#109（KIV）；#98/#101/#102/#103（feature backlog）；#88、#18。下次 review 发现新坑请补到这里。）*

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **#110 `wait_signal` 超时与节点释放可区分**：未命中时返回体新增 `reason` 字段，值为 `"timeout"`（信号在超时前未发射）或 `"node_freed"`（等待期间目标节点被释放）。命中路径（`emitted: true`）不含 `reason`，对齐 `wait_property` matched 时无 reason 的约定。非 BREAKING（新增可选字段）。
+
 ### Fixed (BREAKING — exit code changes)
 
 - **#111 argparse 用法错 exit 2 → exit 64**: 所有 argparse 层错误（缺位置参数、非法 choices、未知子命令等）现在统一输出 `-1003` 信封并以 exit 64 退出。之前是 exit 2（argparse 默认）。影响：脚本若用 `[ $? -eq 2 ]` 判 argparse 错需改为 `[ $? -eq 64 ]`。

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -96,7 +96,7 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 | `wait_for_node(path, timeout)` | `await client.wait_for_node("/root/Boss", timeout=10.0)` |
 | `wait_game_time(seconds)` | `await client.wait_game_time(2.5)` |
 | `wait_property(path, prop, value, op, timeout, tolerance)` | `await client.wait_property("/root/Player", "position:x", 500, op="gt", timeout=3.0)` |
-| `wait_signal(path, signal, timeout)` | `await client.wait_signal("/root/Game", "level_complete", timeout=10.0)` |
+| `wait_signal(path, signal, timeout)` | `await client.wait_signal("/root/Game", "level_complete", timeout=10.0)` — miss result includes `reason: "timeout"\|"node_freed"` |
 | `wait_frames(frames, physics)` | `await client.wait_frames(4)` |
 | `action_press(action)` | `await client.action_press("jump")` |
 | `action_release(action)` | `await client.action_release("jump")` |
@@ -115,6 +115,10 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 > **Event pipeline**: `press` / `tap` / `hold` / `combo` inject an `InputEventAction` through the engine's event pipeline — both polling (`is_action_pressed`, `get_vector`) **and** event callbacks (`_input`, `_unhandled_input`) see the input. `InputEventAction` carries no mouse coordinates; position-dependent `_gui_input` widgets need `click` instead.
 
 > **No-arg `GameClient()` / `GameBridge()`**: with no `port` argument they auto-discover the daemon's port from `.cli_control/port` (falling back to `9877`), so a single-connection script connects to a running daemon without hardcoding a port.
+
+### Variant encoding depth limit
+
+`get` encodes property values recursively. Containers nested deeper than **64 levels**, or self-referencing containers, are replaced with the sentinel string `"<max-depth-exceeded>"`. If you see it, narrow your read using a sub-path (`get /root/Node mydict:somekey`).
 
 ### Error codes
 

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -130,7 +130,7 @@ func _read_property(node: Node, property: String) -> Dictionary:
 	if property.is_empty():
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'property' parameter")
 	var is_sub_path: bool = ":" in property
-	var top_level: String = property.split(":", true, 1)[0] if is_sub_path else property
+	var top_level: String = _top_level_of(property)
 	if not _has_property(node, top_level):
 		return _err(CliControlErrorCodes.PROPERTY_NOT_FOUND, "Property not found: %s" % top_level)
 	if is_sub_path:
@@ -153,18 +153,18 @@ func handle_get_properties(params: Dictionary) -> Dictionary:
 		if not raw_prop is String or (raw_prop as String).is_empty():
 			return _err(CliControlErrorCodes.INVALID_PARAMS, "'properties' must be a non-empty array of strings")
 		var prop_name: String = raw_prop as String
-		var top_level: String = prop_name.split(":", true, 1)[0] if ":" in prop_name else prop_name
+		var top_level: String = _top_level_of(prop_name)
 		if not _has_property(node, top_level):
 			missing.append(prop_name)
 	if not missing.is_empty():
 		return _err(CliControlErrorCodes.PROPERTY_NOT_FOUND, "Properties not found: %s" % ", ".join(missing))
 	var values: Dictionary = {}
-	for raw_prop2: Variant in props:
-		var prop_name2: String = raw_prop2 as String
-		var read: Dictionary = _read_property(node, prop_name2)
+	for raw_prop: Variant in props:
+		var prop_name: String = raw_prop as String
+		var read: Dictionary = _read_property(node, prop_name)
 		if read.has("error"):
 			return read  # 防御纵深：上面已全量校验，理论到不了这里
-		values[prop_name2] = CliControlVariantCodec.encode(read["value"])
+		values[prop_name] = CliControlVariantCodec.encode(read["value"])
 	return {"values": values}
 
 
@@ -180,7 +180,7 @@ func handle_set_property(params: Dictionary) -> Dictionary:
 	# 前的 top-level 名重新过一次，否则 "script:source_code" / "texture:resource_path"
 	# 这类嵌套写入会绕开 blacklist；整串也走一次（防御深度，万一未来加非冒号反射子路径）。
 	var is_sub_path: bool = ":" in property
-	var top_level: String = property.split(":", true, 1)[0] if is_sub_path else property
+	var top_level: String = _top_level_of(property)
 	if property in _property_blacklist or top_level in _property_blacklist:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "Blocked property: %s" % property)
 	var value: Variant = params.get("value", null)
@@ -482,6 +482,14 @@ func take_screenshot_async() -> Dictionary:
 func _get_node_or_error(params: Dictionary) -> Node:
 	var path: String = params.get("path", "") as String
 	return get_tree().root.get_node_or_null(path)
+
+
+## sub-path "position:x" → "position"；无冒号直接返回原值。
+## 集中替代三处 `property.split(":", true, 1)[0]` 字面重复（issue #112）。
+func _top_level_of(property: String) -> String:
+	if ":" in property:
+		return property.split(":", true, 1)[0]
+	return property
 
 
 func _node_not_found(path: String) -> Dictionary:

--- a/addons/godot_cli_control/bridge/wait_api.gd
+++ b/addons/godot_cli_control/bridge/wait_api.gd
@@ -232,17 +232,19 @@ func wait_signal_async(params: Dictionary) -> Dictionary:
 	var cb: Callable = capture.callable_for(argc)
 	node.connect(signal_name, cb, CONNECT_ONE_SHOT)
 	var start_ms: int = Time.get_ticks_msec()
+	var reason: String = "timeout"
 	while not capture.fired:
 		if float(Time.get_ticks_msec() - start_ms) / 1000.0 >= timeout:
 			break
 		await get_tree().process_frame
 		if not is_instance_valid(node):
+			reason = "node_freed"
 			break  # 节点被释放：连接随之失效，按未命中处理
 	if not capture.fired:
 		# one-shot 未触发时连接仍挂着，必须显式清理（防悬挂 Callable 泄漏）
 		if is_instance_valid(node) and node.is_connected(signal_name, cb):
 			node.disconnect(signal_name, cb)
-		return {"emitted": false}
+		return {"emitted": false, "reason": reason}
 	var encoded_args: Array = []
 	for arg: Variant in capture.args:
 		encoded_args.append(CliControlVariantCodec.encode(arg))

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -807,12 +807,9 @@ func test_get_properties_missing_prop_fails_atomically_naming_all() -> void:
 func test_get_property_object_type_returns_string_type_field() -> void:
 	## handle_get_property 读 Object 属性 → codec 编码为 {"value": "<str>", "type": "Object"}
 	## 检验 handler → codec 全链路（codec 单测已覆盖 encode，这里测 handler 调 codec 的接缝）。
-	## Node.get_viewport() 返回 Viewport（Object 子类），是内置可用的 Object 属性。
+	## 用 Node 的 "multiplayer" 属性（MultiplayerAPI，headless 下恒非 null）作内置 Object 属性。
 	var node := Node2D.new()
 	add_child_autofree(node)
-	# "owner" 在未 add_child 前是 null，不适合测 Object 值。
-	# Node.get_viewport() 是方法而非属性。找一个内置 Object 类型属性：
-	# Node 的 "multiplayer" 属性是 MultiplayerAPI（Object 子类）且总有非 null 值。
 	var result: Dictionary = _api.handle_get_property({
 		"path": str(node.get_path()), "property": "multiplayer",
 	})
@@ -823,11 +820,7 @@ func test_get_property_object_type_returns_string_type_field() -> void:
 
 func test_get_property_stringname_type_returns_string_type_field() -> void:
 	## handle_get_property 读 StringName 属性 → codec 编码为 {"value": "<str>", "type": "StringName"}
-	## Node "scene_file_path" 是 String，不是 StringName。
-	## AnimationPlayer.current_animation 是 String。
-	## 用自定义 fixture 节点持有 StringName 类型属性来测。
-	## Node.name 在 GDScript 里是 String（不是 StringName），无法直接用内置属性。
-	## 改用 custom fixture：
+	## 内置属性在 GDScript 暴露面里都是 String（如 Node.name），用自建 fixture 持有 StringName。
 	var fixture := _StringNameFixture.new()
 	add_child_autofree(fixture)
 	var result: Dictionary = _api.handle_get_property({

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -22,6 +22,11 @@ class _CoerceFixture extends Node:
 	var test_object: Object = null
 
 
+# issue #112：handler → codec 接缝测试 —— StringName 属性 fixture
+class _StringNameFixture extends Node:
+	var test_sn: StringName = &"hello"
+
+
 var _api: Node
 var _target: Node
 
@@ -795,6 +800,43 @@ func test_get_properties_missing_prop_fails_atomically_naming_all() -> void:
 	assert_eq(int(result.error.code), 1002)
 	assert_string_contains(str(result.error.message), "nope1")
 	assert_string_contains(str(result.error.message), "nope2")
+
+
+# ── issue #112：handle_get_property → codec 接缝测试（Object / StringName） ──
+
+func test_get_property_object_type_returns_string_type_field() -> void:
+	## handle_get_property 读 Object 属性 → codec 编码为 {"value": "<str>", "type": "Object"}
+	## 检验 handler → codec 全链路（codec 单测已覆盖 encode，这里测 handler 调 codec 的接缝）。
+	## Node.get_viewport() 返回 Viewport（Object 子类），是内置可用的 Object 属性。
+	var node := Node2D.new()
+	add_child_autofree(node)
+	# "owner" 在未 add_child 前是 null，不适合测 Object 值。
+	# Node.get_viewport() 是方法而非属性。找一个内置 Object 类型属性：
+	# Node 的 "multiplayer" 属性是 MultiplayerAPI（Object 子类）且总有非 null 值。
+	var result: Dictionary = _api.handle_get_property({
+		"path": str(node.get_path()), "property": "multiplayer",
+	})
+	assert_does_not_have(result, "error", "multiplayer 是合法 Object 属性，不应报错")
+	assert_eq(result.get("type"), "Object", "Object 类型属性必须带 type=Object 字段")
+	assert_true(result.get("value") is String, "Object 编码应是字符串（str(obj)）")
+
+
+func test_get_property_stringname_type_returns_string_type_field() -> void:
+	## handle_get_property 读 StringName 属性 → codec 编码为 {"value": "<str>", "type": "StringName"}
+	## Node "scene_file_path" 是 String，不是 StringName。
+	## AnimationPlayer.current_animation 是 String。
+	## 用自定义 fixture 节点持有 StringName 类型属性来测。
+	## Node.name 在 GDScript 里是 String（不是 StringName），无法直接用内置属性。
+	## 改用 custom fixture：
+	var fixture := _StringNameFixture.new()
+	add_child_autofree(fixture)
+	var result: Dictionary = _api.handle_get_property({
+		"path": str(fixture.get_path()), "property": "test_sn",
+	})
+	assert_does_not_have(result, "error", "test_sn 是合法 StringName 属性，不应报错")
+	assert_eq(result.get("type"), "StringName", "StringName 属性必须带 type=StringName 字段")
+	assert_true(result.get("value") is String, "StringName 编码应转为普通 String")
+	assert_eq(result.get("value"), "hello", "StringName 值应正确编码为原始字串")
 
 
 func test_get_properties_rejects_empty_or_non_string() -> void:

--- a/addons/godot_cli_control/tests/gut/test_wait_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_wait_api.gd
@@ -228,3 +228,46 @@ func test_wait_property_without_setup_returns_internal_error() -> void:
 	assert_has(result, "error", "未 setup 的 WaitApi 应返回 error 信封")
 	assert_eq(int(result.error.code), -32603,
 		"未 setup 应报 -32603 internal error，实际 code=%d" % [int(result.error.code)])
+
+
+# ── issue #110：wait_signal reason 字段 ──
+
+func test_wait_signal_timeout_has_reason_timeout() -> void:
+	## 真超时 → {"emitted": false, "reason": "timeout"}
+	var emitter := Node.new()
+	emitter.add_user_signal("never_fires_2")
+	add_child_autofree(emitter)
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "never_fires_2", "timeout": 0.1,
+	})
+	assert_false(result["emitted"])
+	assert_has(result, "reason", "超时应有 reason 字段")
+	assert_eq(result["reason"], "timeout")
+
+
+func test_wait_signal_node_freed_has_reason_node_freed() -> void:
+	## 等待中把目标节点 free() → {"emitted": false, "reason": "node_freed"}
+	var emitter := Node.new()
+	emitter.add_user_signal("fleeting_sig")
+	add_child_autofree(emitter)
+	# 50ms 后释放节点，timeout 留足余量确保先 free 后 timeout
+	get_tree().create_timer(0.05).timeout.connect(func() -> void: emitter.free())
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "fleeting_sig", "timeout": 2.0,
+	})
+	assert_false(result["emitted"])
+	assert_has(result, "reason", "节点释放应有 reason 字段")
+	assert_eq(result["reason"], "node_freed")
+
+
+func test_wait_signal_emitted_has_no_reason() -> void:
+	## 命中信号 → {"emitted": true, "args": [...]} 不含 reason 字段（对齐 wait_property matched 时无 reason）
+	var emitter := Node.new()
+	emitter.add_user_signal("fires_soon", [{"name": "n", "type": TYPE_INT}])
+	add_child_autofree(emitter)
+	get_tree().create_timer(0.05).timeout.connect(func() -> void: emitter.emit_signal("fires_soon", 7))
+	var result: Dictionary = await _api.wait_signal_async({
+		"path": str(emitter.get_path()), "signal": "fires_soon", "timeout": 2.0,
+	})
+	assert_true(result["emitted"])
+	assert_does_not_have(result, "reason", "命中信号时不应有 reason 字段")

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -182,7 +182,7 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 - `wait-node <path> [timeout]` — block until node appears (exit 0=found, 1=timeout)
 - `wait-time <seconds>` — wait N in-game seconds (matters for `--write-movie`). Server bounds: `0 ≤ seconds ≤ 3600`; passing out-of-range gets `-32602 "seconds must be ..."`. Client short-circuits `seconds <= 0` without an RPC.
 - `wait-prop <path> <prop> <json-value> [--op eq|ne|gt|lt|ge|le] [--timeout N] [--tolerance N]` — block until property satisfies condition (exit 0=matched, 1=timeout). Example: `wait-prop /root/Player position:x 500 --op gt`. Default `--op eq`, `--timeout 5.0`, `--tolerance 0.0`.
-- `wait-signal <path> <signal> [--timeout N]` — block until signal fires (exit 0=emitted, 1=timeout). Result: `{"emitted": bool, "args": [...]}`.
+- `wait-signal <path> <signal> [--timeout N]` — block until signal fires (exit 0=emitted, 1=timeout). Result on success: `{"emitted": true, "args": [...]}`. Result on miss: `{"emitted": false, "reason": "timeout"|"node_freed"}` — `"timeout"` means the signal never fired within the deadline; `"node_freed"` means the target node was freed during the wait (use this to distinguish a race from a stale path).
 - `wait-frames <N> [--physics]` — advance exactly N process frames (or physics frames with `--physics`). Result: `{"success": true, "frames": N}`.
 
 **Render:**
@@ -250,6 +250,10 @@ godot-cli-control call /root/Game start 42 easy --text-value # ✓ calls with ("
 ```
 
 Use this when generating commands from a template — it removes the three-quote escaping headache (`'"null"'`).
+
+### Variant encoding depth limit
+
+`get` encodes property values recursively. Containers (Arrays, Dictionaries) nested deeper than **64 levels**, or self-referencing containers, are replaced with the sentinel string `"<max-depth-exceeded>"` rather than causing an error or hang. The sentinel is a diagnostic signal — not game data. If you see it, narrow your read: use a sub-path (`get /root/Node mydict:somekey`) or restructure your property access to avoid deeply nested containers.
 
 ### Tree truncation
 

--- a/python/tests/test_e2e_input.py
+++ b/python/tests/test_e2e_input.py
@@ -200,7 +200,7 @@ def test_abnormal_disconnect_releases_held_inputs(daemon: Any) -> None:
     assert _pressed(project) == [], "异常掉线应触发 release_all 清掉持有输入"
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def probe_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """带 probe.gd（_unhandled_input 探针）的独立 Godot 项目，用于 issue #97 e2e。"""
     proj = tmp_path_factory.mktemp("gcc_e2e_probe")

--- a/python/tests/test_e2e_input.py
+++ b/python/tests/test_e2e_input.py
@@ -202,7 +202,11 @@ def test_abnormal_disconnect_releases_held_inputs(daemon: Any) -> None:
 
 @pytest.fixture(scope="module")
 def probe_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """带 probe.gd（_unhandled_input 探针）的独立 Godot 项目，用于 issue #97 e2e。"""
+    """带 probe.gd（_unhandled_input 探针）的独立 Godot 项目，用于 issue #97 e2e。
+
+    module scope 对齐 godot_project 先例（#113）：全量 import ~12s，后续 probe 类
+    e2e 复用同一项目目录；消费测试自管 daemon 起停，无跨用例状态。
+    """
     proj = tmp_path_factory.mktemp("gcc_e2e_probe")
     (proj / "addons").mkdir()
     shutil.copytree(_ADDON_SRC, proj / "addons" / "godot_cli_control")


### PR DESCRIPTION
## 改动

**#110 wait_signal 超时与节点释放可区分**
- 未命中返回加 `reason: "timeout" | "node_freed"`（对齐 wait_property 的 reason 模式）；命中路径不变、无 reason
- GUT 三态测试（timeout / node_freed / 命中无 reason）；SKILL.md / README / CHANGELOG 同步

**#112 get 路径打磨**
- `raw_prop2`/`prop_name2` 防御性数字后缀去除
- 抽 `_top_level_of()` 消除三处 `property.split(":", true, 1)[0]` 字面重复（行为不变）
- 补 handler↔codec 接缝 GUT 测试 ×2（Object / StringName 值属性的信封形态）

**#107 codec 深度哨兵文档**
- SKILL.md 模板 + addon README 补：编码递归深度上限 64、超深/自引用降级为 `"<max-depth-exceeded>"` 哨兵、agent 应缩小读取范围（sub-path）而非当作游戏数据

**#113 probe_project fixture 升 module scope**
- 对齐 `godot_project` 先例，全量 import（~12s）只跑一次；消费测试自管 daemon 起停无跨用例状态（注释已说明）

**收尾**：项目 CLAUDE.md「已知遗留 issue」段更新为 2026-06-04 批次后的状态。

## 验证

- GUT 145/145（+5：3 reason 三态 + 2 接缝）
- pytest 全量 457 passed / 2 skipped，覆盖率 96%；ruff 干净
- 两阶段评审通过（spec 一次过；质量 Approved，非阻塞建议已顺手清理）

Closes #110
Closes #112
Closes #107
Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)