### PR TITLE
chore: peek parser stderr 降噪 + Object 接缝测试自建 fixture（#118 #119）

### DIFF
--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -27,6 +27,12 @@ class _StringNameFixture extends Node:
 	var test_sn: StringName = &"hello"
 
 
+# issue #119：handler → codec 接缝测试 —— Object 引用属性 fixture
+# （自建属性，不依赖 Node.multiplayer 等内置属性的版本演化语义）
+class _ObjectFixture extends Node:
+	var test_obj: RefCounted = RefCounted.new()
+
+
 var _api: Node
 var _target: Node
 
@@ -807,15 +813,18 @@ func test_get_properties_missing_prop_fails_atomically_naming_all() -> void:
 func test_get_property_object_type_returns_string_type_field() -> void:
 	## handle_get_property 读 Object 属性 → codec 编码为 {"value": "<str>", "type": "Object"}
 	## 检验 handler → codec 全链路（codec 单测已覆盖 encode，这里测 handler 调 codec 的接缝）。
-	## 用 Node 的 "multiplayer" 属性（MultiplayerAPI，headless 下恒非 null）作内置 Object 属性。
-	var node := Node2D.new()
-	add_child_autofree(node)
+	## 用自建 fixture 持有 Object 引用属性（issue #119：不依赖内置 multiplayer
+	## 属性的版本演化语义；内容断言只锚类名，不锚 str(obj) 的实例 id 部分）。
+	var fixture := _ObjectFixture.new()
+	add_child_autofree(fixture)
 	var result: Dictionary = _api.handle_get_property({
-		"path": str(node.get_path()), "property": "multiplayer",
+		"path": str(fixture.get_path()), "property": "test_obj",
 	})
-	assert_does_not_have(result, "error", "multiplayer 是合法 Object 属性，不应报错")
+	assert_does_not_have(result, "error", "test_obj 是合法 Object 属性，不应报错")
 	assert_eq(result.get("type"), "Object", "Object 类型属性必须带 type=Object 字段")
 	assert_true(result.get("value") is String, "Object 编码应是字符串（str(obj)）")
+	# 内容断言锚类名（str(obj) 形如 <RefCounted#id>），不锚实例 id 部分
+	assert_string_contains(str(result.get("value")), "RefCounted")
 
 
 func test_get_property_stringname_type_returns_string_type_field() -> void:

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1678,6 +1678,17 @@ def _add_output_format_flags(p: argparse.ArgumentParser) -> None:
     )
 
 
+class _QuietPeekParser(argparse.ArgumentParser):
+    """peek-parse 专用：error() 不往 stderr 打 usage/error，直接抛 SystemExit。
+
+    peek parser 自身解析失败（如 `--text=x`）属预期内分支（调用方 catch 后
+    回落 JSON 信封），不应在 stderr 留下第二段 usage 噪声（#118）。
+    """
+
+    def error(self, message: str) -> NoReturn:
+        raise SystemExit(2)
+
+
 class _EnvelopeArgumentParser(argparse.ArgumentParser):
     """覆写 argparse 的 error() —— 把用法错统一进 JSON 信封 + exit 64。
 
@@ -1705,8 +1716,9 @@ class _EnvelopeArgumentParser(argparse.ArgumentParser):
         self.print_usage(sys.stderr)
         # --text / --no-json 旁路判定：用 peek-parse 而非 token 扫描，
         # 避免 `--` 之后的字面量 --text 被误判为 text 模式旗标。
-        # peek parser 是普通 ArgumentParser（非 _EnvelopeArgumentParser），避免递归。
-        _peek = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+        # peek parser 用 _QuietPeekParser（非 _EnvelopeArgumentParser），
+        # 既避免递归、也避免解析失败时往 stderr 重复打 usage（#118）。
+        _peek = _QuietPeekParser(add_help=False, allow_abbrev=False)
         _add_output_format_flags(_peek)
         _is_text_mode = False
         try:

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -2441,6 +2441,33 @@ def test_argparse_literal_text_after_dashdash_still_emits_json_envelope(
     assert payload["error"]["code"] == -1003
 
 
+def test_argparse_peek_parse_failure_no_extra_usage_on_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`get --text=x`（store_const 不接受显式值）：peek parser 自身解析失败时
+    不得往 stderr 追加它自己的 usage/error 行，stderr 只保留真 parser 的
+    单段 usage；stdout 的 -1003 信封契约不变（#118）。
+    """
+    import json as _json
+
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["get", "--text=x", "/root/Foo", "name"])
+    assert exc_info.value.code == 64
+
+    captured = capsys.readouterr()
+    out_lines = [ln for ln in captured.out.splitlines() if ln.strip()]
+    assert len(out_lines) == 1, f"stdout 应为单行 JSON 信封: {captured.out!r}"
+    payload = _json.loads(out_lines[0])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    # stderr 只允许真 parser 打的一段 usage；peek parser 的不该出现
+    assert captured.err.count("usage:") == 1, (
+        f"stderr 出现 peek parser 的冗余 usage/error 行: {captured.err!r}"
+    )
+
+
 def test_argparse_text_mode_real_bypass_no_json_on_stdout(
     capsys: pytest.CaptureFixture[str],
 ) -> None:


### PR DESCRIPTION
## Summary

review 收尾两连修（均为 2026-06-04 quality review 标记的 P4 非阻塞项）：

### #118 peek parser stderr usage 噪声
- `_EnvelopeArgumentParser.error()` 的 peek-parse 在遇到 `--text=x`（store_const 不接受显式值）这类 token 时，peek parser 自身会先往 stderr 打一行它自己的 usage + error 才抛 `SystemExit`，stderr 出现两段 usage 噪声
- 修复：新增 `_QuietPeekParser`，覆写 `error()` 直接抛 `SystemExit` 不打印；stdout 的 `-1003` JSON 信封 + exit 64 契约不变
- 测试：新增 `test_argparse_peek_parse_failure_no_extra_usage_on_stderr`，断言 stderr 仅一段 usage（TDD：先 RED 后 GREEN）

### #119 GUT Object 接缝用例断言偏软
- `test_get_property_object_type_returns_string_type_field` 原依赖 `Node.multiplayer` 内置属性恒非 null（Godot 版本演化可能调整），且只断 `value is String`
- 修复：改用自建 `_ObjectFixture`（对齐 `_StringNameFixture` 先例）持有 `RefCounted` 引用属性，加 `assert_string_contains(value, "RefCounted")` 类名级内容断言（不锚 `str(obj)` 的实例 id 部分）

Fixes #118
Fixes #119

## Test plan
- [x] Python 全量：458 passed / 2 skipped，覆盖率 89%（门槛 80%）
- [x] GUT 全量：145/145 通过（含改后的 Object 接缝用例）

🤖 Generated with [Claude Code](https://claude.com/claude-code)