### PR TITLE
feat(scene): scene-reload/scene-change + pytest fresh_scene（#98）

### DIFF
--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -138,10 +138,10 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `1008` | server | Scene unavailable (`scene-reload` / `scene-change`): no current scene, scene file missing / failed to load, or timed out waiting for the new scene to become ready. Fix the path (permanent) or inspect the daemon log (timeout). |
 | `-32600` | server | Malformed JSON-RPC request |
 | `-32601` | server | Unknown method name |
-| `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements, or `hold` given `duration ≤ 0` — use `press` for an indefinite hold) |
+| `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements, or `hold` given `duration ≤ 0` — use `press` for an indefinite hold; also out-of-range values like a scene `timeout` outside `(0, 3600]` sent directly via `GameClient`) |
 | `-1001` | client | Connection failure (daemon not running, port wrong, proxy hijacking localhost) |
 | `-1002` | client | Timeout waiting for response |
-| `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, a non-numeric `tap`/`wait-time` arg, a `set`/`call` value that fails JSON parsing, script path not found, or script missing `run(bridge)`). Always exits **64** (#82 / #111). |
+| `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, a non-numeric `tap`/`wait-time` arg, a `scene-change` path not starting with `res://`/`uid://`, a `scene-reload`/`scene-change` `--timeout` outside `(0, 3600]`, a `set`/`call` value that fails JSON parsing, script path not found, or script missing `run(bridge)`). Always exits **64** (#82 / #111). |
 | `-1004` | client | Local file IO error (e.g. screenshot can't write the destination) |
 | `-1005` | client | `run <script>` user script raised an uncaught exception — fix the script |
 | `-1006` | client | Infra pre-condition failure (`daemon start`/`stop`/`run` auto-start failed at OS level — port conflict, Godot binary not found, etc.). Always exits **2** (#92). |

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -107,6 +107,8 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 | `release_all()` | `await client.release_all()` |
 | `get_pressed()` | `await client.get_pressed()` |
 | `list_input_actions(include_builtin=False)` | `await client.list_input_actions()` |
+| `scene_reload(timeout)` | `await client.scene_reload(timeout=10.0)` — reload current scene, block until ready; CLI: `scene-reload [--timeout N]` |
+| `scene_change(path, timeout)` | `await client.scene_change("res://levels/l2.tscn", timeout=10.0)` — switch scene, block until ready; CLI: `scene-change <res://path.tscn> [--timeout N]` |
 
 > **CLI note**: as a shell subcommand, `screenshot` **requires an output path** — `godot-cli-control screenshot /tmp/shot.png` — and writes the PNG to that file. Returning base64 over stdout is intentionally unsupported, to keep large binary payloads out of an automating agent's context window.
 
@@ -133,6 +135,7 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `1005` | server | Scene tree too large (lower `depth` or pass `--max-nodes`) |
 | `1006` | server | Resource transiently unavailable (e.g. screenshot during scene transition). Rare under normal use — GameBridge waits for viewport first-frame before listening, and `screenshot` retries internally. Safe to retry if you do hit it. |
 | `1007` | server | Signal not found on the node (`wait-signal` schema error — signal name typo or the node doesn't define it). Permanent — don't retry; inspect with `tree` or `children` to find valid signals. |
+| `1008` | server | Scene unavailable (`scene-reload` / `scene-change`): no current scene, scene file missing / failed to load, or timed out waiting for the new scene to become ready. Fix the path (permanent) or inspect the daemon log (timeout). |
 | `-32600` | server | Malformed JSON-RPC request |
 | `-32601` | server | Unknown method name |
 | `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements, or `hold` given `duration ≤ 0` — use `press` for an indefinite hold) |

--- a/addons/godot_cli_control/bridge/error_codes.gd
+++ b/addons/godot_cli_control/bridge/error_codes.gd
@@ -24,6 +24,11 @@ const SCENE_TREE_TOO_LARGE: int = 1005
 const RESOURCE_UNAVAILABLE: int = 1006
 # 信号不存在（wait_signal 的 schema 错，永久性——与 1003 method、1002 property 同族）
 const SIGNAL_NOT_FOUND: int = 1007
+# 场景不可用（issue #98 scene_reload/scene_change）：reload 时无 current
+# scene、change 的 res 路径不存在/加载失败、等新场景 ready 超时。
+# 与 1006 拆开：1006 是「短重试可能成功」的 transient；1008 三种情形里
+# 路径不存在是永久错，超时大概率是场景加载本身坏了——agent 应停下排查。
+const SCENE_UNAVAILABLE: int = 1008
 
 const INVALID_PARAMS: int = -32602
 const INVALID_REQUEST: int = -32600

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -219,7 +219,7 @@ func _register_methods() -> void:
 	}
 	# 输入模拟（async_with_id：handler 自行通过 _on_async_response 回响）
 	_methods["input_combo"] = {"callable": _input_sim_api.handle_combo, "kind": "async_with_id"}
-	# Scene API（异步，issue #98）
+	# Scene API（异步）
 	_methods["scene_reload"] = {"callable": _scene_api.scene_reload_async, "kind": "async"}
 	_methods["scene_change"] = {"callable": _scene_api.scene_change_async, "kind": "async"}
 

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -28,6 +28,7 @@ var _outbound_buffer_size: int = DEFAULT_OUTBOUND_BUFFER_MB * 1024 * 1024
 var _low_level_api: LowLevelApi = null
 var _input_sim_api: InputSimulationApi = null
 var _wait_api: WaitApi = null
+var _scene_api: SceneApi = null
 # 方法注册表：{method_name: {"callable": Callable, "kind": "sync"|"async"|"async_with_id"}}
 # - sync: handler(params) -> Dictionary，dispatcher 立即 send response
 # - async: handler(params) -> await Dictionary，dispatcher await 后 send response
@@ -59,6 +60,9 @@ func _ready() -> void:
 	_wait_api.name = "WaitApi"
 	add_child(_wait_api)
 	_wait_api.setup(_low_level_api._read_property)
+	_scene_api = SceneApi.new()
+	_scene_api.name = "SceneApi"
+	add_child(_scene_api)
 	# 构建统一方法注册表
 	_register_methods()
 	# 缓存 outbound buffer 大小（ProjectSettings 可覆盖默认 10MB，至少 1MB）
@@ -215,6 +219,9 @@ func _register_methods() -> void:
 	}
 	# 输入模拟（async_with_id：handler 自行通过 _on_async_response 回响）
 	_methods["input_combo"] = {"callable": _input_sim_api.handle_combo, "kind": "async_with_id"}
+	# Scene API（异步，issue #98）
+	_methods["scene_reload"] = {"callable": _scene_api.scene_reload_async, "kind": "async"}
+	_methods["scene_change"] = {"callable": _scene_api.scene_change_async, "kind": "async"}
 
 
 # screenshot wrapper：take_screenshot_async 不接 params，统一签名为 (params) -> Dictionary

--- a/addons/godot_cli_control/bridge/scene_api.gd
+++ b/addons/godot_cli_control/bridge/scene_api.gd
@@ -1,0 +1,85 @@
+class_name SceneApi
+extends Node
+## 场景生命周期 API：scene_reload / scene_change（issue #98）
+##
+## 两者都等新场景 ready 才返回（逐帧轮询，模式对齐 wait_api.gd），
+## 调用方不需要再 wait-node。错误码常量来自 error_codes.gd。
+
+# 等新场景 ready 的超时上限 / 默认值（秒）
+const _MAX_SCENE_TIMEOUT: float = 3600.0
+const _DEFAULT_TIMEOUT: float = 10.0
+
+
+func scene_reload_async(params: Dictionary) -> Dictionary:
+	var timeout_or_err: Variant = _parse_timeout(params)
+	if timeout_or_err is Dictionary:
+		return timeout_or_err as Dictionary
+	var timeout: float = timeout_or_err as float
+	var old: Node = get_tree().current_scene
+	if old == null:
+		return _err(CliControlErrorCodes.SCENE_UNAVAILABLE, "no current scene to reload")
+	var err: int = get_tree().reload_current_scene()
+	if err != OK:
+		return _err(
+			CliControlErrorCodes.SCENE_UNAVAILABLE,
+			"reload_current_scene failed: %s" % error_string(err),
+		)
+	return await _await_new_scene_ready(old, timeout)
+
+
+func scene_change_async(params: Dictionary) -> Dictionary:
+	var path_raw: Variant = params.get("path", null)
+	if not (path_raw is String) or (path_raw as String).is_empty():
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'path' parameter")
+	var path: String = path_raw as String
+	var timeout_or_err: Variant = _parse_timeout(params)
+	if timeout_or_err is Dictionary:
+		return timeout_or_err as Dictionary
+	var timeout: float = timeout_or_err as float
+	if not ResourceLoader.exists(path, "PackedScene"):
+		return _err(CliControlErrorCodes.SCENE_UNAVAILABLE, "scene not found: %s" % path)
+	# old 在 change 之前捕获，可为 null（script-mode / 启动早期）——
+	# 此时 current_scene != null 本身即构成新实例判定，不会死循环。
+	var old: Node = get_tree().current_scene
+	var err: int = get_tree().change_scene_to_file(path)
+	if err != OK:
+		return _err(
+			CliControlErrorCodes.SCENE_UNAVAILABLE,
+			"change_scene_to_file failed: %s" % error_string(err),
+		)
+	return await _await_new_scene_ready(old, timeout)
+
+
+## 逐帧等到 current_scene 是「不同于 old 的新实例」且 ready，返回新场景信息。
+## reload 后 scene_file_path 不变，只能比实例 id。
+func _await_new_scene_ready(old: Node, timeout: float) -> Dictionary:
+	var old_id: int = old.get_instance_id() if old != null else 0
+	var start_ms: int = Time.get_ticks_msec()
+	while true:
+		var cur: Node = get_tree().current_scene
+		if cur != null and cur.get_instance_id() != old_id and cur.is_node_ready():
+			return {"scene_path": cur.scene_file_path, "name": String(cur.name)}
+		if float(Time.get_ticks_msec() - start_ms) / 1000.0 >= timeout:
+			break
+		await get_tree().process_frame
+	return _err(
+		CliControlErrorCodes.SCENE_UNAVAILABLE, "timeout waiting for new scene ready"
+	)
+
+
+## timeout 参数校验：合法返回 float，非法返回 error Dictionary（调用方透传）。
+func _parse_timeout(params: Dictionary) -> Variant:
+	var raw: Variant = params.get("timeout", _DEFAULT_TIMEOUT)
+	if not (raw is int or raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'timeout' must be a number")
+	var t: float = float(raw)
+	if t < 0.0 or t > _MAX_SCENE_TIMEOUT:
+		return _err(
+			CliControlErrorCodes.INVALID_PARAMS,
+			"timeout must be 0..%s" % _MAX_SCENE_TIMEOUT,
+		)
+	return t
+
+
+func _err(code: int, message: String) -> Dictionary:
+	return {"error": {"code": code, "message": message}}

--- a/addons/godot_cli_control/bridge/scene_api.gd
+++ b/addons/godot_cli_control/bridge/scene_api.gd
@@ -68,15 +68,17 @@ func _await_new_scene_ready(old: Node, timeout: float) -> Dictionary:
 
 
 ## timeout 参数校验：合法返回 float，非法返回 error Dictionary（调用方透传）。
+## 场景切换是 deferred 的，至少需要一帧才能完成，故 timeout=0 无意义——
+## 传 0 会导致调用方永远收到 1008 超时，对 agent 是神秘错误，因此拒收。
 func _parse_timeout(params: Dictionary) -> Variant:
 	var raw: Variant = params.get("timeout", _DEFAULT_TIMEOUT)
 	if not (raw is int or raw is float):
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "'timeout' must be a number")
 	var t: float = float(raw)
-	if t < 0.0 or t > _MAX_SCENE_TIMEOUT:
+	if t <= 0.0 or t > _MAX_SCENE_TIMEOUT:
 		return _err(
 			CliControlErrorCodes.INVALID_PARAMS,
-			"timeout must be 0..%s" % _MAX_SCENE_TIMEOUT,
+			"timeout must be > 0 and <= %s" % _MAX_SCENE_TIMEOUT,
 		)
 	return t
 

--- a/addons/godot_cli_control/tests/gut/test_game_bridge.gd
+++ b/addons/godot_cli_control/tests/gut/test_game_bridge.gd
@@ -20,6 +20,7 @@ const GameBridgeScript := preload("res://addons/godot_cli_control/bridge/game_br
 const LowLevelApiScript := preload("res://addons/godot_cli_control/bridge/low_level_api.gd")
 const InputSimulationApiScript := preload("res://addons/godot_cli_control/bridge/input_simulation_api.gd")
 const WaitApiScript := preload("res://addons/godot_cli_control/bridge/wait_api.gd")
+const SceneApiScript := preload("res://addons/godot_cli_control/bridge/scene_api.gd")
 
 
 # ── 子类：捕获 _send_json 出站 + 跳过 peer 状态检查 ──────────────────
@@ -104,6 +105,7 @@ var _bridge: TestableGameBridge
 var _low: StubLowLevelApi
 var _input: StubInputSimulationApi
 var _wait: StubWaitApi
+var _scene: SceneApi
 
 
 func before_each() -> void:
@@ -123,9 +125,14 @@ func before_each() -> void:
 	_wait.name = "WaitApi"
 	add_child_autofree(_wait)
 
+	_scene = SceneApi.new()
+	_scene.name = "SceneApi"
+	add_child_autofree(_scene)
+
 	_bridge._low_level_api = _low
 	_bridge._input_sim_api = _input
 	_bridge._wait_api = _wait
+	_bridge._scene_api = _scene
 	# InputSim 的 callback：bridge 的 _on_async_response 把 (id, result) 转回 dispatch
 	_input.setup(_bridge._on_async_response)
 	_bridge._register_methods()
@@ -491,3 +498,12 @@ func test_wait_first_frame_ready_returns_under_headless() -> void:
 func test_first_frame_ready_max_frames_constant_is_positive() -> void:
 	# 防回归：常量被改成 0 或负数会让循环立刻退出 → 启动 gate 失效。
 	assert_gt(GameBridgeScript.FIRST_FRAME_READY_MAX_FRAMES, 0)
+
+
+# ── 注册表完整性：scene API（issue #98） ─────────────────────────────
+
+func test_registry_has_scene_methods() -> void:
+	assert_true(_bridge._methods.has("scene_reload"), "scene_reload 应已注册")
+	assert_eq(str(_bridge._methods["scene_reload"]["kind"]), "async")
+	assert_true(_bridge._methods.has("scene_change"), "scene_change 应已注册")
+	assert_eq(str(_bridge._methods["scene_change"]["kind"]), "async")

--- a/addons/godot_cli_control/tests/gut/test_game_bridge.gd
+++ b/addons/godot_cli_control/tests/gut/test_game_bridge.gd
@@ -20,7 +20,6 @@ const GameBridgeScript := preload("res://addons/godot_cli_control/bridge/game_br
 const LowLevelApiScript := preload("res://addons/godot_cli_control/bridge/low_level_api.gd")
 const InputSimulationApiScript := preload("res://addons/godot_cli_control/bridge/input_simulation_api.gd")
 const WaitApiScript := preload("res://addons/godot_cli_control/bridge/wait_api.gd")
-const SceneApiScript := preload("res://addons/godot_cli_control/bridge/scene_api.gd")
 
 
 # ── 子类：捕获 _send_json 出站 + 跳过 peer 状态检查 ──────────────────

--- a/addons/godot_cli_control/tests/gut/test_scene_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_scene_api.gd
@@ -1,0 +1,51 @@
+## GUT 单元测试：SceneApi 错误分支（issue #98）
+##
+## GUT cmdln script-mode 下 current_scene 恒为 null，真 reload/change
+## 由 python/tests/test_e2e_scene.py 兜底；这里测错误分支与参数校验。
+extends GutTest
+
+const SceneApiScript := preload("res://addons/godot_cli_control/bridge/scene_api.gd")
+
+var _api: Node
+
+
+func before_each() -> void:
+	_api = SceneApiScript.new()
+	_api.name = "SceneApi"
+	add_child_autofree(_api)
+
+
+func test_scene_reload_without_current_scene_returns_1008() -> void:
+	var result: Dictionary = await _api.scene_reload_async({})
+	assert_has(result, "error", "script-mode 无 current_scene，reload 应报错")
+	assert_eq(int(result.error.code), 1008)
+	assert_string_contains(str(result.error.message), "no current scene")
+
+
+func test_scene_reload_invalid_timeout_returns_minus_32602() -> void:
+	var result: Dictionary = await _api.scene_reload_async({"timeout": "abc"})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+
+
+func test_scene_change_missing_path_returns_minus_32602() -> void:
+	var result: Dictionary = await _api.scene_change_async({})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+
+
+func test_scene_change_nonexistent_scene_returns_1008() -> void:
+	var result: Dictionary = await _api.scene_change_async({
+		"path": "res://__definitely_missing__.tscn",
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1008)
+	assert_string_contains(str(result.error.message), "scene not found")
+
+
+func test_scene_change_timeout_out_of_range_returns_minus_32602() -> void:
+	var result: Dictionary = await _api.scene_change_async({
+		"path": "res://anything.tscn", "timeout": -1.0,
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)

--- a/addons/godot_cli_control/tests/gut/test_scene_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_scene_api.gd
@@ -49,3 +49,18 @@ func test_scene_change_timeout_out_of_range_returns_minus_32602() -> void:
 	})
 	assert_has(result, "error")
 	assert_eq(int(result.error.code), -32602)
+
+
+func test_scene_reload_zero_timeout_returns_minus_32602() -> void:
+	## timeout=0 无意义（场景切换至少需要一帧），按用法错拒收而非神秘超时
+	var result: Dictionary = await _api.scene_reload_async({"timeout": 0.0})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+
+
+func test_scene_change_timeout_above_max_returns_minus_32602() -> void:
+	var result: Dictionary = await _api.scene_change_async({
+		"path": "res://anything.tscn", "timeout": 3601.0,
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)

--- a/docs/superpowers/plans/2026-06-04-scene-isolation.md
+++ b/docs/superpowers/plans/2026-06-04-scene-isolation.md
@@ -1,0 +1,642 @@
+# 场景隔离（#98）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `scene_reload` / `scene_change` RPC（等新场景 ready 才返回）+ CLI `scene-reload` / `scene-change` + pytest `fresh_scene` fixture，给下游 e2e 提供真正的 per-test 场景隔离。
+
+**Architecture:** GDScript 侧新建 `scene_api.gd`（对齐 #108 wait_api 拆分先例），逐帧轮询等新场景实例 ready；Python 侧走标准三层（client async → bridge sync → cli RpcSpec）；pytest plugin 加 function-scope `fresh_scene` fixture。新业务错误码 `SCENE_UNAVAILABLE = 1008`。
+
+**Tech Stack:** Godot 4 GDScript + GUT 9、Python ≥3.10、websockets、pytest / pytest-asyncio。
+
+**Spec:** `docs/superpowers/specs/2026-06-04-scene-isolation-design.md`（已批准，含全部设计决策）
+
+**分支：** `feat/98-scene-isolation`（已建，基于 main）
+
+**仓库铁律（执行者必读）：**
+- 测试执行一律委托 subagent（`model: "sonnet"`），主会话只收精简结论（仓库 CLAUDE.md 全局规则）。subagent-driven 模式下 implementer 自己跑测试即满足。
+- Python 覆盖率跑法：`coverage run -m pytest`，**不能** `pytest --cov`（pyproject.toml 有注释说明）。
+- GUT 跑法：`GODOT_BIN=$HOME/.local/bin/godot ./addons/godot_cli_control/tests/run_gut.sh`（本机 godot 在 `~/.local/bin/godot`，必须真跑，不允许以缺 GODOT_BIN 为由跳过）。
+- e2e（test_e2e_*.py）需要真实 Godot，本机必真跑。
+- JSON 信封 / 错误码三段制 / 退出码语义等契约见仓库根 CLAUDE.md。
+
+---
+
+## File Structure
+
+| 动作 | 文件 | 职责 |
+|---|---|---|
+| Create | `addons/godot_cli_control/bridge/scene_api.gd` | SceneApi 节点：scene_reload_async / scene_change_async |
+| Create | `addons/godot_cli_control/tests/gut/test_scene_api.gd` | GUT 单测（错误分支） |
+| Modify | `addons/godot_cli_control/bridge/error_codes.gd` | 加 `SCENE_UNAVAILABLE = 1008` |
+| Modify | `addons/godot_cli_control/bridge/game_bridge.gd` | 实例化 SceneApi + 注册 2 个 async RPC |
+| Modify | `addons/godot_cli_control/tests/gut/test_game_bridge.gd` | 注册表断言补 2 个方法 |
+| Modify | `python/godot_cli_control/client.py` | `scene_reload` / `scene_change` async 方法 |
+| Modify | `python/godot_cli_control/bridge.py` | 同步包装 ×2 |
+| Modify | `python/godot_cli_control/cli.py` | 2 个 RpcSpec + handlers + preflight + text_formatter |
+| Modify | `python/godot_cli_control/pytest_plugin.py` | `fresh_scene` fixture |
+| Create | `examples/platformer-demo/second.tscn` | e2e 用第二场景 |
+| Create | `python/tests/test_e2e_scene.py` | e2e：真 reload / change / 1008 / bridge 直连 |
+| Modify | `python/tests/test_client.py`、`test_bridge.py`、`test_cli.py`、`test_pytest_plugin.py` | 三层单测 + fixture 单测 |
+| Modify | `python/godot_cli_control/templates/skill/SKILL.md` | Scene 命令组 + 1008 + fresh_scene + pitfalls ×2 |
+| Modify | `addons/godot_cli_control/README.md` | 命令表 / 错误码表同步 |
+
+---
+
+### Task 1: GDScript SceneApi（GUT 错误分支 TDD）
+
+**Files:**
+- Create: `addons/godot_cli_control/tests/gut/test_scene_api.gd`
+- Create: `addons/godot_cli_control/bridge/scene_api.gd`
+- Modify: `addons/godot_cli_control/bridge/error_codes.gd`
+
+**背景知识：**
+- GUT 测试模式参考 `tests/gut/test_low_level_api.gd`（`extends GutTest`、`before_each` 里 `XxxScript.new()` + `add_child_autofree`）。
+- GUT cmdln（script mode）下 `get_tree().current_scene == null`，所以「无 current scene → 1008」「路径不存在 → 1008」「参数校验 → -32602」三类错误分支都可以单测；**真 reload/change 留给 e2e**（Task 6）。
+- async handler 在 GUT 里直接 `await _api.scene_reload_async({...})`。
+- 错误返回 helper 形如 `{"error": {"code": ..., "message": ...}}`，对齐 `wait_api.gd:258-259` 的 `_err`。
+
+- [ ] **Step 1: 写失败测试**
+
+```gdscript
+## GUT 单元测试：SceneApi 错误分支（issue #98）
+##
+## GUT cmdln script-mode 下 current_scene 恒为 null，真 reload/change
+## 由 python/tests/test_e2e_scene.py 兜底；这里测错误分支与参数校验。
+extends GutTest
+
+const SceneApiScript := preload("res://addons/godot_cli_control/bridge/scene_api.gd")
+
+var _api: Node
+
+
+func before_each() -> void:
+	_api = SceneApiScript.new()
+	_api.name = "SceneApi"
+	add_child_autofree(_api)
+
+
+func test_scene_reload_without_current_scene_returns_1008() -> void:
+	var result: Dictionary = await _api.scene_reload_async({})
+	assert_has(result, "error", "script-mode 无 current_scene，reload 应报错")
+	assert_eq(int(result.error.code), 1008)
+	assert_string_contains(str(result.error.message), "no current scene")
+
+
+func test_scene_reload_invalid_timeout_returns_minus_32602() -> void:
+	var result: Dictionary = await _api.scene_reload_async({"timeout": "abc"})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+
+
+func test_scene_change_missing_path_returns_minus_32602() -> void:
+	var result: Dictionary = await _api.scene_change_async({})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+
+
+func test_scene_change_nonexistent_scene_returns_1008() -> void:
+	var result: Dictionary = await _api.scene_change_async({
+		"path": "res://__definitely_missing__.tscn",
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1008)
+	assert_string_contains(str(result.error.message), "scene not found")
+
+
+func test_scene_change_timeout_out_of_range_returns_minus_32602() -> void:
+	var result: Dictionary = await _api.scene_change_async({
+		"path": "res://anything.tscn", "timeout": -1.0,
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+```
+
+- [ ] **Step 2: 跑 GUT 确认失败**
+
+Run: `GODOT_BIN=$HOME/.local/bin/godot ./addons/godot_cli_control/tests/run_gut.sh`
+Expected: test_scene_api.gd 因 `scene_api.gd` 不存在而 preload 失败（脚本加载错误）。
+
+- [ ] **Step 3: error_codes.gd 加 1008**
+
+在 `SIGNAL_NOT_FOUND` 之后追加：
+
+```gdscript
+# 场景不可用（issue #98 scene_reload/scene_change）：reload 时无 current
+# scene、change 的 res 路径不存在/加载失败、等新场景 ready 超时。
+# 与 1006 拆开：1006 是「短重试可能成功」的 transient；1008 三种情形里
+# 路径不存在是永久错，超时大概率是场景加载本身坏了——agent 应停下排查。
+const SCENE_UNAVAILABLE: int = 1008
+```
+
+- [ ] **Step 4: 写 scene_api.gd 最小实现**
+
+```gdscript
+class_name SceneApi
+extends Node
+## 场景生命周期 API：scene_reload / scene_change（issue #98）
+##
+## 两者都等新场景 ready 才返回（逐帧轮询，模式对齐 wait_api.gd），
+## 调用方不需要再 wait-node。错误码常量来自 error_codes.gd。
+
+# 等新场景 ready 的超时上限 / 默认值（秒）
+const _MAX_SCENE_TIMEOUT: float = 3600.0
+const _DEFAULT_TIMEOUT: float = 10.0
+
+
+func scene_reload_async(params: Dictionary) -> Dictionary:
+	var timeout_or_err: Variant = _parse_timeout(params)
+	if timeout_or_err is Dictionary:
+		return timeout_or_err as Dictionary
+	var timeout: float = timeout_or_err as float
+	var old: Node = get_tree().current_scene
+	if old == null:
+		return _err(CliControlErrorCodes.SCENE_UNAVAILABLE, "no current scene to reload")
+	var err: int = get_tree().reload_current_scene()
+	if err != OK:
+		return _err(
+			CliControlErrorCodes.SCENE_UNAVAILABLE,
+			"reload_current_scene failed: %s" % error_string(err),
+		)
+	return await _await_new_scene_ready(old, timeout)
+
+
+func scene_change_async(params: Dictionary) -> Dictionary:
+	var path_raw: Variant = params.get("path", null)
+	if not (path_raw is String) or (path_raw as String).is_empty():
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "Missing 'path' parameter")
+	var path: String = path_raw as String
+	var timeout_or_err: Variant = _parse_timeout(params)
+	if timeout_or_err is Dictionary:
+		return timeout_or_err as Dictionary
+	var timeout: float = timeout_or_err as float
+	if not ResourceLoader.exists(path, "PackedScene"):
+		return _err(CliControlErrorCodes.SCENE_UNAVAILABLE, "scene not found: %s" % path)
+	# old 在 change 之前捕获，可为 null（script-mode / 启动早期）——
+	# 此时 current_scene != null 本身即构成新实例判定，不会死循环。
+	var old: Node = get_tree().current_scene
+	var err: int = get_tree().change_scene_to_file(path)
+	if err != OK:
+		return _err(
+			CliControlErrorCodes.SCENE_UNAVAILABLE,
+			"change_scene_to_file failed: %s" % error_string(err),
+		)
+	return await _await_new_scene_ready(old, timeout)
+
+
+## 逐帧等到 current_scene 是「不同于 old 的新实例」且 ready，返回新场景信息。
+## reload 后 scene_file_path 不变，只能比实例 id。
+func _await_new_scene_ready(old: Node, timeout: float) -> Dictionary:
+	var old_id: int = old.get_instance_id() if old != null else 0
+	var start_ms: int = Time.get_ticks_msec()
+	while true:
+		var cur: Node = get_tree().current_scene
+		if cur != null and cur.get_instance_id() != old_id and cur.is_node_ready():
+			return {"scene_path": cur.scene_file_path, "name": String(cur.name)}
+		if float(Time.get_ticks_msec() - start_ms) / 1000.0 >= timeout:
+			break
+		await get_tree().process_frame
+	return _err(
+		CliControlErrorCodes.SCENE_UNAVAILABLE, "timeout waiting for new scene ready"
+	)
+
+
+## timeout 参数校验：合法返回 float，非法返回 error Dictionary（调用方透传）。
+func _parse_timeout(params: Dictionary) -> Variant:
+	var raw: Variant = params.get("timeout", _DEFAULT_TIMEOUT)
+	if not (raw is int or raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'timeout' must be a number")
+	var t: float = float(raw)
+	if t < 0.0 or t > _MAX_SCENE_TIMEOUT:
+		return _err(
+			CliControlErrorCodes.INVALID_PARAMS,
+			"timeout must be 0..%s" % _MAX_SCENE_TIMEOUT,
+		)
+	return t
+
+
+func _err(code: int, message: String) -> Dictionary:
+	return {"error": {"code": code, "message": message}}
+```
+
+注意：新建 `.gd` 后 Godot 会生成 `.uid` 文件（参考同目录其它 `.gd.uid`），GUT 跑完后把它一并 `git add`。
+
+- [ ] **Step 5: 跑 GUT 确认通过**
+
+Run: `GODOT_BIN=$HOME/.local/bin/godot ./addons/godot_cli_control/tests/run_gut.sh`
+Expected: 全绿（含新 5 个用例）。若 `Class 'CliControlErrorCodes' not found`，见 wait_api.gd 头注释（先 import 一次）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add addons/godot_cli_control/bridge/scene_api.gd* addons/godot_cli_control/bridge/error_codes.gd addons/godot_cli_control/tests/gut/test_scene_api.gd*
+git commit -m "feat(scene): SceneApi —— scene_reload/scene_change async handler + 1008（#98）"
+```
+
+---
+
+### Task 2: GameBridge 注册（GUT 注册表 TDD）
+
+**Files:**
+- Modify: `addons/godot_cli_control/tests/gut/test_game_bridge.gd`
+- Modify: `addons/godot_cli_control/bridge/game_bridge.gd:28-35`（成员）、`:58-61` 附近（_ready 实例化）、`:192-198`（注册表）
+
+- [ ] **Step 1: 写失败测试** —— 在 test_game_bridge.gd 里找到现有「注册表完整性」断言（搜 `wait_signal` 或 `_methods`），对齐其写法补：
+
+```gdscript
+func test_registry_has_scene_methods() -> void:
+	# 对齐文件内现有注册表断言的获取方式（直接读 bridge._methods）
+	assert_true(_bridge._methods.has("scene_reload"), "scene_reload 应已注册")
+	assert_eq(str(_bridge._methods["scene_reload"]["kind"]), "async")
+	assert_true(_bridge._methods.has("scene_change"), "scene_change 应已注册")
+	assert_eq(str(_bridge._methods["scene_change"]["kind"]), "async")
+```
+
+（若文件内注册表断言的 setup 方式不同——比如绕过 `_should_activate`——照抄现有用例的 setup，别发明新写法。）
+
+- [ ] **Step 2: 跑 GUT 确认失败**（`_methods` 无 scene_reload）
+
+- [ ] **Step 3: 实现注册** —— game_bridge.gd 三处：
+
+```gdscript
+# ① 成员声明（_wait_api 下面）：
+var _scene_api: SceneApi = null
+
+# ② _ready 里 _wait_api.setup(...) 之后：
+_scene_api = SceneApi.new()
+_scene_api.name = "SceneApi"
+add_child(_scene_api)
+
+# ③ _register_methods 的 Wait API 段后面：
+# Scene API（异步，issue #98）
+_methods["scene_reload"] = {"callable": _scene_api.scene_reload_async, "kind": "async"}
+_methods["scene_change"] = {"callable": _scene_api.scene_change_async, "kind": "async"}
+```
+
+- [ ] **Step 4: 跑 GUT 确认全绿**
+
+- [ ] **Step 5: Commit** —— `git add` 两文件，`feat(scene): GameBridge 注册 scene_reload/scene_change（#98）`
+
+---
+
+### Task 3: Python client.py + bridge.py（单测 TDD）
+
+**Files:**
+- Modify: `python/tests/test_client.py`、`python/tests/test_bridge.py`（先看各自现有 wait_signal 用例的 mock 模式，照抄）
+- Modify: `python/godot_cli_control/client.py:355-361` 后、`python/godot_cli_control/bridge.py:93-99` 后
+
+- [ ] **Step 1: 写失败测试**（对齐两文件现有 wait_signal 测试的 transport mock / `_run` stub 写法）：
+
+test_client.py 断言要点：
+- `scene_reload()` 发出 method=`"scene_reload"`、params=`{"timeout": 10.0}`、RPC timeout=15.0
+- `scene_change("res://a.tscn", timeout=3.0)` 发出 method=`"scene_change"`、params=`{"path": "res://a.tscn", "timeout": 3.0}`、RPC timeout=8.0
+
+test_bridge.py 断言要点：
+- `GameBridge.scene_reload()` / `.scene_change(path)` 正确委托到 client 同名方法并返回 dict
+
+- [ ] **Step 2: 跑这两个测试文件确认失败**（`AttributeError: scene_reload`）
+
+Run: `.venv/bin/python -m pytest python/tests/test_client.py python/tests/test_bridge.py -q`
+
+- [ ] **Step 3: 实现**
+
+client.py（`wait_signal` 之后）：
+
+```python
+    async def scene_reload(self, timeout: float = 10.0) -> dict:
+        """重载当前场景并等新场景 ready（issue #98）。
+
+        成功返回 {"scene_path": ..., "name": ...}；无 current scene /
+        等 ready 超时走 RPC error（1008 SCENE_UNAVAILABLE），会抛异常。
+        """
+        return await self.request(
+            "scene_reload", {"timeout": timeout}, timeout=timeout + 5.0
+        )
+
+    async def scene_change(self, path: str, timeout: float = 10.0) -> dict:
+        """切换到指定场景并等新场景 ready（issue #98）。
+
+        path 须为 res:// 或 uid:// 资源路径；不存在/加载失败/超时 → 1008。
+        """
+        return await self.request(
+            "scene_change", {"path": path, "timeout": timeout}, timeout=timeout + 5.0
+        )
+```
+
+bridge.py（`wait_signal` 之后）：
+
+```python
+    def scene_reload(self, timeout: float = 10.0) -> dict:
+        """重载当前场景并等新场景 ready（issue #98）。返回 {"scene_path": ..., "name": ...}。"""
+        return self._run(self._client.scene_reload(timeout=timeout))
+
+    def scene_change(self, path: str, timeout: float = 10.0) -> dict:
+        """切换场景并等新场景 ready（issue #98）。path 须为 res:// 或 uid://。"""
+        return self._run(self._client.scene_change(path, timeout=timeout))
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+- [ ] **Step 5: Commit** —— `feat(scene): client/bridge 两层 scene_reload/scene_change（#98）`
+
+---
+
+### Task 4: CLI RpcSpec（单测 TDD）
+
+**Files:**
+- Modify: `python/tests/test_cli.py`
+- Modify: `python/godot_cli_control/cli.py`
+
+- [ ] **Step 1: 写失败测试**（对齐 test_cli.py 现有 preflight / spec 测试写法）：
+
+```python
+def test_scene_change_preflight_rejects_bad_prefix(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """scene-change 非 res://、uid:// 路径：连 daemon 前 -1003 + exit 64。
+
+    main() 不接参数（读 sys.argv、以 sys.exit 退出）——必须用
+    test_cli.py:1116/:1146 现有 preflight 测试的 monkeypatch+SystemExit 模式。
+    """
+    import json as _json
+    import sys as _sys
+
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    monkeypatch.setattr(
+        _sys, "argv", ["godot-cli-control", "scene-change", "second.tscn"]
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == EXIT_USAGE  # 64
+    payload = _json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert "res://" in payload["error"]["message"]
+
+
+def test_scene_specs_registered() -> None:
+    from godot_cli_control.cli import RPC_BY_NAME
+
+    for name in ("scene-reload", "scene-change"):
+        spec = RPC_BY_NAME[name]
+        assert spec.preflight is not None
+        assert spec.text_formatter({"scene_path": "res://m.tscn", "name": "M"})
+
+
+def test_scene_text_formatters() -> None:
+    from godot_cli_control.cli import RPC_BY_NAME
+
+    r = {"scene_path": "res://main.tscn", "name": "Main"}
+    assert RPC_BY_NAME["scene-reload"].text_formatter(r) == \
+        "scene reloaded: res://main.tscn (root: Main)"
+    assert RPC_BY_NAME["scene-change"].text_formatter(r) == \
+        "scene changed: res://main.tscn (root: Main)"
+```
+
+（preflight 校验超时参数的负例也补一条：`scene-reload --timeout -1` → 64，同 monkeypatch 模式。注：`test_scene_specs_registered` 断言两个 spec 都有 preflight——本计划给 scene-reload 也配了 timeout preflight（Task 4 Step 3 ①），与该断言自洽；这是对 spec「仅 scene-change 做前缀校验」的轻微超出，理由是契约 5（用法错必须在连接前报）对 timeout 同样适用，且对齐 wait-prop 先例。）
+
+- [ ] **Step 2: 跑 test_cli.py 新用例确认失败**（KeyError: 'scene-reload'）
+
+- [ ] **Step 3: 实现** —— cli.py 四处：
+
+```python
+# ① preflight（_preflight_wait_frames 之后）：
+def _preflight_scene_reload(ns: argparse.Namespace) -> None:
+    timeout = _require_float(ns.timeout, "scene-reload", "timeout")
+    if not 0 <= timeout <= 3600:
+        raise ValueError(f"scene-reload: timeout 必须在 0..3600 秒，收到 {timeout}")
+
+
+def _preflight_scene_change(ns: argparse.Namespace) -> None:
+    if not ns.scene_path.startswith(("res://", "uid://")):
+        raise ValueError(
+            f"scene-change: 场景路径必须以 res:// 或 uid:// 开头，收到 {ns.scene_path!r}"
+        )
+    timeout = _require_float(ns.timeout, "scene-change", "timeout")
+    if not 0 <= timeout <= 3600:
+        raise ValueError(f"scene-change: timeout 必须在 0..3600 秒，收到 {timeout}")
+
+
+# ② handler（cmd_wait_frames 之后）：
+async def cmd_scene_reload(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.scene_reload(timeout=float(ns.timeout))
+
+
+async def cmd_scene_change(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.scene_change(ns.scene_path, timeout=float(ns.timeout))
+
+
+# ③ extra_args（_register_wait_frames_args 之后）：
+def _register_scene_reload_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--timeout", default="10",
+                   help="等新场景 ready 的超时秒（0..3600，默认 10）")
+
+
+def _register_scene_change_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("scene_path", help="目标场景资源路径（res:// 或 uid://）")
+    p.add_argument("--timeout", default="10",
+                   help="等新场景 ready 的超时秒（0..3600，默认 10）")
+
+
+# ④ RPC_SPECS（wait-frames 条目之后插入）：
+    RpcSpec(
+        name="scene-reload",
+        handler=cmd_scene_reload,
+        description=(
+            "重载当前场景并阻塞到新场景 ready（per-test 隔离原语）。"
+            "失败（无 current scene / 超时）报 1008，exit 1。"
+            "注意：返回后此前缓存的所有节点路径/引用全部失效。"
+        ),
+        positionals=(),  # 由 extra_args 注册
+        example="scene-reload",
+        extra_args=_register_scene_reload_args,
+        preflight=_preflight_scene_reload,
+        text_formatter=lambda r: f"scene reloaded: {r.get('scene_path')} (root: {r.get('name')})",
+    ),
+    RpcSpec(
+        name="scene-change",
+        handler=cmd_scene_change,
+        description=(
+            "切换到指定场景并阻塞到新场景 ready。路径不存在/加载失败/超时 "
+            "报 1008，exit 1。"
+        ),
+        positionals=(),  # 由 extra_args 注册
+        example="scene-change res://levels/level2.tscn",
+        extra_args=_register_scene_change_args,
+        preflight=_preflight_scene_change,
+        text_formatter=lambda r: f"scene changed: {r.get('scene_path')} (root: {r.get('name')})",
+    ),
+```
+
+- [ ] **Step 4: 跑 test_cli.py 确认通过**
+
+- [ ] **Step 5: Commit** —— `feat(scene): CLI scene-reload/scene-change + preflight（#98）`
+
+---
+
+### Task 5: pytest plugin `fresh_scene` fixture（单测 TDD）
+
+**Files:**
+- Modify: `python/tests/test_pytest_plugin.py`（先读现有用例：该文件怎么 stub daemon/bridge——pytester 还是 monkeypatch，照抄）
+- Modify: `python/godot_cli_control/pytest_plugin.py`
+
+- [ ] **Step 1: 写失败测试** —— 断言要点：
+  1. `fresh_scene` 在 yield 前调了 `bridge.scene_reload()` 恰好一次
+  2. yield 出来的就是同一个 bridge 对象
+  3. teardown 不再调 scene_reload（总调用次数仍为 1）
+
+实现思路（若现有文件用 pytester）：内联 conftest override `bridge` fixture 为 Mock(spec=GameBridge)，测试体里 `assert bridge.scene_reload.call_count == 1`。若现有文件直接调 fixture 函数，则照那个模式。
+
+- [ ] **Step 2: 跑确认失败**（fixture 'fresh_scene' not found）
+
+- [ ] **Step 3: 实现** —— pytest_plugin.py 的 `bridge` fixture 之后：
+
+```python
+@pytest.fixture
+def fresh_scene(bridge: GameBridge) -> Iterator[GameBridge]:
+    """Function-scoped：setup 时 reload 当前场景并等新场景 ready（issue #98）。
+
+    语义是「本用例开始时场景是干净的」：teardown 不做事，下一个需要干净
+    场景的用例自己声明 fresh_scene。reload 后此前缓存的节点路径全部失效。
+
+        def test_jump(godot_daemon, fresh_scene):
+            fresh_scene.click("/root/Game/Start")   # fresh_scene 即 bridge
+    """
+    bridge.scene_reload()
+    yield bridge
+```
+
+同时更新模块 docstring 的 fixtures 列表行（第 1 行附近 `godot_daemon (session) + bridge (function)` 处补 fresh_scene）。
+
+- [ ] **Step 4: 跑 test_pytest_plugin.py 确认通过**
+
+- [ ] **Step 5: Commit** —— `feat(scene): pytest fresh_scene fixture（#98）`
+
+---
+
+### Task 6: e2e（真 Godot 全链路）
+
+**Files:**
+- Create: `examples/platformer-demo/second.tscn`
+- Create: `python/tests/test_e2e_scene.py`（harness 整体照抄 `test_e2e_example.py:1-99`——`find_godot_binary` skipif、`_run_cli`、`demo_project`(module) + `daemon` fixtures）
+
+- [ ] **Step 1: 加 second.tscn**
+
+```
+[gd_scene format=3]
+
+[node name="Second" type="Node2D"]
+
+[node name="Marker" type="Label" parent="."]
+text = "second scene"
+```
+
+- [ ] **Step 2: 写 e2e 测试**（先写完整文件再一次跑——e2e 起 daemon 成本高，不逐用例 RED/GREEN）
+
+`demo_project` 拷贝列表在 example 的基础上加 `"second.tscn"`。用例：
+
+```python
+def test_scene_reload_resets_mutated_state(daemon: Any) -> None:
+    project = daemon
+    assert _run_cli(project, "wait-node", "/root/Main/UI/StartButton")["result"]["found"]
+    # 污染场景状态
+    assert _run_cli(project, "set", "/root/Main/UI/StartButton", "text", '"DIRTY"')["ok"]
+    dirty = _run_cli(project, "get", "/root/Main/UI/StartButton", "text")
+    assert dirty["result"]["value"] == "DIRTY"
+    # reload → 状态归位
+    r = _run_cli(project, "scene-reload")
+    assert r["ok"] is True, r
+    assert r["result"]["name"] == "Main"
+    assert r["result"]["scene_path"] == "res://main.tscn"
+    clean = _run_cli(project, "get", "/root/Main/UI/StartButton", "text")
+    assert clean["result"]["value"] == "Start", "reload 后属性应回到场景文件初值"
+
+
+def test_scene_change_switches_to_second(daemon: Any) -> None:
+    project = daemon
+    assert _run_cli(project, "wait-node", "/root/Main")["result"]["found"]
+    r = _run_cli(project, "scene-change", "res://second.tscn")
+    assert r["ok"] is True, r
+    assert r["result"]["name"] == "Second"
+    assert _run_cli(project, "exists", "/root/Second")["result"] is True
+    # 旧场景根应已不在
+    assert _run_cli(project, "exists", "/root/Main")["result"] is False
+
+
+def test_scene_change_missing_scene_returns_1008(daemon: Any) -> None:
+    project = daemon
+    r = _run_cli(project, "scene-change", "res://__missing__.tscn")
+    assert r["ok"] is False
+    assert r["error"]["code"] == 1008
+
+
+def test_bridge_scene_reload_roundtrip(daemon: Any) -> None:
+    """fresh_scene fixture 的核心调用（bridge.scene_reload）真链路验证。"""
+    from godot_cli_control.bridge import GameBridge
+
+    project = daemon
+    port = int((project / ".cli_control" / "port").read_text().strip())
+    b = GameBridge(port=port)
+    try:
+        result = b.scene_reload()
+        assert result["name"] == "Main"
+    finally:
+        b.close()
+```
+
+（`exists` 的信封 shape 与端口文件路径以现有 e2e/代码为准——动手前各 grep 一眼：`grep -rn "exists" python/tests/test_e2e_example.py`、`grep -rn "cli_control.*port" python/godot_cli_control/daemon.py`。不符就按实际调整。）
+
+- [ ] **Step 3: 跑 e2e 确认通过**
+
+Run: `.venv/bin/python -m pytest python/tests/test_e2e_scene.py -q`（真 Godot，必跑）
+Expected: 4 passed。常见坑：忘了把 second.tscn 加进拷贝列表 → 1008。
+
+- [ ] **Step 4: Commit** —— `test(scene): e2e 真场景 reload/change/1008/bridge 直连（#98）`
+
+---
+
+### Task 7: 文档同步（契约 7）
+
+**Files:**
+- Modify: `python/godot_cli_control/templates/skill/SKILL.md`
+- Modify: `addons/godot_cli_control/README.md`
+
+- [ ] **Step 1: SKILL.md 模板四处**
+  1. `## Command catalogue` 的 **Wait** 组后加 **Scene** 组：
+     ```markdown
+     **Scene:**
+     - `scene-reload [--timeout N]` — reload the current scene and block until the new instance is ready (per-test isolation primitive). All previously cached node paths become stale after it returns.
+     - `scene-change <res://path.tscn> [--timeout N]` — switch to another scene and block until ready. Path must start with `res://` or `uid://` (checked before connecting).
+     ```
+  2. `## Error code reference` 表 1007 行后加：
+     ```markdown
+     | `1008` | Scene unavailable (`scene-reload` / `scene-change`): no current scene, scene file missing / failed to load, or timed out waiting for the new scene to become ready. Missing file is permanent — fix the path; timeout usually means the scene itself fails to load — inspect the daemon log. |
+     ```
+  3. `## pytest plugin` 段示例处补 `fresh_scene` fixture 一句 + 示例改用 `fresh_scene`
+  4. `## Common pitfalls` 加两条：场景切换后旧节点路径全部失效需重新 `wait-node`；`scene-reload` 返回后原场景已被释放，不要复用此前缓存的节点引用/路径
+- [ ] **Step 2: addon README** —— 命令表 / 错误码表加同样条目（结构以该文件现状为准）
+- [ ] **Step 3: 渲染检查**
+
+Run: `.venv/bin/python -c "from godot_cli_control import cli; print(cli.format_full_help())" | head -50`
+Expected: 不崩，help 含 scene-reload / scene-change。
+
+- [ ] **Step 4: 跑 `python/tests/test_skills_install.py`**（init 注入回归）
+- [ ] **Step 5: Commit** —— `docs(scene): SKILL.md/README 同步 Scene 命令组 + 1008 + fresh_scene（#98）`
+
+---
+
+### Task 8: 全量验证 + PR
+
+- [ ] **Step 1: Python 全量** —— `.venv/bin/coverage run -m pytest python/tests/ -q` + `coverage report --fail-under=80`（委托 subagent）
+- [ ] **Step 2: GUT 全量** —— `run_gut.sh`（委托 subagent）
+- [ ] **Step 3: push + PR**
+
+```bash
+git push -u origin feat/98-scene-isolation
+# PR 标题：feat(scene): scene-reload/scene-change + pytest fresh_scene（#98）
+# body 含 Fixes #98 + 测试结论；gh pr merge --auto --squash
+```
+
+注意：PR #120（#118/#119 快修）可能已先合，若 main 有更新先 rebase。
+
+- [ ] **Step 4: 收尾盘点** —— 按仓库 CLAUDE.md「实施收尾必开 Issue」规则盘点遗留（如有），CLAUDE.md 已知遗留段更新留给 PR 合并后。

--- a/docs/superpowers/plans/2026-06-04-scene-isolation.md
+++ b/docs/superpowers/plans/2026-06-04-scene-isolation.md
@@ -393,18 +393,20 @@ def test_scene_text_formatters() -> None:
         "scene changed: res://main.tscn (root: Main)"
 ```
 
-（preflight 校验超时参数的负例也补一条：`scene-reload --timeout -1` → 64，同 monkeypatch 模式。注：`test_scene_specs_registered` 断言两个 spec 都有 preflight——本计划给 scene-reload 也配了 timeout preflight（Task 4 Step 3 ①），与该断言自洽；这是对 spec「仅 scene-change 做前缀校验」的轻微超出，理由是契约 5（用法错必须在连接前报）对 timeout 同样适用，且对齐 wait-prop 先例。）
+（preflight 校验超时参数的负例也补一条：`scene-reload --timeout -1` → 64（timeout=0 同样越界），同 monkeypatch 模式。注：`test_scene_specs_registered` 断言两个 spec 都有 preflight——本计划给 scene-reload 也配了 timeout preflight（Task 4 Step 3 ①），与该断言自洽；这是对 spec「仅 scene-change 做前缀校验」的轻微超出，理由是契约 5（用法错必须在连接前报）对 timeout 同样适用，且对齐 wait-prop 先例。）
 
 - [ ] **Step 2: 跑 test_cli.py 新用例确认失败**（KeyError: 'scene-reload'）
 
 - [ ] **Step 3: 实现** —— cli.py 四处：
 
 ```python
-# ① preflight（_preflight_wait_frames 之后）：
+# ① preflight（_preflight_wait_frames 之后）。
+# 注意边界：服务端 _parse_timeout 拒收 0（场景切换至少需一帧，0 恒超时是陷阱，
+# review I-1 已改为 t <= 0 → -32602），preflight 同样用 0 < timeout <= 3600：
 def _preflight_scene_reload(ns: argparse.Namespace) -> None:
     timeout = _require_float(ns.timeout, "scene-reload", "timeout")
-    if not 0 <= timeout <= 3600:
-        raise ValueError(f"scene-reload: timeout 必须在 0..3600 秒，收到 {timeout}")
+    if not 0 < timeout <= 3600:
+        raise ValueError(f"scene-reload: timeout 必须 > 0 且 <= 3600 秒，收到 {timeout}")
 
 
 def _preflight_scene_change(ns: argparse.Namespace) -> None:
@@ -413,8 +415,8 @@ def _preflight_scene_change(ns: argparse.Namespace) -> None:
             f"scene-change: 场景路径必须以 res:// 或 uid:// 开头，收到 {ns.scene_path!r}"
         )
     timeout = _require_float(ns.timeout, "scene-change", "timeout")
-    if not 0 <= timeout <= 3600:
-        raise ValueError(f"scene-change: timeout 必须在 0..3600 秒，收到 {timeout}")
+    if not 0 < timeout <= 3600:
+        raise ValueError(f"scene-change: timeout 必须 > 0 且 <= 3600 秒，收到 {timeout}")
 
 
 # ② handler（cmd_wait_frames 之后）：
@@ -429,13 +431,13 @@ async def cmd_scene_change(client: GameClient, ns: argparse.Namespace) -> dict:
 # ③ extra_args（_register_wait_frames_args 之后）：
 def _register_scene_reload_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--timeout", default="10",
-                   help="等新场景 ready 的超时秒（0..3600，默认 10）")
+                   help="等新场景 ready 的超时秒（>0 且 <=3600，默认 10）")
 
 
 def _register_scene_change_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("scene_path", help="目标场景资源路径（res:// 或 uid://）")
     p.add_argument("--timeout", default="10",
-                   help="等新场景 ready 的超时秒（0..3600，默认 10）")
+                   help="等新场景 ready 的超时秒（>0 且 <=3600，默认 10）")
 
 
 # ④ RPC_SPECS（wait-frames 条目之后插入）：

--- a/docs/superpowers/specs/2026-06-04-scene-isolation-design.md
+++ b/docs/superpowers/specs/2026-06-04-scene-isolation-design.md
@@ -56,7 +56,9 @@ _methods["scene_change"] = {"callable": _scene_api.scene_change_async, "kind": "
 2. `ResourceLoader.exists(path, "PackedScene")` 为 false → `1008`
    （不碰当前场景就失败，避免半切换状态）
 3. `get_tree().change_scene_to_file(path)` 返回非 OK → `1008`
-4. 等 ready 逻辑与 reload 共用（私有 helper `_await_new_scene_ready(old, timeout)`）
+4. 等 ready 逻辑与 reload 共用（私有 helper `_await_new_scene_ready(old, timeout)`；
+   `old` 是调 `change_scene_to_file` **之前**捕获的 `current_scene`，可为 null——
+   此时「`current_scene != null`」条件本身就构成新实例判定，不会死循环）
 5. 成功返回同 reload
 
 ### 2. 错误码
@@ -102,19 +104,21 @@ def fresh_scene(bridge: GameBridge) -> Iterator[GameBridge]:
 |---|---|---|
 | GUT | `tests/gut/test_scene_api.gd`（新） | 参数校验 -32602；无 current_scene → 1008；路径不存在 → 1008。真 reload/change 受 GUT script-mode runner 环境限制，由 e2e 兜底 |
 | Python 单测 | test_cli.py / test_bridge.py / test_client.py | preflight 前缀校验、text_formatter、RpcSpec 注册完整性、bridge/client 包装（mock transport） |
-| e2e | `test_e2e_scene.py`（新） | platformer-demo 加 `second.tscn`；真跑：改属性 → scene-reload → 属性归位；scene-change → tree 验证新根节点；fresh_scene fixture 全链路 |
+| e2e | `test_e2e_scene.py`（新） | `second.tscn` **预置进 `examples/platformer-demo/`**（demo_project fixture 按固定文件名列表拷贝，新文件加进列表）；真跑：改属性 → scene-reload → 属性归位；scene-change → tree 验证新根节点；fresh_scene fixture 全链路 |
 
 ## 文档同步（契约 7）
 
 - SKILL.md 模板：Command catalogue 加 **Scene 分组**（scene-reload / scene-change）、
-  错误码表加 1008、pytest plugin 段加 fresh_scene、Common pitfalls 加
-  「场景切换后旧节点路径全部失效，需重新 wait-node 定位」
+  错误码表加 1008、pytest plugin 段加 fresh_scene、Common pitfalls 加两条：
+  「场景切换后旧节点路径全部失效，需重新 wait-node 定位」、
+  「scene-reload 返回后原场景已被释放，不要复用此前缓存的节点引用/路径」
 - addon README：命令表 / 错误码表同步
 - 跑 `python -c "from godot_cli_control import cli; print(cli.format_full_help())"` 验证渲染
 
 ## 不做的事（YAGNI）
 
 - 不加 `@pytest.mark.fresh_scene` marker
+- 不给 `fresh_scene` 加超时参数/工厂模式（继承 `scene_reload()` 默认 10s；有真实需求再说）
 - 不做「恢复到主场景 / 可配置目标场景」
 - 不做 `change_scene_to_packed` / 场景栈管理
 - 不动 method blacklist（scene 操作走专用 RPC，不经 `call` 通道）

--- a/docs/superpowers/specs/2026-06-04-scene-isolation-design.md
+++ b/docs/superpowers/specs/2026-06-04-scene-isolation-design.md
@@ -1,0 +1,120 @@
+# 场景隔离设计：scene-reload / scene-change RPC + pytest fresh_scene（issue #98）
+
+日期：2026-06-04
+状态：已批准（brainstorming 四节逐节确认）
+
+## 问题
+
+daemon 跨整个 pytest session 存活，场景状态跨用例累积，没有重置手段。下游 e2e
+被迫为「跨用例残留」写防御代码（XGame `enter_world` 幂等复用、每用例基准动作
+消残留），且只能缓解不能根治——该项目真实出过一次 e2e 顺序依赖 bug。
+
+## 目标
+
+1. RPC 级原语：`scene_reload`（重载当前场景）+ `scene_change <res-path>`（切换场景），
+   两者都**等新场景 ready 才返回**，调用方不需要再自己 wait-node。
+2. pytest 级封装：function-scope `fresh_scene` fixture，声明它的用例开始时
+   拿到刚 reload 的干净场景。
+
+## 已决策的设计选择
+
+| 决策点 | 选择 | 备注 |
+|---|---|---|
+| pytest API 形态 | 仅 fixture，不加 marker | YAGNI；与现有 `bridge` fixture 同风格 |
+| fresh_scene 还原目标 | reload 当前场景 | 只保证「本用例拿到干净场景」；跨场景用例自己先 scene_change |
+| CLI 形态 | 平铺 `scene-reload` / `scene-change` | 对齐 wait-node 先例，直接走 RpcSpec |
+| GDScript 放置 | 独立 `scene_api.gd` | 对齐 #108 把 wait_api 拆出去的先例 |
+| 等 ready 超时语义 | 算错误（1008 + exit 1） | wait 系列超时是合法业务结果；scene 超时意味着场景加载坏了 |
+| 错误码 | 单码 `SCENE_UNAVAILABLE = 1008` | 三种失败共用，message 区分细节 |
+
+## 组件设计
+
+### 1. GDScript：`addons/godot_cli_control/bridge/scene_api.gd`
+
+新文件，`extends Node`，命名 `SceneApi`。GameBridge `_ready` 时实例化并
+`add_child`（对齐 `_wait_api` 先例，game_bridge.gd:58-61），注册：
+
+```
+_methods["scene_reload"] = {"callable": _scene_api.scene_reload_async, "kind": "async"}
+_methods["scene_change"] = {"callable": _scene_api.scene_change_async, "kind": "async"}
+```
+
+**`scene_reload_async(params: Dictionary) -> Dictionary`**
+
+1. `timeout` 可选 float，默认 10.0；非法类型 → `-32602`
+2. `old := get_tree().current_scene`；为 null → `1008`（"no current scene to reload"）
+3. `get_tree().reload_current_scene()` 返回非 OK → `1008`（带 Error 码）
+4. 逐帧 `await get_tree().process_frame`，直到 `current_scene != null` 且
+   **实例不同于 old**（`get_instance_id()` 比对，reload 后 scene_file_path 不变，
+   只能比实例）且 `current_scene.is_node_ready()`
+5. 超时 → `1008`（"timeout waiting for new scene ready"）
+6. 成功返回 `{"scene_path": current_scene.scene_file_path, "name": String(current_scene.name)}`
+
+**`scene_change_async(params: Dictionary) -> Dictionary`**
+
+1. `path` 必填 String，缺失/型错 → `-32602`；`timeout` 同上
+2. `ResourceLoader.exists(path, "PackedScene")` 为 false → `1008`
+   （不碰当前场景就失败，避免半切换状态）
+3. `get_tree().change_scene_to_file(path)` 返回非 OK → `1008`
+4. 等 ready 逻辑与 reload 共用（私有 helper `_await_new_scene_ready(old, timeout)`）
+5. 成功返回同 reload
+
+### 2. 错误码
+
+`error_codes.gd` 新增 `SCENE_UNAVAILABLE = 1008`，覆盖：
+
+- reload 时无 current scene
+- change 的 res 路径不存在 / 加载失败 / change_scene_to_file 返回 Error
+- 等新场景 ready 超时
+
+### 3. Python 三层
+
+- **client.py**：`async def scene_reload(self, timeout: float = 10.0) -> dict`、
+  `async def scene_change(self, path: str, timeout: float = 10.0) -> dict`；
+  RPC 网络超时 = 业务 timeout + 5.0（对齐 wait_signal 先例）
+- **bridge.py**：两个同步包装
+- **cli.py**：两个 `RpcSpec`：
+  - `scene-reload [--timeout N]`
+  - `scene-change <res-path> [--timeout N]`
+  - preflight（仅 scene-change）：path 必须以 `res://` 或 `uid://` 开头，
+    否则连 daemon 前 `-1003` + exit 64（契约 5）
+  - text_formatter：`scene reloaded: res://main.tscn (root: Main)` /
+    `scene changed: res://second.tscn (root: Second)`
+  - 退出码走默认语义（0 成功 / 1 RPC 错 / 2 连接错 / 64 用法错），
+    不需要 `exit_code_from`
+
+### 4. pytest plugin
+
+```python
+@pytest.fixture
+def fresh_scene(bridge: GameBridge) -> Iterator[GameBridge]:
+    bridge.scene_reload()
+    yield bridge
+```
+
+- setup 时 reload 并等 ready；teardown 不动作
+  （语义：「本用例开始时场景是干净的」，下个要干净的用例自己声明）
+- 放在 `pytest_plugin.py` 现有 `bridge` fixture 之后
+
+## 测试策略
+
+| 层 | 文件 | 覆盖 |
+|---|---|---|
+| GUT | `tests/gut/test_scene_api.gd`（新） | 参数校验 -32602；无 current_scene → 1008；路径不存在 → 1008。真 reload/change 受 GUT script-mode runner 环境限制，由 e2e 兜底 |
+| Python 单测 | test_cli.py / test_bridge.py / test_client.py | preflight 前缀校验、text_formatter、RpcSpec 注册完整性、bridge/client 包装（mock transport） |
+| e2e | `test_e2e_scene.py`（新） | platformer-demo 加 `second.tscn`；真跑：改属性 → scene-reload → 属性归位；scene-change → tree 验证新根节点；fresh_scene fixture 全链路 |
+
+## 文档同步（契约 7）
+
+- SKILL.md 模板：Command catalogue 加 **Scene 分组**（scene-reload / scene-change）、
+  错误码表加 1008、pytest plugin 段加 fresh_scene、Common pitfalls 加
+  「场景切换后旧节点路径全部失效，需重新 wait-node 定位」
+- addon README：命令表 / 错误码表同步
+- 跑 `python -c "from godot_cli_control import cli; print(cli.format_full_help())"` 验证渲染
+
+## 不做的事（YAGNI）
+
+- 不加 `@pytest.mark.fresh_scene` marker
+- 不做「恢复到主场景 / 可配置目标场景」
+- 不做 `change_scene_to_packed` / 场景栈管理
+- 不动 method blacklist（scene 操作走专用 RPC，不经 `call` 通道）

--- a/examples/platformer-demo/second.tscn
+++ b/examples/platformer-demo/second.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3]
+
+[node name="Second" type="Node2D"]
+
+[node name="Marker" type="Label" parent="."]
+text = "second scene"

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -98,6 +98,14 @@ class GameBridge:
         """等 N 帧（issue #96）。确定性帧推进，替代短 sleep。"""
         return self._run(self._client.wait_frames(frames, physics=physics))
 
+    def scene_reload(self, timeout: float = 10.0) -> dict:
+        """重载当前场景并等新场景 ready（issue #98）。返回 {"scene_path": ..., "name": ...}。"""
+        return self._run(self._client.scene_reload(timeout=timeout))
+
+    def scene_change(self, path: str, timeout: float = 10.0) -> dict:
+        """切换场景并等新场景 ready（issue #98）。path 须为 res:// 或 uid://。"""
+        return self._run(self._client.scene_change(path, timeout=timeout))
+
     # ── UI 交互 ──
 
     def click(self, path: str) -> dict:

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -286,6 +286,22 @@ def _preflight_wait_frames(ns: argparse.Namespace) -> None:
         raise ValueError(f"wait-frames: frames 必须在 1..3600，收到 {frames}")
 
 
+def _preflight_scene_reload(ns: argparse.Namespace) -> None:
+    timeout = _require_float(ns.timeout, "scene-reload", "timeout")
+    if not 0 < timeout <= 3600:
+        raise ValueError(f"scene-reload: timeout 必须 > 0 且 <= 3600 秒，收到 {timeout}")
+
+
+def _preflight_scene_change(ns: argparse.Namespace) -> None:
+    if not ns.scene_path.startswith(("res://", "uid://")):
+        raise ValueError(
+            f"scene-change: 场景路径必须以 res:// 或 uid:// 开头，收到 {ns.scene_path!r}"
+        )
+    timeout = _require_float(ns.timeout, "scene-change", "timeout")
+    if not 0 < timeout <= 3600:
+        raise ValueError(f"scene-change: timeout 必须 > 0 且 <= 3600 秒，收到 {timeout}")
+
+
 def _combo_total_duration(steps: list[dict]) -> float:
     """combo 全部 step 的累计 game-time（给 ``--wait`` 算阻塞时长，issue #90）。
 
@@ -466,6 +482,14 @@ async def cmd_wait_frames(client: GameClient, ns: argparse.Namespace) -> dict:
     return await client.wait_frames(int(ns.frames), physics=ns.physics)
 
 
+async def cmd_scene_reload(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.scene_reload(timeout=float(ns.timeout))
+
+
+async def cmd_scene_change(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.scene_change(ns.scene_path, timeout=float(ns.timeout))
+
+
 async def cmd_pressed(
     client: GameClient, ns: argparse.Namespace
 ) -> list[str]:
@@ -634,6 +658,17 @@ def _register_wait_prop_args(p: argparse.ArgumentParser) -> None:
 def _register_wait_frames_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("frames", help="等待帧数（1..3600）")
     p.add_argument("--physics", action="store_true", help="等 physics_frame（默认 process_frame）")
+
+
+def _register_scene_reload_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--timeout", default="10",
+                   help="等新场景 ready 的超时秒（>0 且 <=3600，默认 10）")
+
+
+def _register_scene_change_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("scene_path", help="目标场景资源路径（res:// 或 uid://）")
+    p.add_argument("--timeout", default="10",
+                   help="等新场景 ready 的超时秒（>0 且 <=3600，默认 10）")
 
 
 def _register_set_args(p: argparse.ArgumentParser) -> None:
@@ -942,6 +977,33 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
         extra_args=_register_wait_frames_args,
         preflight=_preflight_wait_frames,
         text_formatter=lambda r: f"waited {r.get('frames')} frames",
+    ),
+    RpcSpec(
+        name="scene-reload",
+        handler=cmd_scene_reload,
+        description=(
+            "重载当前场景并阻塞到新场景 ready（per-test 隔离原语）。"
+            "失败（无 current scene / 超时）报 1008，exit 1。"
+            "注意：返回后此前缓存的所有节点路径/引用全部失效。"
+        ),
+        positionals=(),  # 由 extra_args 注册
+        example="scene-reload",
+        extra_args=_register_scene_reload_args,
+        preflight=_preflight_scene_reload,
+        text_formatter=lambda r: f"scene reloaded: {r.get('scene_path')} (root: {r.get('name')})",
+    ),
+    RpcSpec(
+        name="scene-change",
+        handler=cmd_scene_change,
+        description=(
+            "切换到指定场景并阻塞到新场景 ready。路径不存在/加载失败/超时 "
+            "报 1008，exit 1。"
+        ),
+        positionals=(),  # 由 extra_args 注册
+        example="scene-change res://levels/level2.tscn",
+        extra_args=_register_scene_change_args,
+        preflight=_preflight_scene_change,
+        text_formatter=lambda r: f"scene changed: {r.get('scene_path')} (root: {r.get('name')})",
     ),
     RpcSpec(
         name="pressed",

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -381,7 +381,8 @@ class GameClient:
     async def scene_change(self, path: str, timeout: float = 10.0) -> dict:
         """切换到指定场景并等新场景 ready（issue #98）。
 
-        path 须为 res:// 或 uid:// 资源路径；不存在/加载失败/超时 → 1008。
+        成功返回 {"scene_path": ..., "name": ...}；path 须为 res:// 或
+        uid:// 资源路径，不存在/加载失败/超时 → 1008，会抛异常。
         """
         return await self.request(
             "scene_change", {"path": path, "timeout": timeout}, timeout=timeout + 5.0

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -368,6 +368,25 @@ class GameClient:
             timeout=max(30.0, frames / 10.0 + 10.0),
         )
 
+    async def scene_reload(self, timeout: float = 10.0) -> dict:
+        """重载当前场景并等新场景 ready（issue #98）。
+
+        成功返回 {"scene_path": ..., "name": ...}；无 current scene /
+        等 ready 超时走 RPC error（1008 SCENE_UNAVAILABLE），会抛异常。
+        """
+        return await self.request(
+            "scene_reload", {"timeout": timeout}, timeout=timeout + 5.0
+        )
+
+    async def scene_change(self, path: str, timeout: float = 10.0) -> dict:
+        """切换到指定场景并等新场景 ready（issue #98）。
+
+        path 须为 res:// 或 uid:// 资源路径；不存在/加载失败/超时 → 1008。
+        """
+        return await self.request(
+            "scene_change", {"path": path, "timeout": timeout}, timeout=timeout + 5.0
+        )
+
     async def wait_game_time(self, seconds: float) -> dict:
         """按 Godot game time 等待 N 秒。
 

--- a/python/godot_cli_control/pytest_plugin.py
+++ b/python/godot_cli_control/pytest_plugin.py
@@ -111,7 +111,7 @@ def bridge(godot_daemon: Daemon) -> Iterator[GameBridge]:
 
 @pytest.fixture
 def fresh_scene(bridge: GameBridge) -> Iterator[GameBridge]:
-    """Function-scoped：setup 时 reload 当前场景并等新场景 ready（issue #98）。
+    """Function-scoped：setup 时调 bridge.scene_reload() 等新场景 ready（issue #98）。
 
     语义是「本用例开始时场景是干净的」：teardown 不做事，下一个需要干净
     场景的用例自己声明 fresh_scene。reload 后此前缓存的节点路径全部失效。

--- a/python/godot_cli_control/pytest_plugin.py
+++ b/python/godot_cli_control/pytest_plugin.py
@@ -1,4 +1,4 @@
-"""pytest 插件：``godot_daemon`` (session) + ``bridge`` (function) fixtures。
+"""pytest 插件：``godot_daemon`` (session) + ``bridge`` (function) + ``fresh_scene`` (function) fixtures。
 
 加载路径：
   - ``pip install godot-cli-control[pytest]`` 装上 pytest 后，pytest 启动时
@@ -107,3 +107,17 @@ def bridge(godot_daemon: Daemon) -> Iterator[GameBridge]:
         except Exception:  # noqa: BLE001 — 关闭路径，吞掉残留以保证 close 一定跑
             pass
         b.close()
+
+
+@pytest.fixture
+def fresh_scene(bridge: GameBridge) -> Iterator[GameBridge]:
+    """Function-scoped：setup 时 reload 当前场景并等新场景 ready（issue #98）。
+
+    语义是「本用例开始时场景是干净的」：teardown 不做事，下一个需要干净
+    场景的用例自己声明 fresh_scene。reload 后此前缓存的节点路径全部失效。
+
+        def test_jump(godot_daemon, fresh_scene):
+            fresh_scene.click("/root/Game/Start")   # fresh_scene 即 bridge
+    """
+    bridge.scene_reload()
+    yield bridge

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -142,7 +142,7 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 |---|---|
 | `-1001` | Connection failure (daemon not running, port wrong, proxy hijacking localhost). Run `daemon status`. |
 | `-1002` | Timeout waiting for a response. Daemon may be hung mid-frame; check Godot stderr. |
-| `-1003` | Usage error (`combo` got no steps, malformed `--steps-json`, `combo -` from a TTY, a non-numeric `tap`/`wait-time` arg, a `set`/`call` value that fails JSON parsing, script path not found, or script missing `run(bridge)`). Always exits **64** (#111). Fix the invocation. |
+| `-1003` | Usage error (`combo` got no steps, malformed `--steps-json`, `combo -` from a TTY, a non-numeric `tap`/`wait-time` arg, a `scene-change` path not starting with `res://`/`uid://`, a `scene-reload`/`scene-change` `--timeout` outside `(0, 3600]`, a `set`/`call` value that fails JSON parsing, script path not found, or script missing `run(bridge)`). Always exits **64** (#111). Fix the invocation. |
 | `-1004` | Local file IO error (e.g. `screenshot` can't write the destination — bad path, no write permission). **Not** a daemon problem. |
 | `-1005` | `run <script>` user script raised an uncaught exception. The error message has the exception type + last-line summary; full traceback is on stderr. Fix the script, not the CLI. |
 | `-1006` | Infra pre-condition failure (`daemon start` / `daemon stop` / `run`'s auto-start failed at the OS level — port conflict, Godot binary not found, PID file missing, etc.). Always exits **2** (#92). Fix the environment, not the invocation. |

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -126,6 +126,7 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 | `1005` | Scene tree too large to serialize (default safety limit). Pass `--max-nodes` or query a subtree with `children` / `tree <subpath>`. Don't retry as-is. |
 | `1006` | Resource transiently unavailable (e.g. screenshot during scene transition / window resize). Rare under normal use: GameBridge waits for viewport first-frame before accepting connections, and `screenshot` retries internally up to ~30 frames (~500ms at 60 fps, ~1s at 30 fps, longer when `--write-movie` lowers the fixed fps). If you still see this, retry after `wait-time 0.05` or similar. |
 | `1007` | Signal not found on the node (`wait-signal` schema error — signal name typo or the node doesn't define it). Permanent — don't retry; inspect with `tree` to list available signals. |
+| `1008` | Scene unavailable (`scene-reload` / `scene-change`): no current scene, scene file missing / failed to load, or timed out waiting for the new scene to become ready. Missing file is permanent — fix the path; timeout usually means the scene itself fails to load — inspect the daemon log. |
 
 **JSON-RPC standard — negative integers `-32xxx`:**
 
@@ -184,6 +185,10 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 - `wait-prop <path> <prop> <json-value> [--op eq|ne|gt|lt|ge|le] [--timeout N] [--tolerance N]` — block until property satisfies condition (exit 0=matched, 1=timeout). Example: `wait-prop /root/Player position:x 500 --op gt`. Default `--op eq`, `--timeout 5.0`, `--tolerance 0.0`.
 - `wait-signal <path> <signal> [--timeout N]` — block until signal fires (exit 0=emitted, 1=timeout). Result on success: `{"emitted": true, "args": [...]}`. Result on miss: `{"emitted": false, "reason": "timeout"|"node_freed"}` — `"timeout"` means the signal never fired within the deadline; `"node_freed"` means the target node was freed during the wait (use this to distinguish a race from a stale path).
 - `wait-frames <N> [--physics]` — advance exactly N process frames (or physics frames with `--physics`). Result: `{"success": true, "frames": N}`.
+
+**Scene:**
+- `scene-reload [--timeout N]` — reload the current scene and block until the new instance is ready (per-test isolation primitive). All previously cached node paths become stale after it returns.
+- `scene-change <res://path.tscn> [--timeout N]` — switch to another scene and block until ready. Path must start with `res://` or `uid://` (checked before connecting). `--timeout` must be > 0 and <= 3600 (default 10).
 
 **Render:**
 - `screenshot <path>` — write PNG (path is **required** as of 0.2.0)
@@ -392,6 +397,16 @@ def test_jump(godot_daemon, bridge):
 
 - **`godot_daemon`** *(session-scoped)*: starts the daemon for the whole test session and stops it at teardown. If a daemon was **already running** when the session started, the fixture leaves it alone — neither restarts nor kills it. Same test file works in CI and during interactive development.
 - **`bridge`** *(function-scoped)*: a fresh `GameBridge` per test; on teardown it calls `release_all()` and closes the socket so a `hold`/`press` left dangling by one test can't bleed into the next.
+- **`fresh_scene`** *(function-scoped)*: reloads the current scene before the test so it starts from a clean state; yields the same `bridge` object. Use this as a lightweight per-test isolation primitive whenever leftover scene state between tests would cause flakiness — it's cheaper than restarting the daemon.
+
+```python
+def test_score_resets_on_reload(godot_daemon, fresh_scene):
+    # fresh_scene is the bridge — scene was already reloaded at setup
+    assert fresh_scene.get_property("/root/Game", "score") == 0
+    fresh_scene.call_method("/root/Game", "add_score", [10])
+    assert fresh_scene.get_property("/root/Game", "score") == 10
+    # next test that uses fresh_scene starts from score == 0 again
+```
 
 Pytest CLI options the plugin adds:
 
@@ -439,6 +454,8 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **Arrays/Dicts nested inside compound Variants encode as arrays but carry no `type` field — use a sub-path to read a typed leaf.** For example, a `Dictionary` property that happens to contain a `Vector3` will give you an untyped array. If you need the type, use `get <node> mydict:somekey` to read the leaf directly and get its type.
 - **Sub-path reading a non-existent leaf returns `null` — indistinguishable from a real `null` value (typo only detected at the top-level name).** `get /root/Node position:typo` returns `{"value": null}` with no error — the `":" `suffix is not validated beyond checking that `"position"` exists as a top-level property. Verify your leaf name carefully; the only error you'll get is `1002` if the part before `":"` itself doesn't exist.
 - **Python API (`bridge.get_property` / `bridge.get_properties`) returns bare values only — no `type` field.** These convenience methods strip the `type` from the server response to reduce boilerplate. When you need the `type` field (e.g. to distinguish `Vector2` from a plain 2-element array), go through `client.request("get_property", {"path": ..., "property": ...})` directly.
+- **After `scene-change` / `scene-reload`, all node paths from the previous scene are stale** — re-locate nodes with `wait-node` before touching them. The new scene root is a brand-new tree; any path cached from the old scene will return `1001 "node not found"`.
+- **`scene-reload` returning means the OLD scene instance was freed — never reuse node references/paths cached before the reload.** The command blocks until the new scene is ready, but the path strings that were valid in the old scene may now point to different nodes or nothing at all. Always re-query after a reload.
 
 ---
 

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -131,6 +131,12 @@ class _StubClient:
     async def wait_frames(self, frames: int, physics: bool = False) -> dict:
         return self._record("wait_frames", (frames,), {"physics": physics})
 
+    async def scene_reload(self, timeout: float = 10.0) -> dict:
+        return self._record("scene_reload", (), {"timeout": timeout})
+
+    async def scene_change(self, path: str, timeout: float = 10.0) -> dict:
+        return self._record("scene_change", (path,), {"timeout": timeout})
+
 
 @pytest.fixture
 def stub_client(monkeypatch: pytest.MonkeyPatch) -> _StubClient:
@@ -546,4 +552,45 @@ def test_wait_frames_delegates_params(stub_client: dict) -> None:
         {"physics": True},
     )
     assert result == {"success": True, "frames": 5}
+    b.close()
+
+
+# ── issue #98: scene_reload / scene_change bridge 委托 ──
+
+
+def test_scene_reload_delegates_to_client(stub_client: dict) -> None:
+    """bridge.scene_reload() 委托给 client.scene_reload，返回值透传。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["scene_reload"] = {"scene_path": "res://Main.tscn", "name": "Main"}
+    result = b.scene_reload()
+    assert c.calls[-1] == ("scene_reload", (), {"timeout": 10.0})
+    assert result == {"scene_path": "res://Main.tscn", "name": "Main"}
+    b.close()
+
+
+def test_scene_reload_custom_timeout(stub_client: dict) -> None:
+    """bridge.scene_reload(timeout=3.0) 把 timeout 透传到 client。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["scene_reload"] = {"scene_path": "res://Main.tscn", "name": "Main"}
+    b.scene_reload(timeout=3.0)
+    assert c.calls[-1] == ("scene_reload", (), {"timeout": 3.0})
+    b.close()
+
+
+def test_scene_change_delegates_to_client(stub_client: dict) -> None:
+    """bridge.scene_change(path) 委托给 client.scene_change，参数透传，返回值透传。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["scene_change"] = {"scene_path": "res://a.tscn", "name": "A"}
+    result = b.scene_change("res://a.tscn")
+    assert c.calls[-1] == ("scene_change", ("res://a.tscn",), {"timeout": 10.0})
+    assert result == {"scene_path": "res://a.tscn", "name": "A"}
+    b.close()
+
+
+def test_scene_change_custom_timeout(stub_client: dict) -> None:
+    """bridge.scene_change(path, timeout=5.0) 把所有参数透传到 client。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["scene_change"] = {"scene_path": "res://b.tscn", "name": "B"}
+    b.scene_change("res://b.tscn", timeout=5.0)
+    assert c.calls[-1] == ("scene_change", ("res://b.tscn",), {"timeout": 5.0})
     b.close()

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1311,8 +1311,14 @@ def test_scene_change_preflight_rejects_bad_prefix(
     """
     import json as _json
 
+    import godot_cli_control.cli as cli_mod
     from godot_cli_control.cli import EXIT_USAGE, main
 
+    class _ShouldNotConnect:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            raise AssertionError("preflight 失效：scene-change 坏前缀时不应连 daemon")
+
+    monkeypatch.setattr(cli_mod, "GameClient", _ShouldNotConnect)
     monkeypatch.setattr(
         sys, "argv", ["godot-cli-control", "scene-change", "second.tscn"]
     )

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1301,6 +1301,78 @@ def test_daemon_start_rejects_record_with_explicit_headless(
     assert "headless" in payload["error"]["message"]
 
 
+def test_scene_change_preflight_rejects_bad_prefix(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """scene-change 非 res://、uid:// 路径：连 daemon 前 -1003 + exit 64。
+
+    main() 不接参数（读 sys.argv、以 sys.exit 退出）——必须用
+    test_cli.py 现有 preflight 测试的 monkeypatch+SystemExit 模式。
+    """
+    import json as _json
+
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    monkeypatch.setattr(
+        sys, "argv", ["godot-cli-control", "scene-change", "second.tscn"]
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == EXIT_USAGE  # 64
+    payload = _json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert "res://" in payload["error"]["message"]
+
+
+def test_scene_specs_registered() -> None:
+    from godot_cli_control.cli import RPC_BY_NAME
+
+    for name in ("scene-reload", "scene-change"):
+        spec = RPC_BY_NAME[name]
+        assert spec.preflight is not None
+        assert spec.text_formatter({"scene_path": "res://m.tscn", "name": "M"})
+
+
+def test_scene_text_formatters() -> None:
+    from godot_cli_control.cli import RPC_BY_NAME
+
+    r = {"scene_path": "res://main.tscn", "name": "Main"}
+    assert RPC_BY_NAME["scene-reload"].text_formatter(r) == \
+        "scene reloaded: res://main.tscn (root: Main)"
+    assert RPC_BY_NAME["scene-change"].text_formatter(r) == \
+        "scene changed: res://main.tscn (root: Main)"
+
+
+@pytest.mark.parametrize("bad_timeout", ["-1", "0"])
+def test_scene_reload_preflight_rejects_bad_timeout(
+    bad_timeout: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """scene-reload --timeout <=0 必须在连 daemon 之前报 EXIT_USAGE。"""
+    import json as _json
+
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    class _ShouldNotConnect:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            raise AssertionError("preflight 失效：scene-reload 非法 timeout 时不应连 daemon")
+
+    import godot_cli_control.cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "GameClient", _ShouldNotConnect)
+    monkeypatch.setattr(sys, "argv", ["godot-cli-control", "scene-reload", "--timeout", bad_timeout])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == EXIT_USAGE
+    payload = _json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert "timeout" in payload["error"]["message"]
+
+
 def test_daemon_stop_emits_json_envelope(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1329,6 +1329,7 @@ def test_scene_change_preflight_rejects_bad_prefix(
     assert payload["ok"] is False
     assert payload["error"]["code"] == -1003
     assert "res://" in payload["error"]["message"]
+    assert "uid://" in payload["error"]["message"]
 
 
 def test_scene_specs_registered() -> None:
@@ -1337,7 +1338,6 @@ def test_scene_specs_registered() -> None:
     for name in ("scene-reload", "scene-change"):
         spec = RPC_BY_NAME[name]
         assert spec.preflight is not None
-        assert spec.text_formatter({"scene_path": "res://m.tscn", "name": "M"})
 
 
 def test_scene_text_formatters() -> None:
@@ -1359,16 +1359,45 @@ def test_scene_reload_preflight_rejects_bad_timeout(
     """scene-reload --timeout <=0 必须在连 daemon 之前报 EXIT_USAGE。"""
     import json as _json
 
+    import godot_cli_control.cli as cli_mod
     from godot_cli_control.cli import EXIT_USAGE, main
 
     class _ShouldNotConnect:
         def __init__(self, *_: Any, **__: Any) -> None:
             raise AssertionError("preflight 失效：scene-reload 非法 timeout 时不应连 daemon")
 
-    import godot_cli_control.cli as cli_mod
-
     monkeypatch.setattr(cli_mod, "GameClient", _ShouldNotConnect)
     monkeypatch.setattr(sys, "argv", ["godot-cli-control", "scene-reload", "--timeout", bad_timeout])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == EXIT_USAGE
+    payload = _json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert "timeout" in payload["error"]["message"]
+
+
+@pytest.mark.parametrize("bad_timeout", ["-1", "0"])
+def test_scene_change_preflight_rejects_bad_timeout(
+    bad_timeout: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """scene-change --timeout <=0 必须在连 daemon 之前报 EXIT_USAGE。"""
+    import json as _json
+
+    import godot_cli_control.cli as cli_mod
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    class _ShouldNotConnect:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            raise AssertionError("preflight 失效：scene-change 非法 timeout 时不应连 daemon")
+
+    monkeypatch.setattr(cli_mod, "GameClient", _ShouldNotConnect)
+    monkeypatch.setattr(
+        sys, "argv", ["godot-cli-control", "scene-change", "res://ok.tscn", "--timeout", bad_timeout]
+    )
 
     with pytest.raises(SystemExit) as exc:
         main()

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -687,3 +687,82 @@ async def test_wait_frames_sends_correct_rpc_params_and_calculates_timeout() -> 
 
     assert captured[1]["params"] == {"frames": 300, "physics": True}
     assert captured[1]["timeout"] == 40.0
+
+
+# ---- issue #98: scene_reload / scene_change client 包装 ----
+
+
+@pytest.mark.asyncio
+async def test_scene_reload_sends_correct_rpc_params() -> None:
+    """scene_reload 必须发出 method="scene_reload"，params={"timeout": 10.0}，RPC timeout=15.0。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        captured["timeout"] = timeout
+        return {"scene_path": "res://Main.tscn", "name": "Main"}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.scene_reload()
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "scene_reload"
+    assert captured["params"] == {"timeout": 10.0}
+    assert captured["timeout"] == 10.0 + 5.0
+    assert result == {"scene_path": "res://Main.tscn", "name": "Main"}
+
+
+@pytest.mark.asyncio
+async def test_scene_reload_custom_timeout_sends_correct_rpc_params() -> None:
+    """scene_reload(timeout=3.0) 发出 params={"timeout": 3.0}，RPC timeout=8.0。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        captured["timeout"] = timeout
+        return {"scene_path": "res://Main.tscn", "name": "Main"}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        await client.scene_reload(timeout=3.0)
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["params"] == {"timeout": 3.0}
+    assert captured["timeout"] == 3.0 + 5.0
+
+
+@pytest.mark.asyncio
+async def test_scene_change_sends_correct_rpc_params() -> None:
+    """scene_change 必须发出 method="scene_change"，params={"path": ..., "timeout": ...}，RPC timeout=timeout+5。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        captured["timeout"] = timeout
+        return {"scene_path": "res://a.tscn", "name": "A"}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.scene_change("res://a.tscn", timeout=3.0)
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "scene_change"
+    assert captured["params"] == {"path": "res://a.tscn", "timeout": 3.0}
+    assert captured["timeout"] == 3.0 + 5.0
+    assert result == {"scene_path": "res://a.tscn", "name": "A"}

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -738,6 +738,7 @@ async def test_scene_reload_custom_timeout_sends_correct_rpc_params() -> None:
         await client.scene_reload(timeout=3.0)
     finally:
         client_mod.GameClient.request = orig
+    assert captured["method"] == "scene_reload"
     assert captured["params"] == {"timeout": 3.0}
     assert captured["timeout"] == 3.0 + 5.0
 

--- a/python/tests/test_e2e_scene.py
+++ b/python/tests/test_e2e_scene.py
@@ -128,6 +128,11 @@ def test_scene_change_missing_scene_returns_1008(daemon: Any) -> None:
     r = _run_cli(project, "scene-change", "res://__missing__.tscn")
     assert r["ok"] is False
     assert r["error"]["code"] == 1008
+    # 路径校验在碰场景之前（ResourceLoader.exists 先行）：
+    # 1008 后 daemon 仍存活、当前场景不变
+    assert _run_cli(project, "exists", "/root/Main")["result"] is True, (
+        "scene-change 失败不应破坏当前场景"
+    )
 
 
 def test_bridge_scene_reload_roundtrip(daemon: Any) -> None:

--- a/python/tests/test_e2e_scene.py
+++ b/python/tests/test_e2e_scene.py
@@ -1,0 +1,144 @@
+"""端到端回归：scene-reload / scene-change 全链路。
+
+验证点：
+  - scene-reload 让已污染的属性归位（重载即重置）
+  - scene-change 切换到 second.tscn，旧场景根不再存在
+  - scene-change 指向不存在的场景 → 信封 ok=false error.code==1008
+  - GameBridge.scene_reload() 直连链路（fresh_scene fixture 的核心调用）
+
+需要真实 Godot 4：PATH 里有 godot（或设 GODOT_BIN），否则整文件 skip。
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from godot_cli_control.daemon import find_godot_binary
+
+# 与生产 daemon 用同一套 godot 检测（GODOT_BIN > macOS .app > PATH > Windows）。
+_GODOT_BIN = find_godot_binary()
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEMO_SRC = _REPO_ROOT / "examples" / "platformer-demo"
+_ADDON_SRC = _REPO_ROOT / "addons" / "godot_cli_control"
+
+pytestmark = pytest.mark.skipif(
+    not _GODOT_BIN,
+    reason="需要真实 Godot 4：把 godot 装进 PATH 或设 GODOT_BIN，否则整文件 skip",
+)
+
+# 用 `python -m godot_cli_control` 调 CLI：与 PATH 无关，always 命中当前环境。
+_CLI = [sys.executable, "-m", "godot_cli_control"]
+
+# demo 的 project.godot 故意不含这两段（留给 init）。测试里直接 append，等价于
+# init 的 patch，但不依赖 init 的 godot 探测 / 重导入，更可控、与其它 e2e 一致。
+_BRIDGE_SECTIONS = """
+[autoload]
+
+GameBridgeNode="*res://addons/godot_cli_control/bridge/game_bridge.gd"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/godot_cli_control/plugin.cfg")
+"""
+
+
+def _run_cli(project: Path, *args: str, timeout: float = 60.0) -> dict[str, Any]:
+    """跑一条 CLI 子命令（独立进程 = 独立连接），解析最后一行 JSON 信封。"""
+    proc = subprocess.run(
+        _CLI + list(args),
+        cwd=project,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    json_lines = [ln for ln in proc.stdout.splitlines() if ln.strip().startswith("{")]
+    assert json_lines, f"无 JSON 输出：args={args} stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    return json.loads(json_lines[-1])
+
+
+@pytest.fixture(scope="module")
+def demo_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """把 examples/platformer-demo 拷到 tmp，接上 addon + bridge 段，导入一次。"""
+    proj = tmp_path_factory.mktemp("gcc_scene")
+    for name in ("project.godot", "main.tscn", "main.gd", "player.gd", "second.tscn"):
+        shutil.copy(_DEMO_SRC / name, proj / name)
+    (proj / "addons").mkdir()
+    shutil.copytree(_ADDON_SRC, proj / "addons" / "godot_cli_control")
+    with (proj / "project.godot").open("a", encoding="utf-8") as f:
+        f.write(_BRIDGE_SECTIONS)
+
+    # 先跑一次编辑器导入，注册全局 class + 资源 .import（headless 导入即可）。
+    imp = subprocess.run(
+        [_GODOT_BIN, "--headless", "--editor", "--quit", "--path", str(proj)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert imp.returncode == 0, f"Godot 导入失败：{imp.stdout}\n{imp.stderr}"
+    return proj
+
+
+@pytest.fixture
+def daemon(demo_project: Path) -> Any:
+    """每个用例起 / 停一个真实 headless daemon。"""
+    start = _run_cli(demo_project, "daemon", "start", "--headless", timeout=90)
+    assert start["ok"] is True and start["result"]["started"], start
+    try:
+        yield demo_project
+    finally:
+        _run_cli(demo_project, "daemon", "stop", timeout=30)
+
+
+def test_scene_reload_resets_mutated_state(daemon: Any) -> None:
+    project = daemon
+    assert _run_cli(project, "wait-node", "/root/Main/UI/StartButton")["result"]["found"]
+    # 污染场景状态
+    assert _run_cli(project, "set", "/root/Main/UI/StartButton", "text", '"DIRTY"')["ok"]
+    dirty = _run_cli(project, "get", "/root/Main/UI/StartButton", "text")
+    assert dirty["result"]["value"] == "DIRTY"
+    # reload → 状态归位
+    r = _run_cli(project, "scene-reload")
+    assert r["ok"] is True, r
+    assert r["result"]["name"] == "Main"
+    assert r["result"]["scene_path"] == "res://main.tscn"
+    clean = _run_cli(project, "get", "/root/Main/UI/StartButton", "text")
+    assert clean["result"]["value"] == "Start", "reload 后属性应回到场景文件初值"
+
+
+def test_scene_change_switches_to_second(daemon: Any) -> None:
+    project = daemon
+    assert _run_cli(project, "wait-node", "/root/Main")["result"]["found"]
+    r = _run_cli(project, "scene-change", "res://second.tscn")
+    assert r["ok"] is True, r
+    assert r["result"]["name"] == "Second"
+    assert _run_cli(project, "exists", "/root/Second")["result"] is True
+    # 旧场景根应已不在
+    assert _run_cli(project, "exists", "/root/Main")["result"] is False
+
+
+def test_scene_change_missing_scene_returns_1008(daemon: Any) -> None:
+    project = daemon
+    r = _run_cli(project, "scene-change", "res://__missing__.tscn")
+    assert r["ok"] is False
+    assert r["error"]["code"] == 1008
+
+
+def test_bridge_scene_reload_roundtrip(daemon: Any) -> None:
+    """fresh_scene fixture 的核心调用（bridge.scene_reload）真链路验证。"""
+    from godot_cli_control.bridge import GameBridge
+
+    project = daemon
+    port = int((project / ".cli_control" / "port").read_text().strip())
+    b = GameBridge(port=port)
+    try:
+        result = b.scene_reload()
+        assert result["name"] == "Main"
+    finally:
+        b.close()

--- a/python/tests/test_pytest_plugin.py
+++ b/python/tests/test_pytest_plugin.py
@@ -40,7 +40,12 @@ def test_options_registered_in_help(pytester: pytest.Pytester) -> None:
 
 
 def test_fixtures_listed(pytester: pytest.Pytester) -> None:
-    """`pytest --fixtures` 列出 godot_daemon + bridge。"""
+    """`pytest --fixtures` 列出 godot_daemon + bridge + fresh_scene。
+
+    逐个 fnmatch（顺序无关——pytest 对 fixture 的列出顺序不保证），
+    并锚定「<name> ... -- ...pytest_plugin.py」定义行格式，
+    避免 docstring 里提及其它 fixture 名造成假阳性。
+    """
     pytester.makepyfile(
         test_smoke="""
         def test_smoke():
@@ -48,7 +53,8 @@ def test_fixtures_listed(pytester: pytest.Pytester) -> None:
         """
     )
     result = pytester.runpytest("--fixtures")
-    result.stdout.fnmatch_lines(["*godot_daemon*", "*bridge*"])
+    for name in ("godot_daemon", "bridge", "fresh_scene"):
+        result.stdout.fnmatch_lines([f"{name}*-- *pytest_plugin.py*"])
 
 
 def test_fixture_lifecycle(pytester: pytest.Pytester) -> None:
@@ -391,7 +397,7 @@ def test_project_root_option_is_respected(pytester: pytest.Pytester) -> None:
 
 def test_fresh_scene_fixture(pytester: pytest.Pytester) -> None:
     """fresh_scene：setup 时 scene_reload 恰好调 1 次，yield 出 bridge 本身，
-    teardown 不再调 scene_reload（总计 1 次）。
+    teardown 不再调 scene_reload（每用例各 1 次，无额外调用）。
     """
     pytester.makeconftest(
         """

--- a/python/tests/test_pytest_plugin.py
+++ b/python/tests/test_pytest_plugin.py
@@ -382,3 +382,56 @@ def test_project_root_option_is_respected(pytester: pytest.Pytester) -> None:
     result.assert_outcomes(passed=1)
     output = result.stdout.str()
     assert str(custom_root.resolve()) in output
+
+
+# ---------------------------------------------------------------------------
+# fresh_scene fixture（issue #98）
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_scene_fixture(pytester: pytest.Pytester) -> None:
+    """fresh_scene：setup 时 scene_reload 恰好调 1 次，yield 出 bridge 本身，
+    teardown 不再调 scene_reload（总计 1 次）。
+    """
+    pytester.makeconftest(
+        """
+        from __future__ import annotations
+        import godot_cli_control.pytest_plugin as plugin
+
+        RELOAD_COUNT: list = []
+
+        class FakeDaemon:
+            def __init__(self, *a, **kw): pass
+            def is_running(self): return True
+            def start(self, **kw): pass
+            def stop(self): return 0
+            def current_port(self): return 9877
+
+        class FakeBridge:
+            def __init__(self, port): pass
+            def scene_reload(self): RELOAD_COUNT.append(1)
+            def release_all(self): pass
+            def close(self): pass
+
+        plugin.Daemon = FakeDaemon
+        plugin.GameBridge = FakeBridge
+
+        def pytest_terminal_summary(terminalreporter, exitstatus, config):
+            terminalreporter.write_line(f"RELOAD_COUNT={RELOAD_COUNT}")
+        """
+    )
+    pytester.makepyfile(
+        """
+        def test_uses_fresh_scene(fresh_scene, bridge):
+            # fresh_scene 必须是 bridge 同一个对象
+            assert fresh_scene is bridge
+
+        def test_only_one_reload(fresh_scene):
+            pass
+        """
+    )
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(passed=2)
+    output = result.stdout.str()
+    # 两个测试各调 1 次 scene_reload，合计 2 次
+    assert "RELOAD_COUNT=[1, 1]" in output, f"expected 2 reloads, got: {output}"


### PR DESCRIPTION
## Summary

issue #98 场景隔离：给下游 e2e 提供真正的 per-test 隔离原语，替代各项目重复发明的「跨用例残留」防御代码。

### RPC / GDScript
- 新建 `bridge/scene_api.gd`（对齐 #108 wait_api 拆分先例）：`scene_reload` / `scene_change` 两个 async RPC，**逐帧轮询等新场景实例 ready 才返回**（instance_id 比对 + `is_node_ready()`），调用方无需再 wait-node
- 新业务码 **1008 SCENE_UNAVAILABLE**：reload 无 current scene / change 路径不存在或加载失败 / 等 ready 超时
- timeout 合法域 `(0, 3600]` 默认 10——**拒收 0**（场景切换至少需一帧，0 恒超时是陷阱，review 阶段抓出后改为 -32602 用法错）

### CLI
- 平铺 `scene-reload [--timeout N]` / `scene-change <res://path> [--timeout N]`（对齐 wait-node 先例）
- preflight 先行（契约 5）：路径前缀须 `res://`/`uid://`、timeout 范围，连 daemon 前 `-1003` + exit 64
- 退出码走默认语义：0 成功 / 1（1008 落这）/ 2 连接错 / 64 用法错

### pytest plugin
- function-scope **`fresh_scene`** fixture：setup 时 `bridge.scene_reload()`，yield 同一 bridge；teardown 无动作（语义：「本用例开始时场景是干净的」）

### 文档（契约 7）
- SKILL.md 模板：Scene 命令组、1008 错误码行、fresh_scene、两条 pitfall（场景切换后旧节点路径全部失效）、-1003/-32602 行补 scene 情形
- addon README 同步

### 设计/计划文档
- spec：`docs/superpowers/specs/2026-06-04-scene-isolation-design.md`
- plan：`docs/superpowers/plans/2026-06-04-scene-isolation.md`
- 全程 subagent-driven TDD，每 task 过 spec 合规 + 质量两道 review，最终全量 review READY TO MERGE

Fixes #98

## Test plan
- [x] GUT 153/153（含 test_scene_api.gd 7 用例 + 注册表断言）
- [x] Python 全量 476 passed / 2 skipped，覆盖率 89%（门槛 80%）
- [x] e2e 真 Godot 4/4：reload 重置污染态、change 切场景、1008 + 失败不破坏当前场景、GameBridge 直连
- [x] `format_full_help()` 渲染 + `test_skills_install.py` init 注入回归 11/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)