### PR TITLE
feat(time): time-scale/pause/step-frames 时间控制（#102）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,4 +85,4 @@ release.sh                  # 发版脚本
 
 ## 已知遗留 issue（PR 路过时顺手修）
 
-*（截至 2026-06-04，已 land：#96/#97/#99/#100 三连 PR（wait 原语/codec/多属性读）、#111/#92 退出码语义统一、#108 wait_api 拆分、#110 wait_signal reason 字段、#112 get 路径打磨、#107 codec 深度哨兵文档、#113 probe fixture scope。仍 open：#109（KIV）；#98/#101/#102/#103（feature backlog）；#88、#18。下次 review 发现新坑请补到这里。）*
+*（截至 2026-06-05，已 land：#96/#97/#99/#100 三连（wait 原语/codec/多属性读）、#111/#92 退出码统一、#108 wait_api 拆分、#110/#112/#107/#113 收尾批、#118/#119 review 快修（PR #120）、#98 场景隔离 scene-reload/scene-change + fresh_scene（PR #121）、#102 时间控制 time-scale/pause/step-frames + 1009（本批）。仍 open：#109（KIV）；#101/#103（feature backlog）；#88、#18（需 maintainer 操作）；#122（fresh_scene 无场景启动态 pitfall 文档）、#123（GUT wait_frames deprecation）、#124（pause/time_scale 跨用例泄漏兜底，见 #102 最终 review）。下次 review 发现新坑请补到这里。）*

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -109,6 +109,10 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 | `list_input_actions(include_builtin=False)` | `await client.list_input_actions()` |
 | `scene_reload(timeout)` | `await client.scene_reload(timeout=10.0)` — reload current scene, block until ready; CLI: `scene-reload [--timeout N]` |
 | `scene_change(path, timeout)` | `await client.scene_change("res://levels/l2.tscn", timeout=10.0)` — switch scene, block until ready; CLI: `scene-change <res://path.tscn> [--timeout N]` |
+| `time_scale(value=None)` | `await client.time_scale()` — read `Engine.time_scale`; `await client.time_scale(5.0)` — set to 5×; CLI: `time-scale [value]`; valid range `(0, 100]` |
+| `pause()` | `await client.pause()` — freeze scene tree (`get_tree().paused = true`); idempotent; CLI: `pause` |
+| `unpause()` | `await client.unpause()` — resume scene tree; idempotent; CLI: `unpause` |
+| `step_frames(frames, physics=False)` | `await client.step_frames(10)` — while paused, advance exactly N frames (1..3600) then stop; CLI: `step-frames <n> [--physics]`; error `1009` if tree not paused |
 
 > **CLI note**: as a shell subcommand, `screenshot` **requires an output path** — `godot-cli-control screenshot /tmp/shot.png` — and writes the PNG to that file. Returning base64 over stdout is intentionally unsupported, to keep large binary payloads out of an automating agent's context window.
 
@@ -136,6 +140,7 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `1006` | server | Resource transiently unavailable (e.g. screenshot during scene transition). Rare under normal use — GameBridge waits for viewport first-frame before listening, and `screenshot` retries internally. Safe to retry if you do hit it. |
 | `1007` | server | Signal not found on the node (`wait-signal` schema error — signal name typo or the node doesn't define it). Permanent — don't retry; inspect with `tree` or `children` to find valid signals. |
 | `1008` | server | Scene unavailable (`scene-reload` / `scene-change`): no current scene, scene file missing / failed to load, or timed out waiting for the new scene to become ready. Fix the path (permanent) or inspect the daemon log (timeout). |
+| `1009` | server | NOT_PAUSED: `step-frames` called while the scene tree is not paused. Call `pause` first. Precondition error — not a param error (distinct from `-32602`). |
 | `-32600` | server | Malformed JSON-RPC request |
 | `-32601` | server | Unknown method name |
 | `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements, or `hold` given `duration ≤ 0` — use `press` for an indefinite hold; also out-of-range values like a scene `timeout` outside `(0, 3600]` sent directly via `GameClient`) |
@@ -155,7 +160,7 @@ The daemon is the long-lived Godot process the CLI talks to (one per project roo
 
 | Command | What it does |
 |---|---|
-| `daemon start [--headless\|--gui] [--record]` | Launch Godot with the bridge listening. Headless vs GUI is auto-detected from the TTY; `--record` forces GUI (Movie Maker needs a real renderer) and is **rejected with `--headless`** (exit 2). |
+| `daemon start [--headless\|--gui] [--record] [--time-scale N]` | Launch Godot with the bridge listening. Headless vs GUI is auto-detected from the TTY; `--record` forces GUI (Movie Maker needs a real renderer) and is **rejected with `--headless`** (exit 2). `--time-scale N` sets `Engine.time_scale` from frame 0 (range `(0, 100]`). |
 | `daemon stop` | Stop this project's daemon. Exit 2 if it stopped cleanly but the `.avi`→`.mp4` ffmpeg transcode failed (raw `.avi` kept; see `.cli_control/ffmpeg.log`). |
 | `daemon stop --all` | Stop every registered daemon across all projects. **Exit 3** if at least one failed; per-record `rc` (and an `error` field on failures) is in `result.stopped[]`. |
 | `daemon stop --project <path>` | Stop the daemon for one specific project root. |

--- a/addons/godot_cli_control/bridge/error_codes.gd
+++ b/addons/godot_cli_control/bridge/error_codes.gd
@@ -29,6 +29,9 @@ const SIGNAL_NOT_FOUND: int = 1007
 # 与 1006 拆开：1006 是「短重试可能成功」的 transient；1008 三种情形里
 # 路径不存在是永久错，超时大概率是场景加载本身坏了——agent 应停下排查。
 const SCENE_UNAVAILABLE: int = 1008
+# step_frames 的状态前置错（issue #102）：tree 未 paused 时调 step_frames。
+# 与 -32602 区分：参数本身没问题，是世界状态不满足前置——agent 应先 pause。
+const NOT_PAUSED: int = 1009
 
 const INVALID_PARAMS: int = -32602
 const INVALID_REQUEST: int = -32600

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -29,6 +29,7 @@ var _low_level_api: LowLevelApi = null
 var _input_sim_api: InputSimulationApi = null
 var _wait_api: WaitApi = null
 var _scene_api: SceneApi = null
+var _time_api: TimeApi = null
 # 方法注册表：{method_name: {"callable": Callable, "kind": "sync"|"async"|"async_with_id"}}
 # - sync: handler(params) -> Dictionary，dispatcher 立即 send response
 # - async: handler(params) -> await Dictionary，dispatcher await 后 send response
@@ -63,6 +64,15 @@ func _ready() -> void:
 	_scene_api = SceneApi.new()
 	_scene_api.name = "SceneApi"
 	add_child(_scene_api)
+	_time_api = TimeApi.new()
+	_time_api.name = "TimeApi"
+	add_child(_time_api)
+	# 启动倍速（issue #102）：非法值 parse 内已 printerr + 忽略，不挡启动
+	# 必须在 await _wait_first_frame_ready() 之前，保证「第 0 帧即倍速」
+	var startup_scale: float = TimeApi.parse_cmdline_time_scale(OS.get_cmdline_args())
+	if startup_scale > 0.0:
+		Engine.time_scale = startup_scale
+		print("GameBridge: Engine.time_scale = %s (from --cli-time-scale)" % startup_scale)
 	# 构建统一方法注册表
 	_register_methods()
 	# 缓存 outbound buffer 大小（ProjectSettings 可覆盖默认 10MB，至少 1MB）
@@ -222,6 +232,11 @@ func _register_methods() -> void:
 	# Scene API（异步）
 	_methods["scene_reload"] = {"callable": _scene_api.scene_reload_async, "kind": "async"}
 	_methods["scene_change"] = {"callable": _scene_api.scene_change_async, "kind": "async"}
+	# Time API（issue #102）
+	_methods["time_scale"] = {"callable": _time_api.handle_time_scale, "kind": "sync"}
+	_methods["pause"] = {"callable": _time_api.handle_pause, "kind": "sync"}
+	_methods["unpause"] = {"callable": _time_api.handle_unpause, "kind": "sync"}
+	_methods["step_frames"] = {"callable": _time_api.step_frames_async, "kind": "async"}
 
 
 # screenshot wrapper：take_screenshot_async 不接 params，统一签名为 (params) -> Dictionary

--- a/addons/godot_cli_control/bridge/time_api.gd
+++ b/addons/godot_cli_control/bridge/time_api.gd
@@ -1,0 +1,90 @@
+class_name TimeApi
+extends Node
+## 时间控制 API：time_scale / pause / unpause / step_frames（issue #102）
+##
+## 挂在 GameBridge（PROCESS_MODE_ALWAYS）下，tree paused 时 RPC 照常工作——
+## 这是 step_frames「paused 下推帧」的机制基础。错误码常量见 error_codes.gd。
+
+# time_scale 合法域 (0, 100]：=0 冻死 wait-time 且与 pause 职责重叠，拒收；
+# 上限防呆（误传 1e9 之类）。
+const _MAX_TIME_SCALE: float = 100.0
+# step_frames 防呆上限，对齐 wait_api._MAX_WAIT_FRAMES
+const _MAX_STEP_FRAMES: int = 3600
+
+
+## 解析 --cli-time-scale=<x> 启动参数（_parse_port_from_args 同构）。
+## 无该参数返回 -1.0；非法值（非数字 / 越界）printerr 警告后也返回 -1.0
+## ——不挡启动。静态纯查询：GameBridge 传 OS.get_cmdline_args()，GUT 传构造数组。
+static func parse_cmdline_time_scale(args: PackedStringArray) -> float:
+	for arg: String in args:
+		if arg.begins_with("--cli-time-scale="):
+			var parts: PackedStringArray = arg.split("=", false, 1)
+			if parts.size() != 2 or not parts[1].is_valid_float():
+				printerr("GameBridge: invalid %s ignored (must be a number in (0, %s])" % [arg, _MAX_TIME_SCALE])
+				return -1.0
+			var scale: float = parts[1].to_float()
+			if scale <= 0.0 or scale > _MAX_TIME_SCALE:
+				printerr("GameBridge: invalid %s ignored (must be in (0, %s])" % [arg, _MAX_TIME_SCALE])
+				return -1.0
+			return scale
+	return -1.0
+
+
+## value 缺省 = 读当前值（Engine 不是节点，get 够不着，这是唯一读通道）。
+func handle_time_scale(params: Dictionary) -> Dictionary:
+	if not params.has("value"):
+		return {"time_scale": Engine.time_scale}
+	var raw: Variant = params["value"]
+	if not (raw is int or raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'value' must be a number")
+	var scale: float = float(raw)
+	if scale <= 0.0 or scale > _MAX_TIME_SCALE:
+		return _err(
+			CliControlErrorCodes.INVALID_PARAMS,
+			"value must be > 0 and <= %s (use pause to freeze the game, not time_scale 0)" % _MAX_TIME_SCALE,
+		)
+	Engine.time_scale = scale
+	return {"time_scale": scale}
+
+
+func handle_pause(_params: Dictionary) -> Dictionary:
+	get_tree().paused = true
+	return {"paused": true}
+
+
+func handle_unpause(_params: Dictionary) -> Dictionary:
+	get_tree().paused = false
+	return {"paused": false}
+
+
+## paused 前置下确定性推进 N 帧再停。未 paused → 1009（fail-loud：
+## 教会 agent「pause → step → 断言」的正确模型，不隐式改全局状态）。
+func step_frames_async(params: Dictionary) -> Dictionary:
+	var frames_raw: Variant = params.get("frames", null)
+	if not (frames_raw is int or frames_raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'frames' must be an integer")
+	var frames: int = int(frames_raw)
+	if frames < 1 or frames > _MAX_STEP_FRAMES:
+		return _err(
+			CliControlErrorCodes.INVALID_PARAMS,
+			"frames must be 1..%d (got %d)" % [_MAX_STEP_FRAMES, frames],
+		)
+	var physics: bool = bool(params.get("physics", false))
+	if not get_tree().paused:
+		return _err(
+			CliControlErrorCodes.NOT_PAUSED,
+			"step_frames requires the tree to be paused — call pause first",
+		)
+	get_tree().paused = false
+	for _i in frames:
+		if physics:
+			await get_tree().physics_frame
+		else:
+			await get_tree().process_frame
+	# 无条件恒写：即使推进期间外力改了 paused，返回时也保证停在 paused
+	get_tree().paused = true
+	return {"stepped": frames, "paused": true}
+
+
+func _err(code: int, message: String) -> Dictionary:
+	return {"error": {"code": code, "message": message}}

--- a/addons/godot_cli_control/bridge/time_api.gd
+++ b/addons/godot_cli_control/bridge/time_api.gd
@@ -12,7 +12,8 @@ const _MAX_TIME_SCALE: float = 100.0
 const _MAX_STEP_FRAMES: int = 3600
 
 
-## 解析 --cli-time-scale=<x> 启动参数（_parse_port_from_args 同构）。
+## 解析 --cli-time-scale=<x> 启动参数（解析结构同 _parse_port_from_args，
+## 但非法值用 printerr 而非 push_warning——headless 下 stderr 是用户唯一可见渠道）。
 ## 无该参数返回 -1.0；非法值（非数字 / 越界）printerr 警告后也返回 -1.0
 ## ——不挡启动。静态纯查询：GameBridge 传 OS.get_cmdline_args()，GUT 传构造数组。
 static func parse_cmdline_time_scale(args: PackedStringArray) -> float:

--- a/addons/godot_cli_control/bridge/time_api.gd
+++ b/addons/godot_cli_control/bridge/time_api.gd
@@ -76,6 +76,9 @@ func step_frames_async(params: Dictionary) -> Dictionary:
 			"step_frames requires the tree to be paused — call pause first",
 		)
 	get_tree().paused = false
+	# 并发边界：process_frame/physics_frame 是 SceneTree 信号，paused 下也照常
+	# 发射（pause 只停节点回调，不停主循环），所以即使推进期间有并发 pause RPC
+	# 把树暂停，本循环也不会挂死——只是被暂停的那些帧不推进游戏逻辑（帧数照计）。
 	for _i in frames:
 		if physics:
 			await get_tree().physics_frame

--- a/addons/godot_cli_control/bridge/wait_api.gd
+++ b/addons/godot_cli_control/bridge/wait_api.gd
@@ -85,6 +85,10 @@ func wait_game_time_async(params: Dictionary) -> Dictionary:
 		return _err(CliControlErrorCodes.INVALID_PARAMS, "seconds must be <= %s" % _MAX_WAIT_SECONDS)
 	if seconds == 0.0:
 		return {"success": true}
+	# create_timer 的 process_always 默认 true：tree paused 时计时器照常走
+	# （e2e 依赖此语义在 paused 下用 wait-time 验证冻结）；它同时跟随
+	# Engine.time_scale（time-scale 调大 → wait 语义不变、墙钟变快，#102）。
+	# 别"优化"成显式 process_always=false——paused 下 wait-time 会永久挂死。
 	await get_tree().create_timer(seconds).timeout
 	return {"success": true}
 

--- a/addons/godot_cli_control/tests/gut/test_game_bridge.gd
+++ b/addons/godot_cli_control/tests/gut/test_game_bridge.gd
@@ -20,7 +20,6 @@ const GameBridgeScript := preload("res://addons/godot_cli_control/bridge/game_br
 const LowLevelApiScript := preload("res://addons/godot_cli_control/bridge/low_level_api.gd")
 const InputSimulationApiScript := preload("res://addons/godot_cli_control/bridge/input_simulation_api.gd")
 const WaitApiScript := preload("res://addons/godot_cli_control/bridge/wait_api.gd")
-const TimeApiScript := preload("res://addons/godot_cli_control/bridge/time_api.gd")
 
 
 # ── 子类：捕获 _send_json 出站 + 跳过 peer 状态检查 ──────────────────

--- a/addons/godot_cli_control/tests/gut/test_game_bridge.gd
+++ b/addons/godot_cli_control/tests/gut/test_game_bridge.gd
@@ -20,6 +20,7 @@ const GameBridgeScript := preload("res://addons/godot_cli_control/bridge/game_br
 const LowLevelApiScript := preload("res://addons/godot_cli_control/bridge/low_level_api.gd")
 const InputSimulationApiScript := preload("res://addons/godot_cli_control/bridge/input_simulation_api.gd")
 const WaitApiScript := preload("res://addons/godot_cli_control/bridge/wait_api.gd")
+const TimeApiScript := preload("res://addons/godot_cli_control/bridge/time_api.gd")
 
 
 # ── 子类：捕获 _send_json 出站 + 跳过 peer 状态检查 ──────────────────
@@ -105,6 +106,7 @@ var _low: StubLowLevelApi
 var _input: StubInputSimulationApi
 var _wait: StubWaitApi
 var _scene: SceneApi
+var _time: TimeApi
 
 
 func before_each() -> void:
@@ -128,10 +130,15 @@ func before_each() -> void:
 	_scene.name = "SceneApi"
 	add_child_autofree(_scene)
 
+	_time = TimeApi.new()
+	_time.name = "TimeApi"
+	add_child_autofree(_time)
+
 	_bridge._low_level_api = _low
 	_bridge._input_sim_api = _input
 	_bridge._wait_api = _wait
 	_bridge._scene_api = _scene
+	_bridge._time_api = _time
 	# InputSim 的 callback：bridge 的 _on_async_response 把 (id, result) 转回 dispatch
 	_input.setup(_bridge._on_async_response)
 	_bridge._register_methods()
@@ -506,3 +513,13 @@ func test_registry_has_scene_methods() -> void:
 	assert_eq(str(_bridge._methods["scene_reload"]["kind"]), "async")
 	assert_true(_bridge._methods.has("scene_change"), "scene_change 应已注册")
 	assert_eq(str(_bridge._methods["scene_change"]["kind"]), "async")
+
+
+# ── 注册表完整性：time API（issue #102） ─────────────────────────────
+
+func test_registry_has_time_methods() -> void:
+	for m: String in ["time_scale", "pause", "unpause"]:
+		assert_true(_bridge._methods.has(m), "%s 应已注册" % m)
+		assert_eq(str(_bridge._methods[m]["kind"]), "sync")
+	assert_true(_bridge._methods.has("step_frames"), "step_frames 应已注册")
+	assert_eq(str(_bridge._methods["step_frames"]["kind"]), "async")

--- a/addons/godot_cli_control/tests/gut/test_time_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_time_api.gd
@@ -1,0 +1,122 @@
+## GUT 单元测试：TimeApi（issue #102）
+##
+## Engine.time_scale / get_tree().paused 是全局状态，after_each 必须还原，
+## 否则污染同一进程里的其它测试文件。
+extends GutTest
+
+const TimeApiScript := preload("res://addons/godot_cli_control/bridge/time_api.gd")
+
+var _api: Node
+
+
+func before_each() -> void:
+	_api = TimeApiScript.new()
+	_api.name = "TimeApi"
+	add_child_autofree(_api)
+
+
+func after_each() -> void:
+	Engine.time_scale = 1.0
+	get_tree().paused = false
+
+
+# ── time_scale ──
+
+func test_time_scale_read_returns_current() -> void:
+	var result: Dictionary = _api.handle_time_scale({})
+	assert_does_not_have(result, "error")
+	assert_eq(float(result.get("time_scale")), 1.0)
+
+
+func test_time_scale_write_sets_engine_and_returns_new_value() -> void:
+	var result: Dictionary = _api.handle_time_scale({"value": 2.5})
+	assert_does_not_have(result, "error")
+	assert_eq(float(result.get("time_scale")), 2.5)
+	assert_eq(Engine.time_scale, 2.5)
+
+
+func test_time_scale_non_number_returns_minus_32602() -> void:
+	var result: Dictionary = _api.handle_time_scale({"value": "fast"})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+
+
+func test_time_scale_zero_returns_minus_32602() -> void:
+	## =0 冻死 wait-time 且与 pause 职责重叠，拒收
+	var result: Dictionary = _api.handle_time_scale({"value": 0.0})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+	assert_eq(Engine.time_scale, 1.0, "拒收时不得改 Engine.time_scale")
+
+
+func test_time_scale_above_max_returns_minus_32602() -> void:
+	var result: Dictionary = _api.handle_time_scale({"value": 100.5})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+
+
+# ── pause / unpause ──
+
+func test_pause_unpause_idempotent() -> void:
+	var r1: Dictionary = _api.handle_pause({})
+	assert_eq(r1.get("paused"), true)
+	assert_true(get_tree().paused)
+	var r2: Dictionary = _api.handle_pause({})
+	assert_eq(r2.get("paused"), true, "重复 pause 幂等成功")
+	var r3: Dictionary = _api.handle_unpause({})
+	assert_eq(r3.get("paused"), false)
+	assert_false(get_tree().paused)
+	var r4: Dictionary = _api.handle_unpause({})
+	assert_eq(r4.get("paused"), false, "重复 unpause 幂等成功")
+
+
+# ── step_frames ──
+
+func test_step_frames_not_paused_returns_1009() -> void:
+	var result: Dictionary = await _api.step_frames_async({"frames": 2})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1009)
+	assert_string_contains(str(result.error.message), "pause")
+
+
+func test_step_frames_invalid_frames_returns_minus_32602() -> void:
+	get_tree().paused = true
+	for bad: Variant in [null, "abc", 0, 3601]:
+		var result: Dictionary = await _api.step_frames_async({"frames": bad})
+		assert_has(result, "error", "frames=%s 应报错" % [bad])
+		assert_eq(int(result.error.code), -32602)
+
+
+func test_step_frames_advances_and_ends_paused() -> void:
+	get_tree().paused = true
+	var result: Dictionary = await _api.step_frames_async({"frames": 2})
+	assert_does_not_have(result, "error")
+	assert_eq(int(result.get("stepped")), 2)
+	assert_eq(result.get("paused"), true)
+	assert_true(get_tree().paused, "step 结束必须停在 paused")
+
+
+func test_step_frames_physics_advances() -> void:
+	get_tree().paused = true
+	var result: Dictionary = await _api.step_frames_async({"frames": 2, "physics": true})
+	assert_does_not_have(result, "error")
+	assert_eq(int(result.get("stepped")), 2)
+
+
+# ── parse_cmdline_time_scale（静态纯函数）──
+
+func test_parse_cmdline_time_scale_valid() -> void:
+	var args := PackedStringArray(["--headless", "--cli-time-scale=2.5"])
+	assert_eq(TimeApiScript.parse_cmdline_time_scale(args), 2.5)
+
+
+func test_parse_cmdline_time_scale_absent_returns_minus_1() -> void:
+	assert_eq(TimeApiScript.parse_cmdline_time_scale(PackedStringArray(["--headless"])), -1.0)
+
+
+func test_parse_cmdline_time_scale_invalid_returns_minus_1() -> void:
+	for bad: String in ["--cli-time-scale=abc", "--cli-time-scale=0", "--cli-time-scale=150", "--cli-time-scale="]:
+		assert_eq(
+			TimeApiScript.parse_cmdline_time_scale(PackedStringArray([bad])), -1.0,
+			"%s 应返回 -1" % bad
+		)

--- a/addons/godot_cli_control/tests/gut/test_wait_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_wait_api.gd
@@ -36,8 +36,8 @@ func test_wait_frames_advances_n_process_frames() -> void:
 
 
 func test_wait_frames_physics_mode() -> void:
-	# 帧边界防御，同上
-	await get_tree().process_frame
+	# 帧边界防御，同上——本用例测物理帧差，跨 physics_frame 边界才对齐
+	await get_tree().physics_frame
 	var start: int = Engine.get_physics_frames()
 	var result: Dictionary = await _api.wait_frames_async({"frames": 2, "physics": true})
 	assert_eq(result, {"success": true, "frames": 2})

--- a/addons/godot_cli_control/tests/gut/test_wait_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_wait_api.gd
@@ -26,6 +26,9 @@ func before_each() -> void:
 # ── issue #96：wait_frames ──
 
 func test_wait_frames_advances_n_process_frames() -> void:
+	# 帧边界防御：前驱 async 测试可能结束在 process_frame 发射周期内，
+	# 此时下一个 await 同帧立即解析，会让帧差测量少算 1（await-during-emission 语义）
+	await get_tree().process_frame
 	var start: int = Engine.get_process_frames()
 	var result: Dictionary = await _api.wait_frames_async({"frames": 3})
 	assert_eq(result, {"success": true, "frames": 3})
@@ -33,6 +36,8 @@ func test_wait_frames_advances_n_process_frames() -> void:
 
 
 func test_wait_frames_physics_mode() -> void:
+	# 帧边界防御，同上
+	await get_tree().process_frame
 	var start: int = Engine.get_physics_frames()
 	var result: Dictionary = await _api.wait_frames_async({"frames": 2, "physics": true})
 	assert_eq(result, {"success": true, "frames": 2})

--- a/docs/superpowers/plans/2026-06-05-time-control.md
+++ b/docs/superpowers/plans/2026-06-05-time-control.md
@@ -1,0 +1,688 @@
+# 时间控制（#102）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `time_scale` / `pause` / `unpause` / `step_frames` RPC + CLI + `daemon start --time-scale` + pytest plugin 透传，给 e2e 提供整体倍速与确定性帧推进。
+
+**Architecture:** GDScript 侧新建 `time_api.gd`（对齐 wait_api/scene_api 拆分先例）；`step_frames` 以「已 paused 前置（否则 1009）→ unpause → await N 帧 → 恒写回 paused」实现；启动倍速走 Godot cmdline arg `--cli-time-scale=<x>`（`_parse_port_from_args` 同构静态解析，第 0 帧生效）；Python 走标准三层 + daemon/plugin 两处透传。
+
+**Tech Stack:** Godot 4 GDScript + GUT 9、Python ≥3.10、websockets、pytest / pytest-asyncio。
+
+**Spec:** `docs/superpowers/specs/2026-06-04-time-control-design.md`（已批准）
+
+**分支：** `feat/102-time-control`（已建，基于 #98 合并后的 main）
+
+**仓库铁律（执行者必读，同 #98 计划）：**
+- 测试执行委托 subagent（subagent-driven 模式下 implementer 自己跑即满足）。
+- Python 覆盖率：`coverage run -m pytest`，**不能** `pytest --cov`。
+- GUT：`GODOT_BIN=$HOME/.local/bin/godot ./addons/godot_cli_control/tests/run_gut.sh`（godot 在 `~/.local/bin/godot`，必须真跑）。
+- e2e 需真实 Godot，本机必真跑。
+- 服务端错误 message 用英文（对齐现有 handler）；CLI preflight message 用中文（对齐现有 preflight）。
+
+---
+
+## File Structure
+
+| 动作 | 文件 | 职责 |
+|---|---|---|
+| Create | `addons/godot_cli_control/bridge/time_api.gd` | TimeApi：4 个 handler + 静态 cmdline 解析 |
+| Create | `addons/godot_cli_control/tests/gut/test_time_api.gd` | GUT 单测 |
+| Modify | `addons/godot_cli_control/bridge/error_codes.gd` | 加 `NOT_PAUSED = 1009` |
+| Modify | `addons/godot_cli_control/bridge/game_bridge.gd` | 实例化 TimeApi + 启动倍速 + 注册 4 RPC |
+| Modify | `addons/godot_cli_control/tests/gut/test_game_bridge.gd` | 注册表断言补 4 方法 |
+| Modify | `python/godot_cli_control/client.py` / `bridge.py` | 4 方法 ×2 层 |
+| Modify | `python/godot_cli_control/cli.py` | 4 个 RpcSpec + `daemon start --time-scale` |
+| Modify | `python/godot_cli_control/daemon.py` | `start(time_scale=None)` → argv 追加 |
+| Modify | `python/godot_cli_control/pytest_plugin.py` | `--godot-cli-time-scale` 选项透传 |
+| Create | `python/tests/test_e2e_time.py` | e2e（4 用例真 Godot） |
+| Modify | `python/tests/test_client.py` / `test_bridge.py` / `test_cli.py` / `test_daemon.py` / `test_pytest_plugin.py` | 各层单测 |
+| Modify | `python/godot_cli_control/templates/skill/SKILL.md` + `addons/godot_cli_control/README.md` | Time 命令组 + 1009 + pitfalls ×3 |
+
+---
+
+### Task 1: GDScript TimeApi（GUT TDD）
+
+**Files:**
+- Create: `addons/godot_cli_control/tests/gut/test_time_api.gd`
+- Create: `addons/godot_cli_control/bridge/time_api.gd`
+- Modify: `addons/godot_cli_control/bridge/error_codes.gd`
+
+**背景：** GUT 模式参考 `test_scene_api.gd`（#98 刚加的，同形态：错误分支 + async await）。**注意 GUT 环境里改 `Engine.time_scale` / `get_tree().paused` 会泄漏到其它测试文件——`after_each` 必须还原**。`await get_tree().process_frame` 是 SceneTree 信号、不依赖节点 process_mode，paused 下照常发射，所以 step_frames 可在 GUT 真测。
+
+- [ ] **Step 1: 写失败测试**
+
+```gdscript
+## GUT 单元测试：TimeApi（issue #102）
+##
+## Engine.time_scale / get_tree().paused 是全局状态，after_each 必须还原，
+## 否则污染同一进程里的其它测试文件。
+extends GutTest
+
+const TimeApiScript := preload("res://addons/godot_cli_control/bridge/time_api.gd")
+
+var _api: Node
+
+
+func before_each() -> void:
+	_api = TimeApiScript.new()
+	_api.name = "TimeApi"
+	add_child_autofree(_api)
+
+
+func after_each() -> void:
+	Engine.time_scale = 1.0
+	get_tree().paused = false
+
+
+# ── time_scale ──
+
+func test_time_scale_read_returns_current() -> void:
+	var result: Dictionary = _api.handle_time_scale({})
+	assert_does_not_have(result, "error")
+	assert_eq(float(result.get("time_scale")), 1.0)
+
+
+func test_time_scale_write_sets_engine_and_returns_new_value() -> void:
+	var result: Dictionary = _api.handle_time_scale({"value": 2.5})
+	assert_does_not_have(result, "error")
+	assert_eq(float(result.get("time_scale")), 2.5)
+	assert_eq(Engine.time_scale, 2.5)
+
+
+func test_time_scale_non_number_returns_minus_32602() -> void:
+	var result: Dictionary = _api.handle_time_scale({"value": "fast"})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+
+
+func test_time_scale_zero_returns_minus_32602() -> void:
+	## =0 冻死 wait-time 且与 pause 职责重叠，拒收
+	var result: Dictionary = _api.handle_time_scale({"value": 0.0})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+	assert_eq(Engine.time_scale, 1.0, "拒收时不得改 Engine.time_scale")
+
+
+func test_time_scale_above_max_returns_minus_32602() -> void:
+	var result: Dictionary = _api.handle_time_scale({"value": 100.5})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), -32602)
+
+
+# ── pause / unpause ──
+
+func test_pause_unpause_idempotent() -> void:
+	var r1: Dictionary = _api.handle_pause({})
+	assert_eq(r1.get("paused"), true)
+	assert_true(get_tree().paused)
+	var r2: Dictionary = _api.handle_pause({})
+	assert_eq(r2.get("paused"), true, "重复 pause 幂等成功")
+	var r3: Dictionary = _api.handle_unpause({})
+	assert_eq(r3.get("paused"), false)
+	assert_false(get_tree().paused)
+	var r4: Dictionary = _api.handle_unpause({})
+	assert_eq(r4.get("paused"), false, "重复 unpause 幂等成功")
+
+
+# ── step_frames ──
+
+func test_step_frames_not_paused_returns_1009() -> void:
+	var result: Dictionary = await _api.step_frames_async({"frames": 2})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1009)
+	assert_string_contains(str(result.error.message), "pause")
+
+
+func test_step_frames_invalid_frames_returns_minus_32602() -> void:
+	get_tree().paused = true
+	for bad: Variant in [null, "abc", 0, 3601]:
+		var result: Dictionary = await _api.step_frames_async({"frames": bad})
+		assert_has(result, "error", "frames=%s 应报错" % [bad])
+		assert_eq(int(result.error.code), -32602)
+
+
+func test_step_frames_advances_and_ends_paused() -> void:
+	get_tree().paused = true
+	var result: Dictionary = await _api.step_frames_async({"frames": 2})
+	assert_does_not_have(result, "error")
+	assert_eq(int(result.get("stepped")), 2)
+	assert_eq(result.get("paused"), true)
+	assert_true(get_tree().paused, "step 结束必须停在 paused")
+
+
+func test_step_frames_physics_advances() -> void:
+	get_tree().paused = true
+	var result: Dictionary = await _api.step_frames_async({"frames": 2, "physics": true})
+	assert_does_not_have(result, "error")
+	assert_eq(int(result.get("stepped")), 2)
+
+
+# ── parse_cmdline_time_scale（静态纯函数）──
+
+func test_parse_cmdline_time_scale_valid() -> void:
+	var args := PackedStringArray(["--headless", "--cli-time-scale=2.5"])
+	assert_eq(TimeApiScript.parse_cmdline_time_scale(args), 2.5)
+
+
+func test_parse_cmdline_time_scale_absent_returns_minus_1() -> void:
+	assert_eq(TimeApiScript.parse_cmdline_time_scale(PackedStringArray(["--headless"])), -1.0)
+
+
+func test_parse_cmdline_time_scale_invalid_returns_minus_1() -> void:
+	for bad: String in ["--cli-time-scale=abc", "--cli-time-scale=0", "--cli-time-scale=150", "--cli-time-scale="]:
+		assert_eq(
+			TimeApiScript.parse_cmdline_time_scale(PackedStringArray([bad])), -1.0,
+			"%s 应返回 -1" % bad
+		)
+```
+
+- [ ] **Step 2: 跑 GUT 确认失败**（preload 失败，Scripts 数不变）
+
+Run: `GODOT_BIN=$HOME/.local/bin/godot ./addons/godot_cli_control/tests/run_gut.sh`
+
+- [ ] **Step 3: error_codes.gd 加 1009**（`SCENE_UNAVAILABLE` 之后）
+
+```gdscript
+# step_frames 的状态前置错（issue #102）：tree 未 paused 时调 step_frames。
+# 与 -32602 区分：参数本身没问题，是世界状态不满足前置——agent 应先 pause。
+const NOT_PAUSED: int = 1009
+```
+
+- [ ] **Step 4: 写 time_api.gd**
+
+```gdscript
+class_name TimeApi
+extends Node
+## 时间控制 API：time_scale / pause / unpause / step_frames（issue #102）
+##
+## 挂在 GameBridge（PROCESS_MODE_ALWAYS）下，tree paused 时 RPC 照常工作——
+## 这是 step_frames「paused 下推帧」的机制基础。错误码常量见 error_codes.gd。
+
+# time_scale 合法域 (0, 100]：=0 冻死 wait-time 且与 pause 职责重叠，拒收；
+# 上限防呆（误传 1e9 之类）。
+const _MAX_TIME_SCALE: float = 100.0
+# step_frames 防呆上限，对齐 wait_api._MAX_WAIT_FRAMES
+const _MAX_STEP_FRAMES: int = 3600
+
+
+## 解析 --cli-time-scale=<x> 启动参数（_parse_port_from_args 同构）。
+## 无该参数返回 -1.0；非法值（非数字 / 越界）printerr 警告后也返回 -1.0
+## ——不挡启动。静态纯查询：GameBridge 传 OS.get_cmdline_args()，GUT 传构造数组。
+static func parse_cmdline_time_scale(args: PackedStringArray) -> float:
+	for arg: String in args:
+		if arg.begins_with("--cli-time-scale="):
+			var parts: PackedStringArray = arg.split("=", false, 1)
+			if parts.size() != 2 or not parts[1].is_valid_float():
+				printerr("GameBridge: invalid %s ignored (must be a number in (0, %s])" % [arg, _MAX_TIME_SCALE])
+				return -1.0
+			var scale: float = parts[1].to_float()
+			if scale <= 0.0 or scale > _MAX_TIME_SCALE:
+				printerr("GameBridge: invalid %s ignored (must be in (0, %s])" % [arg, _MAX_TIME_SCALE])
+				return -1.0
+			return scale
+	return -1.0
+
+
+## value 缺省 = 读当前值（Engine 不是节点，get 够不着，这是唯一读通道）。
+func handle_time_scale(params: Dictionary) -> Dictionary:
+	if not params.has("value"):
+		return {"time_scale": Engine.time_scale}
+	var raw: Variant = params["value"]
+	if not (raw is int or raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'value' must be a number")
+	var scale: float = float(raw)
+	if scale <= 0.0 or scale > _MAX_TIME_SCALE:
+		return _err(
+			CliControlErrorCodes.INVALID_PARAMS,
+			"value must be > 0 and <= %s (use pause to freeze the game, not time_scale 0)" % _MAX_TIME_SCALE,
+		)
+	Engine.time_scale = scale
+	return {"time_scale": scale}
+
+
+func handle_pause(_params: Dictionary) -> Dictionary:
+	get_tree().paused = true
+	return {"paused": true}
+
+
+func handle_unpause(_params: Dictionary) -> Dictionary:
+	get_tree().paused = false
+	return {"paused": false}
+
+
+## paused 前置下确定性推进 N 帧再停。未 paused → 1009（fail-loud：
+## 教会 agent「pause → step → 断言」的正确模型，不隐式改全局状态）。
+func step_frames_async(params: Dictionary) -> Dictionary:
+	var frames_raw: Variant = params.get("frames", null)
+	if not (frames_raw is int or frames_raw is float):
+		return _err(CliControlErrorCodes.INVALID_PARAMS, "'frames' must be an integer")
+	var frames: int = int(frames_raw)
+	if frames < 1 or frames > _MAX_STEP_FRAMES:
+		return _err(
+			CliControlErrorCodes.INVALID_PARAMS,
+			"frames must be 1..%d (got %d)" % [_MAX_STEP_FRAMES, frames],
+		)
+	var physics: bool = bool(params.get("physics", false))
+	if not get_tree().paused:
+		return _err(
+			CliControlErrorCodes.NOT_PAUSED,
+			"step_frames requires the tree to be paused — call pause first",
+		)
+	get_tree().paused = false
+	for _i in frames:
+		if physics:
+			await get_tree().physics_frame
+		else:
+			await get_tree().process_frame
+	# 无条件恒写：即使推进期间外力改了 paused，返回时也保证停在 paused
+	get_tree().paused = true
+	return {"stepped": frames, "paused": true}
+
+
+func _err(code: int, message: String) -> Dictionary:
+	return {"error": {"code": code, "message": message}}
+```
+
+- [ ] **Step 5: 跑 GUT 确认全绿**（新增 13 个用例；基线数以执行时实跑为准——main 合入 #98 后已是 153）
+- [ ] **Step 6: Commit** —— `feat(time): TimeApi —— time_scale/pause/unpause/step_frames + 1009（#102）`
+
+---
+
+### Task 2: GameBridge 接线 + 启动倍速（GUT TDD）
+
+**Files:**
+- Modify: `addons/godot_cli_control/tests/gut/test_game_bridge.gd`
+- Modify: `addons/godot_cli_control/bridge/game_bridge.gd`
+
+- [ ] **Step 1: 写失败测试** —— 对齐 #98 的 `test_registry_has_scene_methods` 写法（同 setup）：
+
+```gdscript
+func test_registry_has_time_methods() -> void:
+	for m: String in ["time_scale", "pause", "unpause"]:
+		assert_true(_bridge._methods.has(m), "%s 应已注册" % m)
+		assert_eq(str(_bridge._methods[m]["kind"]), "sync")
+	assert_true(_bridge._methods.has("step_frames"), "step_frames 应已注册")
+	assert_eq(str(_bridge._methods["step_frames"]["kind"]), "async")
+```
+
+（before_each 需要照 `_scene` 的先例加 `_time` 实例并赋给 `_bridge._time_api`，否则 `_register_methods` 解引用 null。）
+
+- [ ] **Step 2: 跑 GUT 确认失败**
+- [ ] **Step 3: 实现** —— game_bridge.gd 四处：
+
+```gdscript
+# ① 成员（_scene_api 下面）：
+var _time_api: TimeApi = null
+
+# ② _ready 里 _scene_api 块之后（关键：必须在 await _wait_first_frame_ready() 之前，
+#    保证「第 0 帧即倍速」——spec 明确要求）：
+_time_api = TimeApi.new()
+_time_api.name = "TimeApi"
+add_child(_time_api)
+# 启动倍速（issue #102）：非法值 parse 内已 printerr + 忽略，不挡启动
+var startup_scale: float = TimeApi.parse_cmdline_time_scale(OS.get_cmdline_args())
+if startup_scale > 0.0:
+	Engine.time_scale = startup_scale
+	print("GameBridge: Engine.time_scale = %s (from --cli-time-scale)" % startup_scale)
+
+# ③ _register_methods 的 Scene API 段后面：
+# Time API（issue #102）
+_methods["time_scale"] = {"callable": _time_api.handle_time_scale, "kind": "sync"}
+_methods["pause"] = {"callable": _time_api.handle_pause, "kind": "sync"}
+_methods["unpause"] = {"callable": _time_api.handle_unpause, "kind": "sync"}
+_methods["step_frames"] = {"callable": _time_api.step_frames_async, "kind": "async"}
+```
+
+- [ ] **Step 4: 跑 GUT 全绿**
+- [ ] **Step 5: Commit** —— `feat(time): GameBridge 注册 time RPC + 启动倍速 cmdline（#102）`
+
+---
+
+### Task 3: client/bridge 两层（单测 TDD）
+
+**Files:** `python/tests/test_client.py`、`python/tests/test_bridge.py`、`python/godot_cli_control/client.py`、`python/godot_cli_control/bridge.py`
+
+- [ ] **Step 1: 写失败测试**（照 #98 scene 系列的 fake_request / _StubClient 模式）。断言要点：
+  - `time_scale()`（无参）→ method="time_scale"、params=`{}`（**不带 value 键**）
+  - `time_scale(2.5)` → params=`{"value": 2.5}`
+  - `pause()` / `unpause()` → 各自 method、params=`{}`
+  - `step_frames(5)` → params=`{"frames": 5, "physics": False}`、RPC timeout=30.0（`max(30, 5/10+10)`）
+  - `step_frames(600)` → RPC timeout=70.0
+  - bridge 四个包装委托 + 返回透传
+- [ ] **Step 2: 跑两文件确认失败**（AttributeError）
+- [ ] **Step 3: 实现** —— client.py（`scene_change` 之后）：
+
+```python
+    async def time_scale(self, value: float | None = None) -> dict:
+        """读 / 写 Engine.time_scale（issue #102）。
+
+        value=None 纯读。合法域 (0, 100]，越界 → -32602。
+        返回 {"time_scale": x}。wait_game_time 跟随 time_scale，
+        套件整体倍速时 wait 语义不变、墙钟变快。
+        """
+        params: dict = {} if value is None else {"value": value}
+        return await self.request("time_scale", params)
+
+    async def pause(self) -> dict:
+        """暂停 SceneTree（issue #102）。幂等；返回 {"paused": True}。"""
+        return await self.request("pause", {})
+
+    async def unpause(self) -> dict:
+        """恢复 SceneTree（issue #102）。幂等；返回 {"paused": False}。"""
+        return await self.request("unpause", {})
+
+    async def step_frames(self, frames: int, physics: bool = False) -> dict:
+        """paused 前置下确定性推进 N 帧再停（issue #102）。
+
+        未 pause → 1009 NOT_PAUSED。返回 {"stepped": N, "paused": True}。
+        网络超时对齐 wait_frames（最低 10fps 估算 + 10s grace）。
+        """
+        return await self.request(
+            "step_frames",
+            {"frames": frames, "physics": physics},
+            timeout=max(30.0, frames / 10.0 + 10.0),
+        )
+```
+
+bridge.py（`scene_change` 之后）四个同款同步包装（docstring 一句话 + `self._run(...)`）。
+
+- [ ] **Step 4: 跑确认通过** → **Step 5: Commit** —— `feat(time): client/bridge 两层时间控制（#102）`
+
+---
+
+### Task 4: CLI RpcSpec ×4（单测 TDD）
+
+**Files:** `python/tests/test_cli.py`、`python/godot_cli_control/cli.py`
+
+- [ ] **Step 1: 写失败测试**（照 #98 scene 系列模式，含 `_ShouldNotConnect`）：
+  - `test_time_specs_registered`：四个 spec 在 `RPC_BY_NAME`；time-scale / step-frames 有 preflight
+  - `test_time_text_formatters`：`time-scale` → `"time_scale = 2.5"`；`pause` → `"paused: True"`→（按实现定，见 Step 3）；`step-frames` → `"stepped 5 frames (still paused)"`
+  - preflight 负例（parametrize + monkeypatch sys.argv + SystemExit 64 + -1003 信封）：`time-scale 0`、`time-scale -1`、`time-scale 101`、`time-scale abc`；`step-frames 0`、`step-frames 3601`、`step-frames abc`
+  - 正例不连 daemon 没法跑，注册性断言即可
+- [ ] **Step 2: 跑确认失败**（KeyError）
+- [ ] **Step 3: 实现** —— cli.py 四处：
+
+```python
+# ① preflight（_preflight_scene_change 之后）：
+def _preflight_time_scale(ns: argparse.Namespace) -> None:
+    if ns.value is None:
+        return  # 无参 = 读当前值
+    v = _require_float(ns.value, "time-scale", "value")
+    if not 0 < v <= 100:
+        raise ValueError(
+            f"time-scale: value 必须 > 0 且 <= 100，收到 {v}（要冻结游戏用 pause，别用 0）"
+        )
+
+
+def _preflight_step_frames(ns: argparse.Namespace) -> None:
+    try:
+        frames = int(ns.frames)
+    except (TypeError, ValueError):
+        raise ValueError(f"step-frames: frames 必须是整数，收到 {ns.frames!r}")
+    if not 1 <= frames <= 3600:
+        raise ValueError(f"step-frames: frames 必须在 1..3600，收到 {frames}")
+
+
+# ② handler（cmd_scene_change 之后）：
+async def cmd_time_scale(client: GameClient, ns: argparse.Namespace) -> dict:
+    value = float(ns.value) if ns.value is not None else None
+    return await client.time_scale(value)
+
+
+async def cmd_pause(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.pause()
+
+
+async def cmd_unpause(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.unpause()
+
+
+async def cmd_step_frames(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.step_frames(int(ns.frames), physics=ns.physics)
+
+
+# ③ extra_args（_register_scene_change_args 之后）：
+def _register_time_scale_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("value", nargs="?", default=None,
+                   help="新倍速（>0 且 <=100）；省略则读当前值")
+
+
+def _register_step_frames_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("frames", help="推进帧数（1..3600）")
+    p.add_argument("--physics", action="store_true",
+                   help="推进 physics_frame（默认 process_frame）")
+
+
+# ④ RPC_SPECS（scene-change 条目之后插入）：
+    RpcSpec(
+        name="time-scale",
+        handler=cmd_time_scale,
+        description=(
+            "读 / 写 Engine.time_scale（无参 = 读）。wait-time 按 game time 计，"
+            "倍速后语义不变、墙钟变快。合法域 (0, 100]。注意：--record 下仍生效，"
+            "录出的是加速画面。"
+        ),
+        positionals=(),  # 由 extra_args 注册
+        example="time-scale 5",
+        extra_args=_register_time_scale_args,
+        preflight=_preflight_time_scale,
+        text_formatter=lambda r: f"time_scale = {r.get('time_scale')}",
+    ),
+    RpcSpec(
+        name="pause",
+        handler=cmd_pause,
+        description="暂停 SceneTree（get_tree().paused = true）。幂等。",
+        positionals=(),
+        example="pause",
+        text_formatter=lambda r: f"paused: {r.get('paused')}",
+    ),
+    RpcSpec(
+        name="unpause",
+        handler=cmd_unpause,
+        description="恢复 SceneTree。幂等。",
+        positionals=(),
+        example="unpause",
+        text_formatter=lambda r: f"paused: {r.get('paused')}",
+    ),
+    RpcSpec(
+        name="step-frames",
+        handler=cmd_step_frames,
+        description=(
+            "paused 状态下确定性推进 N 帧再停（物理断言银弹：推 N 个物理帧后状态"
+            "必然确定）。必须先 pause，否则报 1009，exit 1。"
+        ),
+        positionals=(),  # 由 extra_args 注册
+        example="step-frames 3 --physics",
+        extra_args=_register_step_frames_args,
+        preflight=_preflight_step_frames,
+        text_formatter=lambda r: f"stepped {r.get('stepped')} frames (still paused)",
+    ),
+```
+
+- [ ] **Step 4: 跑 test_cli.py 全文件通过** → **Step 5: Commit** —— `feat(time): CLI time-scale/pause/unpause/step-frames + preflight（#102）`
+
+---
+
+### Task 5: daemon --time-scale + plugin 透传（单测 TDD）
+
+**Files:** `python/tests/test_daemon.py`、`python/tests/test_pytest_plugin.py`、`python/godot_cli_control/daemon.py`、`python/godot_cli_control/cli.py`（daemon start 段）、`python/godot_cli_control/pytest_plugin.py`
+
+- [ ] **Step 1: 写失败测试**：
+  - test_daemon.py（照 `:1279` 的 `--game-bridge-idle-timeout` Popen argv 捕获先例）：
+    - `daemon.start(time_scale=2.5)` → argv 含 `--cli-time-scale=2.5`
+    - 不传 → argv 无 `--cli-time-scale` 前缀
+    - `daemon.start(time_scale=0)` / `(time_scale=101)` → 抛 `DaemonError`（spawn 前拒绝，对齐 "--record requires --movie-path" 先例）
+  - test_pytest_plugin.py（照现有 FakeDaemon kwargs 捕获模式）：`runpytest("--godot-cli-time-scale", "3")` → `FakeDaemon.start` 收到 `time_scale=3.0`；不传 → `time_scale=None`
+  - test_cli.py：`daemon start --time-scale abc` / `--time-scale 0` → exit 64 + -1003 信封（argparse type 校验路径）
+- [ ] **Step 2: 跑确认失败**
+- [ ] **Step 3: 实现**：
+
+daemon.py —— `start()` 签名加 `time_scale: float | None = None`，校验（`record and headless` 检查之后）：
+
+```python
+        if time_scale is not None and not 0 < time_scale <= 100:
+            raise DaemonError(
+                f"--time-scale 必须 > 0 且 <= 100，收到 {time_scale}"
+                "（要暂停游戏用 pause RPC，不要 time-scale 0）"
+            )
+```
+
+argv 构造（`idle_timeout` 行之后）：
+
+```python
+        if time_scale is not None:
+            args.append(f"--cli-time-scale={time_scale}")
+```
+
+cli.py —— daemon start 子命令注册处（找 `--idle-timeout` 的注册位置，同处）加：
+
+```python
+def _time_scale_arg(raw: str) -> float:
+    """argparse type：daemon start --time-scale 的域校验（错误走 -1003 + 64）。"""
+    try:
+        v = float(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"必须是数字，收到 {raw!r}")
+    if not 0 < v <= 100:
+        raise argparse.ArgumentTypeError(f"必须 > 0 且 <= 100，收到 {v}")
+    return v
+
+# daemon start parser:
+    p.add_argument("--time-scale", type=_time_scale_arg, default=None,
+                   help="启动即设 Engine.time_scale（>0 且 <=100），整套 e2e 倒速用")
+```
+
+`cmd_daemon_start` 把 `ns.time_scale` 传给 `d.start(..., time_scale=ns.time_scale)`。
+
+注：argparse 的 `add_subparsers` 默认 `parser_class=type(self)`，所以 daemon start
+子 parser 也是 `_EnvelopeArgumentParser`，`ArgumentTypeError` 会走 error() →
+-1003 信封 + 64（cli.py 类 docstring 也说明了子 parser error() 共享 argv）。
+若测试发现不走信封（极小概率），回退方案：去掉 type 校验，改在
+`cmd_daemon_start` 里手动校验抛用法错（对齐 `_resolve_idle_timeout` 模式）。
+
+pytest_plugin.py —— addoption 组里加：
+
+```python
+    group.addoption(
+        "--godot-cli-time-scale",
+        action="store",
+        default=None,
+        help="Engine.time_scale applied at daemon startup (e.g. 5 to speed up the whole suite).",
+    )
+```
+
+`godot_daemon` fixture 的 start 调用改为：
+
+```python
+    raw_scale = config.getoption("--godot-cli-time-scale")
+    time_scale = float(raw_scale) if raw_scale is not None else None
+    ...
+    daemon.start(headless=headless, port=port, time_scale=time_scale)
+```
+
+- [ ] **Step 4: 跑 test_daemon.py + test_pytest_plugin.py + test_cli.py 通过**
+- [ ] **Step 5: Commit** —— `feat(time): daemon start --time-scale + pytest plugin 透传（#102）`
+
+---
+
+### Task 6: e2e（真 Godot）
+
+**Files:** Create `python/tests/test_e2e_time.py`（harness 照抄 `test_e2e_scene.py`：**含 module-scope `demo_project` fixture 与 function-scope `daemon` fixture 的完整定义，不能跨文件引用**；拷贝列表用 example 原版四文件即可，本文件不需要 second.tscn）
+
+- [ ] **Step 1: 写完整测试文件**（e2e 不逐用例 RED/GREEN）。用例：
+
+```python
+def test_pause_freezes_and_step_frames_advances_physics(daemon: Any) -> None:
+    """pause 冻结物理 → step-frames --physics 确定性推进 → unpause。"""
+    project = daemon
+    assert _run_cli(project, "wait-node", "/root/Main/UI/StartButton")["result"]["found"]
+    assert _run_cli(project, "click", "/root/Main/UI/StartButton")["ok"]
+    assert _run_cli(project, "wait-node", "/root/Main/World/Player")["result"]["found"]
+    # player 正在下落；pause 后位置必须冻结
+    assert _run_cli(project, "pause")["result"]["paused"] is True
+    y1 = _run_cli(project, "get", "/root/Main/World/Player", "position:y")["result"]["value"]
+    _run_cli(project, "wait-time", "0.3")  # 墙钟流逝，但树已 pause
+    y2 = _run_cli(project, "get", "/root/Main/World/Player", "position:y")["result"]["value"]
+    assert y2 == y1, f"paused 下位置不得变化：{y1} -> {y2}"
+    # 确定性推进 10 个物理帧：重力必须使 y 增大
+    r = _run_cli(project, "step-frames", "10", "--physics")
+    assert r["ok"] is True, r
+    assert r["result"]["stepped"] == 10
+    assert r["result"]["paused"] is True
+    y3 = _run_cli(project, "get", "/root/Main/World/Player", "position:y")["result"]["value"]
+    assert y3 > y2, f"10 个物理帧后应下落：{y2} -> {y3}"
+    assert _run_cli(project, "unpause")["result"]["paused"] is False
+
+
+def test_step_frames_without_pause_returns_1009(daemon: Any) -> None:
+    project = daemon
+    assert _run_cli(project, "wait-node", "/root/Main")["result"]["found"]
+    r = _run_cli(project, "step-frames", "3")
+    assert r["ok"] is False
+    assert r["error"]["code"] == 1009
+
+
+def test_time_scale_roundtrip(daemon: Any) -> None:
+    project = daemon
+    assert _run_cli(project, "wait-node", "/root/Main")["result"]["found"]
+    assert _run_cli(project, "time-scale")["result"]["time_scale"] == 1.0
+    assert _run_cli(project, "time-scale", "5")["result"]["time_scale"] == 5.0
+    assert _run_cli(project, "time-scale")["result"]["time_scale"] == 5.0
+    # 还原，避免影响同 daemon 的后续操作（虽然 daemon 是 function-scope，防御性）
+    assert _run_cli(project, "time-scale", "1")["ok"]
+
+
+def test_daemon_start_time_scale_applies_at_startup(demo_project: Path) -> None:
+    """daemon start --time-scale 2：连上即读到 2.0（第 0 帧生效路径）。"""
+    project = demo_project
+    start = _run_cli(project, "daemon", "start", "--headless", "--time-scale", "2", timeout=90)
+    assert start["ok"] is True and start["result"]["started"], start
+    try:
+        r = _run_cli(project, "time-scale")
+        assert r["result"]["time_scale"] == 2.0
+    finally:
+        _run_cli(project, "daemon", "stop", timeout=30)
+```
+
+（前三个用例用 function-scope `daemon` fixture；第四个自管 daemon 起停，签名直接依赖 `demo_project`。）
+
+- [ ] **Step 2: 跑 e2e 确认通过**
+
+Run: `GODOT_BIN=$HOME/.local/bin/godot .venv/bin/python -m pytest python/tests/test_e2e_time.py -q`
+Expected: 4 passed。坑提示：若 `position:y` 的 get shape 与断言不符，先 grep test_e2e_example.py 的 get 断言写法对齐。
+
+- [ ] **Step 3: Commit** —— `test(time): e2e pause/step-frames/time-scale/启动倍速（#102）`
+
+---
+
+### Task 7: 文档同步（契约 7）
+
+**Files:** `python/godot_cli_control/templates/skill/SKILL.md`、`addons/godot_cli_control/README.md`
+
+- [ ] **Step 1: SKILL.md 五处**（英文，风格对齐周边）：
+  1. Command catalogue 的 **Scene:** 组后加 **Time:** 组：
+     ```markdown
+     **Time:**
+     - `time-scale [value]` — read (no arg) or set `Engine.time_scale`. Valid range `(0, 100]`. `wait-time` counts game time, so a higher scale speeds up the whole suite without changing wait semantics.
+     - `pause` / `unpause` — freeze / resume the scene tree (`get_tree().paused`). Idempotent.
+     - `step-frames <n> [--physics]` — while paused, advance exactly N frames then stop (deterministic stepping for physics assertions). Requires `pause` first — otherwise error `1009`.
+     ```
+  2. Error code reference 表 1008 行后加 1009 行（NOT_PAUSED：step-frames called while the tree is not paused — call `pause` first; precondition error, not a param error）
+  3. Daemon management 段：`daemon start` 选项处补 `--time-scale N`（applies `Engine.time_scale` from the very first frame）
+  4. pytest plugin 段：CLI 选项列表补 `--godot-cli-time-scale`
+  5. Common pitfalls 三条：
+     - With `--record` (Movie Maker fixed-FPS), `time_scale` still applies — the captured video plays back sped-up. Don't combine unless that's what you want.
+     - `time-scale` also shortens the wall-clock duration of `wait-time` (game-time semantics unchanged) — don't "compensate" wait times after scaling.
+     - `step-frames` requires `pause` first (error `1009`) — the intended pattern is `pause` → `step-frames` → assert → `unpause`.
+- [ ] **Step 2: addon README**：命令表加 4 行 + 错误码表加 1009（风格照抄现有行）
+- [ ] **Step 3: 渲染检查**：`format_full_help()` 含 time-scale/pause/unpause/step-frames；跑 `test_skills_install.py`
+- [ ] **Step 4: Commit** —— `docs(time): SKILL.md/README 同步 Time 命令组 + 1009 + pitfalls（#102）`
+
+---
+
+### Task 8: 全量验证 + PR
+
+- [ ] **Step 1: Python 全量**（`coverage run -m pytest` + `--fail-under=80`，带 GODOT_BIN 让 e2e 真跑；委托 subagent）
+- [ ] **Step 2: GUT 全量**（委托 subagent）
+- [ ] **Step 3: push + PR**（标题 `feat(time): time-scale/pause/step-frames 时间控制（#102）`，body 含 Fixes #102 + 测试结论；`gh pr merge --auto --squash`；若 main 有更新先 rebase）
+- [ ] **Step 4: 收尾盘点**（按 CLAUDE.md「实施收尾必开 Issue」；CLAUDE.md 已知遗留段更新留到批次收尾）

--- a/docs/superpowers/specs/2026-06-04-time-control-design.md
+++ b/docs/superpowers/specs/2026-06-04-time-control-design.md
@@ -1,0 +1,128 @@
+# 时间控制设计：time-scale / pause / unpause / step-frames（issue #102）
+
+日期：2026-06-04
+状态：已批准（brainstorming 四节逐节确认）
+
+## 问题
+
+方法注册表没有 `Engine.time_scale` / `get_tree().paused` / 帧步进类控制：
+
+1. e2e 套件时长被真实时间 sleep 主导（XGame 实测两个 e2e 文件里 0.15~0.3s 的
+   `wait_game_time` 10+ 处，全按真实墙钟流逝）
+2. 无法确定性帧推进：物理/动画类断言只能「等足够久再读」，本质是和调度器赛跑
+
+## 目标
+
+1. `time_scale`：读 / 写 `Engine.time_scale`——`wait_game_time` 用 `create_timer`
+   （跟随 time_scale），所以「wait-time 语义不变、墙钟整体倍速」天然成立
+2. `pause` / `unpause`：写 `get_tree().paused`
+3. `step_frames`：paused 状态下确定性推进 N 帧再停（「推 3 个物理帧后位置必然是 X」）
+4. `daemon start --time-scale N`：启动即设默认倍速（pytest/CI 整套倒速场景）
+
+## 已决策的设计选择
+
+| 决策点 | 选择 | 备注 |
+|---|---|---|
+| step_frames 的 pause 前置 | 要求已 paused，否则报错（1009） | fail-loud 教会 agent「pause → step → 断言」模型；不隐式改全局状态 |
+| pause CLI 形态 | `pause` / `unpause` 两个命令 | 动词即意图，零参数零歧义 |
+| 启动倍速 | 这轮做，走 Godot cmdline arg | `--cli-time-scale=<x>`，第 0 帧生效无竞态；读取路径对齐 `--cli-control` 激活旗标先例 |
+| 与 --record 交互 | 文档说明，不加硬限制 | Movie Maker 下 time_scale 仍生效（录出加速画面），可预测行为；合法场景（故意录倒速）不误伤 |
+| time-scale 读通道 | CLI 无参 = 读当前值 | Engine 不是节点，`get` 够不着，这是唯一读通道 |
+| time_scale 合法域 | `(0, 100]` | =0 冻死 wait-time 且与 pause 职责重叠，拒收；>100 防呆 |
+| GDScript 放置 | 独立 `time_api.gd` | 对齐 wait_api（#108）/ scene_api（#98）拆分先例 |
+| plugin 透传 | 这轮做 `--godot-cli-time-scale` | issue 核心动机是 e2e 提速，这一步闭环 |
+
+## 组件设计
+
+### 1. GDScript：`addons/godot_cli_control/bridge/time_api.gd`
+
+新文件，`class_name TimeApi extends Node`。GameBridge `_ready` 实例化并
+`add_child`（子节点继承 GameBridge 的 `PROCESS_MODE_ALWAYS` → tree paused 时
+RPC 照常工作，这是 step_frames 的机制基础）。注册：
+
+```
+_methods["time_scale"]  = {"callable": _time_api.handle_time_scale, "kind": "sync"}
+_methods["pause"]       = {"callable": _time_api.handle_pause, "kind": "sync"}
+_methods["unpause"]     = {"callable": _time_api.handle_unpause, "kind": "sync"}
+_methods["step_frames"] = {"callable": _time_api.step_frames_async, "kind": "async"}
+```
+
+**`handle_time_scale(params)`**（sync）
+
+1. `value` 可选：缺省 → 返回 `{"time_scale": Engine.time_scale}`（纯读）
+2. 有 value：非 int/float → `-32602`；`<= 0.0` 或 `> 100.0` → `-32602`
+3. 设置 `Engine.time_scale = value`，返回 `{"time_scale": value}`
+
+**`handle_pause(params)` / `handle_unpause(params)`**（sync）
+
+- 写 `get_tree().paused`，幂等（重复调用照常成功），返回 `{"paused": true/false}`
+
+**`step_frames_async(params)`**（async）
+
+1. `frames` 必填 int，`1..3600`（对齐 wait_frames `_MAX_WAIT_FRAMES` 防呆）→ 否则 `-32602`
+2. `physics` 可选 bool（默认 false）
+3. 前置：`get_tree().paused` 必须为 true → 否则 **`1009 NOT_PAUSED`**
+   （message 给出正确用法：「pause first, then step-frames」）
+4. 执行：`paused = false` → `await get_tree().physics_frame / process_frame` ×N
+   → `paused = true` → 返回 `{"stepped": N, "paused": true}`
+5. `await process_frame` 是 SceneTree 信号、不依赖节点 process_mode，
+   GUT 环境下也能真测
+
+**启动倍速**
+
+- `static func parse_cmdline_time_scale(args: PackedStringArray) -> float`：
+  解析 `--cli-time-scale=<x>`，无该参数 / 非数字 / 越界（(0,100] 外）返回 `-1.0`
+  ——静态纯函数，GUT 可单测
+- GameBridge `_ready`（激活判定之后）调用它（读取路径对齐 `--cli-control`
+  现有实现），返回值 > 0 则 `Engine.time_scale = x`；非法值 `printerr` 警告
+  并忽略，**不挡启动**
+
+### 2. 错误码
+
+`error_codes.gd` 新增 `NOT_PAUSED: int = 1009`：step_frames 的状态前置错
+（业务码——与 -32602 参数错区分：参数没问题，是世界状态不满足前置）。
+
+### 3. Python 三层 + daemon + plugin
+
+- **client.py**：
+  - `time_scale(value: float | None = None) -> dict`（params 仅在 value 非 None 时带 `"value"`）
+  - `pause()` / `unpause() -> dict`
+  - `step_frames(frames: int, physics: bool = False) -> dict`，
+    RPC 网络超时对齐 wait_frames：`max(30.0, frames / 10.0 + 10.0)`
+- **bridge.py**：四个同步包装
+- **cli.py**：四个 `RpcSpec`：
+  - `time-scale [value]`（value 可选位置参数；preflight：有值时数字 + (0,100]）
+  - `pause` / `unpause`（零参数）
+  - `step-frames <n> [--physics]`（preflight：整数 + 1..3600）
+  - 退出码默认语义（1009 → exit 1），无 `exit_code_from`
+- **daemon.py**：`start(..., time_scale: float | None = None)`，非 None 时启动
+  参数追加 `--cli-time-scale=<x>`；CLI `daemon start --time-scale N`
+  （preflight 域校验）
+- **pytest plugin**：`--godot-cli-time-scale` 选项（默认 None），
+  `godot_daemon` fixture 透传 `daemon.start(time_scale=...)`
+
+## 测试策略
+
+| 层 | 文件 | 覆盖 |
+|---|---|---|
+| GUT | `tests/gut/test_time_api.gd`（新） | time_scale 读/写/非法值与域负例；pause/unpause 幂等；step_frames 未 paused → 1009、frames 非法 → -32602、**paused 下真推帧**（pause → step 2 帧 → 断言返回 shape 且结束仍 paused）；`parse_cmdline_time_scale` 静态单测（合法/缺失/非数字/越界）。注意 teardown 还原 `Engine.time_scale = 1.0` 与 `paused = false`，避免污染其它测试文件 |
+| Python 单测 | test_cli.py / test_client.py / test_bridge.py / test_daemon.py / test_pytest_plugin.py | preflight 域校验、RpcSpec 注册、三层委托（mock）、daemon 启动参数含 `--cli-time-scale`、plugin 选项透传 |
+| e2e | `test_e2e_time.py`（新） | ① pause → step-frames --physics 推进（platformer player 受重力，断言 position:y 确定性变化且推进期间外 paused 不动）→ unpause；② time-scale 设置/读回往返；③ daemon start --time-scale 启动即生效（连上直接读 time_scale 断言） |
+
+## 文档同步（契约 7）
+
+- SKILL.md 模板：Command catalogue 加 **Time** 分组（time-scale / pause /
+  unpause / step-frames）、错误码表加 1009、`daemon start --time-scale` 说明、
+  Common pitfalls 三条：
+  1. `--record`（Movie Maker 固定帧率）下 time_scale 仍生效——录出的是加速画面
+  2. time-scale 同时加速 `wait-time` 的墙钟表现（game-time 语义不变）
+  3. `step-frames` 必须先 `pause`，否则 1009
+- addon README：命令表 / 错误码表同步
+- 跑 `format_full_help()` 渲染检查 + `test_skills_install.py`
+
+## 不做的事（YAGNI）
+
+- 不做 `step-frames` 的自动 pause（fail-loud 已决策）
+- 不做 record 模式下的 time_scale 硬限制（文档说明已决策）
+- 不做 `Engine.physics_ticks_per_second` 等其它时间参数的暴露
+- 不做 pause 状态查询 RPC（`pause`/`unpause` 返回值已带；真需要再说）

--- a/docs/superpowers/specs/2026-06-04-time-control-design.md
+++ b/docs/superpowers/specs/2026-06-04-time-control-design.md
@@ -65,6 +65,8 @@ _methods["step_frames"] = {"callable": _time_api.step_frames_async, "kind": "asy
    （message 给出正确用法：「pause first, then step-frames」）
 4. 执行：`paused = false` → `await get_tree().physics_frame / process_frame` ×N
    → `paused = true` → 返回 `{"stepped": N, "paused": true}`
+   （结尾的 `paused = true` 无条件写——即使推进期间外力改了 paused 状态，
+   step_frames 返回时也恒保证停在 paused）
 5. `await process_frame` 是 SceneTree 信号、不依赖节点 process_mode，
    GUT 环境下也能真测
 
@@ -73,9 +75,11 @@ _methods["step_frames"] = {"callable": _time_api.step_frames_async, "kind": "asy
 - `static func parse_cmdline_time_scale(args: PackedStringArray) -> float`：
   解析 `--cli-time-scale=<x>`，无该参数 / 非数字 / 越界（(0,100] 外）返回 `-1.0`
   ——静态纯函数，GUT 可单测
-- GameBridge `_ready`（激活判定之后）调用它（读取路径对齐 `--cli-control`
-  现有实现），返回值 > 0 则 `Engine.time_scale = x`；非法值 `printerr` 警告
-  并忽略，**不挡启动**
+- GameBridge `_ready`（激活判定之后）调用它（读取路径对齐 `_parse_port_from_args`
+  / `_has_cli_flag` 现有同构实现），返回值 > 0 则 `Engine.time_scale = x`；
+  非法值 `printerr` 警告并忽略，**不挡启动**
+- 调用位置必须在 `_ready` 的 `await _wait_first_frame_ready()` **之前**
+  （否则第 0 帧已过，「启动即生效」承诺失效）
 
 ### 2. 错误码
 

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -106,6 +106,22 @@ class GameBridge:
         """切换场景并等新场景 ready（issue #98）。path 须为 res:// 或 uid://。"""
         return self._run(self._client.scene_change(path, timeout=timeout))
 
+    def time_scale(self, value: float | None = None) -> dict:
+        """读 / 写 Engine.time_scale（issue #102）。value=None 纯读，返回 {"time_scale": x}。"""
+        return self._run(self._client.time_scale(value))
+
+    def pause(self) -> dict:
+        """暂停 SceneTree（issue #102）。幂等；返回 {"paused": True}。"""
+        return self._run(self._client.pause())
+
+    def unpause(self) -> dict:
+        """恢复 SceneTree（issue #102）。幂等；返回 {"paused": False}。"""
+        return self._run(self._client.unpause())
+
+    def step_frames(self, frames: int, physics: bool = False) -> dict:
+        """paused 前置下确定性推进 N 帧再停（issue #102）。返回 {"stepped": N, "paused": True}。"""
+        return self._run(self._client.step_frames(frames, physics=physics))
+
     # ── UI 交互 ──
 
     def click(self, path: str) -> dict:

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -107,7 +107,7 @@ class GameBridge:
         return self._run(self._client.scene_change(path, timeout=timeout))
 
     def time_scale(self, value: float | None = None) -> dict:
-        """读 / 写 Engine.time_scale（issue #102）。value=None 纯读，返回 {"time_scale": x}。"""
+        """读 / 写 Engine.time_scale（issue #102）。value=None 纯读，返回 {"time_scale": x}；越界（<=0 或 >100）→ -32602。"""
         return self._run(self._client.time_scale(value))
 
     def pause(self) -> dict:
@@ -119,7 +119,7 @@ class GameBridge:
         return self._run(self._client.unpause())
 
     def step_frames(self, frames: int, physics: bool = False) -> dict:
-        """paused 前置下确定性推进 N 帧再停（issue #102）。返回 {"stepped": N, "paused": True}。"""
+        """paused 前置下确定性推进 N 帧再停（issue #102）。未 pause → 1009；返回 {"stepped": N, "paused": True}。"""
         return self._run(self._client.step_frames(frames, physics=physics))
 
     # ── UI 交互 ──

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1176,6 +1176,7 @@ def cmd_daemon_start(ns: argparse.Namespace) -> int:
             fps=ns.fps,
             port=ns.port,
             idle_timeout=idle_seconds,
+            time_scale=getattr(ns, "time_scale", None),
         )
     except DaemonError as e:
         _emit_top_error(ns, code=CLIENT_CODE_PRECONDITION, message=str(e))  # infra 前置失败 → -1006（#92）
@@ -1753,6 +1754,17 @@ _TOP_EPILOG = """\
 """
 
 
+def _time_scale_arg(raw: str) -> float:
+    """argparse type：daemon start --time-scale 的域校验（错误走 -1003 + 64）。"""
+    try:
+        v = float(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"必须是数字，收到 {raw!r}")
+    if not 0 < v <= 100:
+        raise argparse.ArgumentTypeError(f"必须 > 0 且 <= 100，收到 {v}")
+    return v
+
+
 def _add_daemon_flags(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--record",
@@ -1935,6 +1947,12 @@ def build_parser() -> argparse.ArgumentParser:
         description="启动 Godot daemon 并写入 .cli_control/{godot.pid,port}。",
     )
     _add_daemon_flags(start_p)
+    start_p.add_argument(
+        "--time-scale",
+        type=_time_scale_arg,
+        default=None,
+        help="启动即设 Engine.time_scale（>0 且 <=100），整套 e2e 倒速用",
+    )
     _add_output_format_flags(start_p)
 
     stop_p = daemon_subs.add_parser(

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -254,6 +254,17 @@ def _require_float(raw: Any, cmd: str, field: str) -> float:
         raise ValueError(f"{cmd}: {field} 必须是数字，收到 {raw!r}")
 
 
+def _require_frames(raw: Any, cmd: str) -> int:
+    """frames 参数校验：整数 + 1..3600（wait-frames / step-frames 共用）。"""
+    try:
+        frames = int(raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"{cmd}: frames 必须是整数，收到 {raw!r}")
+    if not 1 <= frames <= 3600:
+        raise ValueError(f"{cmd}: frames 必须在 1..3600，收到 {frames}")
+    return frames
+
+
 def _preflight_wait_prop(ns: argparse.Namespace) -> None:
     timeout = _require_float(ns.timeout, "wait-prop", "timeout")
     if not 0 <= timeout <= 3600:
@@ -278,12 +289,7 @@ def _preflight_wait_signal(ns: argparse.Namespace) -> None:
 
 
 def _preflight_wait_frames(ns: argparse.Namespace) -> None:
-    try:
-        frames = int(ns.frames)
-    except (TypeError, ValueError):
-        raise ValueError(f"wait-frames: frames 必须是整数，收到 {ns.frames!r}")
-    if not 1 <= frames <= 3600:
-        raise ValueError(f"wait-frames: frames 必须在 1..3600，收到 {frames}")
+    _require_frames(ns.frames, "wait-frames")
 
 
 def _preflight_scene_reload(ns: argparse.Namespace) -> None:
@@ -313,12 +319,7 @@ def _preflight_time_scale(ns: argparse.Namespace) -> None:
 
 
 def _preflight_step_frames(ns: argparse.Namespace) -> None:
-    try:
-        frames = int(ns.frames)
-    except (TypeError, ValueError):
-        raise ValueError(f"step-frames: frames 必须是整数，收到 {ns.frames!r}")
-    if not 1 <= frames <= 3600:
-        raise ValueError(f"step-frames: frames 必须在 1..3600，收到 {frames}")
+    _require_frames(ns.frames, "step-frames")
 
 
 def _combo_total_duration(steps: list[dict]) -> float:
@@ -1069,7 +1070,7 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
     RpcSpec(
         name="pause",
         handler=cmd_pause,
-        description="暂停 SceneTree（get_tree().paused = true）。幂等。",
+        description='暂停 SceneTree（get_tree().paused = true）。幂等；返回 {"paused": true}。',
         positionals=(),
         example="pause",
         text_formatter=lambda r: f"paused: {r.get('paused')}",
@@ -1077,7 +1078,7 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
     RpcSpec(
         name="unpause",
         handler=cmd_unpause,
-        description="恢复 SceneTree。幂等。",
+        description='恢复 SceneTree（paused = false）。幂等；返回 {"paused": false}。',
         positionals=(),
         example="unpause",
         text_formatter=lambda r: f"paused: {r.get('paused')}",

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -302,6 +302,25 @@ def _preflight_scene_change(ns: argparse.Namespace) -> None:
         raise ValueError(f"scene-change: timeout 必须 > 0 且 <= 3600 秒，收到 {timeout}")
 
 
+def _preflight_time_scale(ns: argparse.Namespace) -> None:
+    if ns.value is None:
+        return  # 无参 = 读当前值，无需校验
+    v = _require_float(ns.value, "time-scale", "value")
+    if not 0 < v <= 100:
+        raise ValueError(
+            f"time-scale: value 必须 > 0 且 <= 100，收到 {v}（要冻结游戏用 pause，别用 0）"
+        )
+
+
+def _preflight_step_frames(ns: argparse.Namespace) -> None:
+    try:
+        frames = int(ns.frames)
+    except (TypeError, ValueError):
+        raise ValueError(f"step-frames: frames 必须是整数，收到 {ns.frames!r}")
+    if not 1 <= frames <= 3600:
+        raise ValueError(f"step-frames: frames 必须在 1..3600，收到 {frames}")
+
+
 def _combo_total_duration(steps: list[dict]) -> float:
     """combo 全部 step 的累计 game-time（给 ``--wait`` 算阻塞时长，issue #90）。
 
@@ -490,6 +509,23 @@ async def cmd_scene_change(client: GameClient, ns: argparse.Namespace) -> dict:
     return await client.scene_change(ns.scene_path, timeout=float(ns.timeout))
 
 
+async def cmd_time_scale(client: GameClient, ns: argparse.Namespace) -> dict:
+    value = float(ns.value) if ns.value is not None else None
+    return await client.time_scale(value)
+
+
+async def cmd_pause(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.pause()
+
+
+async def cmd_unpause(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.unpause()
+
+
+async def cmd_step_frames(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.step_frames(int(ns.frames), physics=ns.physics)
+
+
 async def cmd_pressed(
     client: GameClient, ns: argparse.Namespace
 ) -> list[str]:
@@ -669,6 +705,17 @@ def _register_scene_change_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("scene_path", help="目标场景资源路径（res:// 或 uid://）")
     p.add_argument("--timeout", default="10",
                    help="等新场景 ready 的超时秒（>0 且 <=3600，默认 10）")
+
+
+def _register_time_scale_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("value", nargs="?", default=None,
+                   help="新倍速（>0 且 <=100）；省略则读当前值")
+
+
+def _register_step_frames_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("frames", help="推进帧数（1..3600）")
+    p.add_argument("--physics", action="store_true",
+                   help="推进 physics_frame（默认 process_frame）")
 
 
 def _register_set_args(p: argparse.ArgumentParser) -> None:
@@ -1004,6 +1051,49 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
         extra_args=_register_scene_change_args,
         preflight=_preflight_scene_change,
         text_formatter=lambda r: f"scene changed: {r.get('scene_path')} (root: {r.get('name')})",
+    ),
+    RpcSpec(
+        name="time-scale",
+        handler=cmd_time_scale,
+        description=(
+            "读 / 写 Engine.time_scale（无参 = 读）。wait-time 按 game time 计，"
+            "倍速后语义不变、墙钟变快。合法域 (0, 100]。注意：--record 下仍生效，"
+            "录出的是加速画面。"
+        ),
+        positionals=(),  # 由 extra_args 注册
+        example="time-scale 5",
+        extra_args=_register_time_scale_args,
+        preflight=_preflight_time_scale,
+        text_formatter=lambda r: f"time_scale = {r.get('time_scale')}",
+    ),
+    RpcSpec(
+        name="pause",
+        handler=cmd_pause,
+        description="暂停 SceneTree（get_tree().paused = true）。幂等。",
+        positionals=(),
+        example="pause",
+        text_formatter=lambda r: f"paused: {r.get('paused')}",
+    ),
+    RpcSpec(
+        name="unpause",
+        handler=cmd_unpause,
+        description="恢复 SceneTree。幂等。",
+        positionals=(),
+        example="unpause",
+        text_formatter=lambda r: f"paused: {r.get('paused')}",
+    ),
+    RpcSpec(
+        name="step-frames",
+        handler=cmd_step_frames,
+        description=(
+            "paused 状态下确定性推进 N 帧再停（物理断言银弹：推 N 个物理帧后状态"
+            "必然确定）。必须先 pause，否则报 1009，exit 1。"
+        ),
+        positionals=(),  # 由 extra_args 注册
+        example="step-frames 3 --physics",
+        extra_args=_register_step_frames_args,
+        preflight=_preflight_step_frames,
+        text_formatter=lambda r: f"stepped {r.get('stepped')} frames (still paused)",
     ),
     RpcSpec(
         name="pressed",

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1755,7 +1755,10 @@ _TOP_EPILOG = """\
 
 
 def _time_scale_arg(raw: str) -> float:
-    """argparse type：daemon start --time-scale 的域校验（错误走 -1003 + 64）。"""
+    """argparse type：daemon start --time-scale 的域校验（错误走 -1003 + 64）。
+
+    # 域 (0, 100] 与 _preflight_time_scale / daemon.start 校验对齐，改动需三处同步
+    """
     try:
         v = float(raw)
     except ValueError:
@@ -1951,7 +1954,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--time-scale",
         type=_time_scale_arg,
         default=None,
-        help="启动即设 Engine.time_scale（>0 且 <=100），整套 e2e 倒速用",
+        help="启动即设 Engine.time_scale（>0 且 <=100），整套 e2e 提速用",
     )
     _add_output_format_flags(start_p)
 

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -388,6 +388,36 @@ class GameClient:
             "scene_change", {"path": path, "timeout": timeout}, timeout=timeout + 5.0
         )
 
+    async def time_scale(self, value: float | None = None) -> dict:
+        """读 / 写 Engine.time_scale（issue #102）。
+
+        value=None 纯读。合法域 (0, 100]，越界 → -32602。
+        返回 {"time_scale": x}。wait_game_time 跟随 time_scale，
+        套件整体倍速时 wait 语义不变、墙钟变快。
+        """
+        params: dict = {} if value is None else {"value": value}
+        return await self.request("time_scale", params)
+
+    async def pause(self) -> dict:
+        """暂停 SceneTree（issue #102）。幂等；返回 {"paused": True}。"""
+        return await self.request("pause", {})
+
+    async def unpause(self) -> dict:
+        """恢复 SceneTree（issue #102）。幂等；返回 {"paused": False}。"""
+        return await self.request("unpause", {})
+
+    async def step_frames(self, frames: int, physics: bool = False) -> dict:
+        """paused 前置下确定性推进 N 帧再停（issue #102）。
+
+        未 pause → 1009 NOT_PAUSED。返回 {"stepped": N, "paused": True}。
+        网络超时对齐 wait_frames（最低 10fps 估算 + 10s grace）。
+        """
+        return await self.request(
+            "step_frames",
+            {"frames": frames, "physics": physics},
+            timeout=max(30.0, frames / 10.0 + 10.0),
+        )
+
     async def wait_game_time(self, seconds: float) -> dict:
         """按 Godot game time 等待 N 秒。
 

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -108,7 +108,7 @@ class Daemon:
             )
         if time_scale is not None and not 0 < time_scale <= 100:
             raise DaemonError(
-                f"--time-scale 必须 > 0 且 <= 100，收到 {time_scale}"
+                f"--time-scale 必须 > 0 且 <= 100，收到 {time_scale} "
                 "（要暂停游戏用 pause RPC，不要 time-scale 0）"
             )
 

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -79,6 +79,7 @@ class Daemon:
         port: int = 0,  # 0 = OS 自动分配；显式 --port 9877 仍可固定
         wait_seconds: int = 30,
         idle_timeout: int = 0,
+        time_scale: float | None = None,
     ) -> int:
         """启动 Godot daemon，等端口就绪后返回 PID。"""
         # 项目根校验：拒绝在非 Godot 项目目录跑，避免 Godot 用 --path .
@@ -104,6 +105,11 @@ class Daemon:
                 "录制与 --headless 冲突：Godot Movie Maker 需要真实渲染器，"
                 "headless dummy renderer 拿不到 viewport texture，add_frame() 会"
                 " SIGSEGV。去掉 --headless（默认/非 TTY 会自动开窗）或显式 --gui。"
+            )
+        if time_scale is not None and not 0 < time_scale <= 100:
+            raise DaemonError(
+                f"--time-scale 必须 > 0 且 <= 100，收到 {time_scale}"
+                "（要暂停游戏用 pause RPC，不要 time-scale 0）"
             )
 
         bin_path = (
@@ -155,6 +161,8 @@ class Daemon:
             args.append("--headless")
         if idle_timeout > 0:
             args.append(f"--game-bridge-idle-timeout={idle_timeout}")
+        if time_scale is not None:
+            args.append(f"--cli-time-scale={time_scale}")
 
         env = os.environ.copy()
         if record:

--- a/python/godot_cli_control/pytest_plugin.py
+++ b/python/godot_cli_control/pytest_plugin.py
@@ -16,6 +16,7 @@ CLI 选项：
   --godot-cli-port            GameBridge 端口（默认 0 = OS 自动分配）
   --godot-cli-no-headless     带窗口跑（默认 headless）
   --godot-cli-project-root    指定 Godot 项目根（默认 pytest rootdir）
+  --godot-cli-time-scale      Engine.time_scale（整套 suite 加速用，如 5）
 """
 
 from __future__ import annotations
@@ -50,6 +51,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help="Godot project root (default: pytest rootdir).",
     )
+    group.addoption(
+        "--godot-cli-time-scale",
+        action="store",
+        default=None,
+        help="Engine.time_scale applied at daemon startup (e.g. 5 to speed up the whole suite).",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -71,11 +78,14 @@ def godot_daemon(request: pytest.FixtureRequest) -> Iterator[Daemon]:
         else Path(str(config.rootpath)).resolve()
     )
 
+    raw_scale = config.getoption("--godot-cli-time-scale")
+    time_scale = float(raw_scale) if raw_scale is not None else None
+
     daemon = Daemon(project_root)
     started_by_us = False
     if not daemon.is_running():
         try:
-            daemon.start(headless=headless, port=port)
+            daemon.start(headless=headless, port=port, time_scale=time_scale)
         except DaemonError as e:
             pytest.fail(f"无法启动 Godot daemon：{e}", pytrace=False)
         started_by_us = True

--- a/python/godot_cli_control/pytest_plugin.py
+++ b/python/godot_cli_control/pytest_plugin.py
@@ -54,6 +54,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     group.addoption(
         "--godot-cli-time-scale",
         action="store",
+        type=float,
         default=None,
         help="Engine.time_scale applied at daemon startup (e.g. 5 to speed up the whole suite).",
     )
@@ -78,8 +79,7 @@ def godot_daemon(request: pytest.FixtureRequest) -> Iterator[Daemon]:
         else Path(str(config.rootpath)).resolve()
     )
 
-    raw_scale = config.getoption("--godot-cli-time-scale")
-    time_scale = float(raw_scale) if raw_scale is not None else None
+    time_scale: float | None = config.getoption("--godot-cli-time-scale")
 
     daemon = Daemon(project_root)
     started_by_us = False

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -60,6 +60,7 @@ fi
 
 ```bash
 godot-cli-control daemon start             # boot daemon for cwd project
+godot-cli-control daemon start --time-scale 5  # start at 5× game speed (applies Engine.time_scale from frame 0)
 godot-cli-control daemon status            # exit 0 = running, 1 = stopped
 godot-cli-control daemon stop              # stop cwd-project daemon (rc 0; rc 2 = ffmpeg transcode failed)
 godot-cli-control daemon stop --project /path/to/other/godot/project
@@ -71,6 +72,7 @@ godot-cli-control daemon ls                # list all running daemons (cross-pro
 - **`daemon status` payload when stopped**: `{"state": "stopped"}`. If the previous launch wrote `.cli_control/godot.log` or recorded an exit code, the envelope also includes `"last_log": "<path>"` and/or `"last_exit_code": <int>` — use these to diagnose why the daemon died without manually grepping under `.cli_control/`.
 - **`daemon ls` payload**: `{"daemons": [{"project_root", "pid", "port", "started_at", "godot_bin", "log_path"}, ...]}`. Dead records (PID gone) are auto-pruned on each call, so this is the canonical list of *actually-alive* daemons across all projects on the machine.
 - **`daemon stop --all` payload**: `{"stopped": [{"project_root","pid","port","rc"[, "error"]}, ...], "rc": 0|3}`. Each entry's `rc` is the per-project stop result; the top-level `rc` is the aggregate exit code.
+- **`daemon start --time-scale N`**: sets `Engine.time_scale = N` (range `(0, 100]`) from the very first frame of the Godot process. Useful to run an entire test suite at e.g. 5× speed. **Asymmetry**: `run <script>` mode does not support `--time-scale` as a startup flag — inside the script call `bridge.time_scale(5)` on the first line instead; or use `daemon start --time-scale 5` beforehand and connect the script to the already-running daemon.
 
 ## JSON envelope examples
 
@@ -127,6 +129,7 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 | `1006` | Resource transiently unavailable (e.g. screenshot during scene transition / window resize). Rare under normal use: GameBridge waits for viewport first-frame before accepting connections, and `screenshot` retries internally up to ~30 frames (~500ms at 60 fps, ~1s at 30 fps, longer when `--write-movie` lowers the fixed fps). If you still see this, retry after `wait-time 0.05` or similar. |
 | `1007` | Signal not found on the node (`wait-signal` schema error — signal name typo or the node doesn't define it). Permanent — don't retry; inspect with `tree` to list available signals. |
 | `1008` | Scene unavailable (`scene-reload` / `scene-change`): no current scene, scene file missing / failed to load, or timed out waiting for the new scene to become ready. Missing file is permanent — fix the path; timeout usually means the scene itself fails to load — inspect the daemon log. |
+| `1009` | NOT_PAUSED: `step-frames` was called while the scene tree is not paused. This is a state precondition error, not a parameter error — the frames value is valid, but the world state doesn't satisfy the prerequisite. Call `pause` first, then `step-frames`. Don't confuse with `-32602` (bad param value) or `-1003` (CLI usage error). |
 
 **JSON-RPC standard — negative integers `-32xxx`:**
 
@@ -189,6 +192,11 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 **Scene:**
 - `scene-reload [--timeout N]` — reload the current scene and block until the new instance is ready (per-test isolation primitive). All previously cached node paths become stale after it returns.
 - `scene-change <res://path.tscn> [--timeout N]` — switch to another scene and block until ready. Path must start with `res://` or `uid://` (checked before connecting). `--timeout` must be > 0 and <= 3600 (default 10).
+
+**Time:**
+- `time-scale [value]` — read (no arg) or set `Engine.time_scale`. Valid range `(0, 100]`. `wait-time` counts game time, so a higher scale speeds up the whole suite without changing wait semantics.
+- `pause` / `unpause` — freeze / resume the scene tree (`get_tree().paused`). Idempotent. Returns `{"paused": true/false}`.
+- `step-frames <n> [--physics]` — while paused, advance exactly N frames (1..3600) then stop (deterministic stepping for physics assertions). Requires `pause` first — otherwise error `1009`, exit 1. Returns `{"stepped": N, "paused": true}`.
 
 **Render:**
 - `screenshot <path>` — write PNG (path is **required** as of 0.2.0)
@@ -363,6 +371,10 @@ Errors raise `RpcError(code, message)` (a `RuntimeError` subclass) that preserve
 | `await client.release_all()` | `release-all` |
 | `await client.get_pressed()` | `pressed` |
 | `await client.list_input_actions(include_builtin)` | `actions [--all]` |
+| `await client.time_scale(value=None)` | `time-scale [value]` — `value=None` reads current; pass a float to set |
+| `await client.pause()` | `pause` |
+| `await client.unpause()` | `unpause` |
+| `await client.step_frames(frames, physics=False)` | `step-frames <n> [--physics]` — requires tree to be paused (error `1009` otherwise) |
 
 ## `def run(bridge)` script mode
 
@@ -415,6 +427,7 @@ Pytest CLI options the plugin adds:
 | `--godot-cli-port` | `(auto)` | GameBridge port. Default: read from `.cli_control/port` (which the daemon writes when it starts). |
 | `--godot-cli-no-headless` | off (i.e. headless) | Drop `--headless`, open a real Godot window |
 | `--godot-cli-project-root` | `pytest rootdir` | Override the Godot project root |
+| `--godot-cli-time-scale` | `None` (engine default = 1.0) | Set `Engine.time_scale` at daemon startup (e.g. `5` to run the whole suite at 5× speed). Passed as `--cli-time-scale=N` to Godot; valid range `(0, 100]`. |
 
 If the entry-point isn't picking up automatically (rare — usually means an editable install glitch), fall back to listing it in `conftest.py`:
 
@@ -456,6 +469,9 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **Python API (`bridge.get_property` / `bridge.get_properties`) returns bare values only — no `type` field.** These convenience methods strip the `type` from the server response to reduce boilerplate. When you need the `type` field (e.g. to distinguish `Vector2` from a plain 2-element array), go through `client.request("get_property", {"path": ..., "property": ...})` directly.
 - **After `scene-change` / `scene-reload`, all node paths from the previous scene are stale** — re-locate nodes with `wait-node` before touching them. The new scene root is a brand-new tree; any path cached from the old scene will return `1001 "node not found"`.
 - **`scene-reload` returning means the OLD scene instance was freed — never reuse node references/paths cached before the reload.** The command blocks until the new scene is ready, but the path strings that were valid in the old scene may now point to different nodes or nothing at all. Always re-query after a reload.
+- **`step-frames` requires `pause` first (error `1009`) — the intended pattern is `pause` → `step-frames` → assert → `unpause`.** Error `1009` means the precondition (tree is paused) was not met; it is distinct from `-32602` (bad param value) and `-1003` (CLI usage error). If you get `1009`, call `pause` before `step-frames`.
+- **`time-scale` also shortens the wall-clock duration of `wait-time` (game-time semantics unchanged) — don't "compensate" wait times after scaling.** `wait-time 1.0` always waits 1 in-game second regardless of `Engine.time_scale`. At `time_scale=5`, that 1 game-second completes in 0.2 wall-clock seconds — don't multiply your wait values, they're already correct.
+- **With `--record` (Movie Maker fixed-FPS), `time_scale` still applies — the captured video plays back sped-up.** Don't combine `--record` with a high `time_scale` unless you intentionally want a fast-forward video. Movie Maker records at wall-clock time at the configured `--fps`, so raising `time_scale` compresses the animation into fewer frames.
 
 ---
 

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -195,7 +195,7 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 
 **Time:**
 - `time-scale [value]` — read (no arg) or set `Engine.time_scale`. Valid range `(0, 100]`. `wait-time` counts game time, so a higher scale speeds up the whole suite without changing wait semantics.
-- `pause` / `unpause` — freeze / resume the scene tree (`get_tree().paused`). Idempotent. Returns `{"paused": true/false}`.
+- `pause` / `unpause` — freeze / resume the scene tree (`get_tree().paused`). Idempotent. Returns `{"paused": true/false}`. Note: `wait-time` keeps counting while paused (its timer uses `process_always`), so you can use `wait-time` + `get` to verify a frozen state.
 - `step-frames <n> [--physics]` — while paused, advance exactly N frames (1..3600) then stop (deterministic stepping for physics assertions). Requires `pause` first — otherwise error `1009`, exit 1. Returns `{"stepped": N, "paused": true}`.
 
 **Render:**
@@ -471,7 +471,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **`scene-reload` returning means the OLD scene instance was freed — never reuse node references/paths cached before the reload.** The command blocks until the new scene is ready, but the path strings that were valid in the old scene may now point to different nodes or nothing at all. Always re-query after a reload.
 - **`step-frames` requires `pause` first (error `1009`) — the intended pattern is `pause` → `step-frames` → assert → `unpause`.** Error `1009` means the precondition (tree is paused) was not met; it is distinct from `-32602` (bad param value) and `-1003` (CLI usage error). If you get `1009`, call `pause` before `step-frames`.
 - **`time-scale` also shortens the wall-clock duration of `wait-time` (game-time semantics unchanged) — don't "compensate" wait times after scaling.** `wait-time 1.0` always waits 1 in-game second regardless of `Engine.time_scale`. At `time_scale=5`, that 1 game-second completes in 0.2 wall-clock seconds — don't multiply your wait values, they're already correct.
-- **With `--record` (Movie Maker fixed-FPS), `time_scale` still applies — the captured video plays back sped-up.** Don't combine `--record` with a high `time_scale` unless you intentionally want a fast-forward video. Movie Maker records at wall-clock time at the configured `--fps`, so raising `time_scale` compresses the animation into fewer frames.
+- **With `--record` (Movie Maker fixed-FPS), `time_scale` still applies — the captured video plays back sped-up.** Don't combine `--record` with a high `time_scale` unless you intentionally want a fast-forward video. Movie Maker renders a fixed number of frames per game-time at the configured `--fps`; with a higher `time_scale` each rendered frame covers more game-time, so the frame count stays the same but the animation appears fast-forwarded at normal playback speed.
 
 ---
 

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -137,6 +137,18 @@ class _StubClient:
     async def scene_change(self, path: str, timeout: float = 10.0) -> dict:
         return self._record("scene_change", (path,), {"timeout": timeout})
 
+    async def time_scale(self, value: float | None = None) -> dict:
+        return self._record("time_scale", (value,), {})
+
+    async def pause(self) -> dict:
+        return self._record("pause", (), {})
+
+    async def unpause(self) -> dict:
+        return self._record("unpause", (), {})
+
+    async def step_frames(self, frames: int, physics: bool = False) -> dict:
+        return self._record("step_frames", (frames,), {"physics": physics})
+
 
 @pytest.fixture
 def stub_client(monkeypatch: pytest.MonkeyPatch) -> _StubClient:
@@ -593,4 +605,66 @@ def test_scene_change_custom_timeout(stub_client: dict) -> None:
     c.returns["scene_change"] = {"scene_path": "res://b.tscn", "name": "B"}
     b.scene_change("res://b.tscn", timeout=5.0)
     assert c.calls[-1] == ("scene_change", ("res://b.tscn",), {"timeout": 5.0})
+    b.close()
+
+
+# ── issue #102: time_scale / pause / unpause / step_frames bridge 委托 ──
+
+
+def test_time_scale_no_arg_delegates_to_client(stub_client: dict) -> None:
+    """bridge.time_scale() 无参时委托 client.time_scale(None)，返回值透传。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["time_scale"] = {"time_scale": 1.0}
+    result = b.time_scale()
+    assert c.calls[-1] == ("time_scale", (None,), {})
+    assert result == {"time_scale": 1.0}
+    b.close()
+
+
+def test_time_scale_with_value_delegates_to_client(stub_client: dict) -> None:
+    """bridge.time_scale(2.5) 委托 client.time_scale(2.5)，返回值透传。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["time_scale"] = {"time_scale": 2.5}
+    result = b.time_scale(2.5)
+    assert c.calls[-1] == ("time_scale", (2.5,), {})
+    assert result == {"time_scale": 2.5}
+    b.close()
+
+
+def test_pause_delegates_to_client(stub_client: dict) -> None:
+    """bridge.pause() 委托给 client.pause()，返回值透传。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["pause"] = {"paused": True}
+    result = b.pause()
+    assert c.calls[-1] == ("pause", (), {})
+    assert result == {"paused": True}
+    b.close()
+
+
+def test_unpause_delegates_to_client(stub_client: dict) -> None:
+    """bridge.unpause() 委托给 client.unpause()，返回值透传。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["unpause"] = {"paused": False}
+    result = b.unpause()
+    assert c.calls[-1] == ("unpause", (), {})
+    assert result == {"paused": False}
+    b.close()
+
+
+def test_step_frames_delegates_to_client(stub_client: dict) -> None:
+    """bridge.step_frames(10) 委托给 client.step_frames(10, physics=False)，返回值透传。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["step_frames"] = {"stepped": 10, "paused": True}
+    result = b.step_frames(10)
+    assert c.calls[-1] == ("step_frames", (10,), {"physics": False})
+    assert result == {"stepped": 10, "paused": True}
+    b.close()
+
+
+def test_step_frames_physics_flag_delegates_to_client(stub_client: dict) -> None:
+    """bridge.step_frames(5, physics=True) 把 physics=True 透传到 client。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["step_frames"] = {"stepped": 5, "paused": True}
+    b.step_frames(5, physics=True)
+    assert c.calls[-1] == ("step_frames", (5,), {"physics": True})
     b.close()

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1461,6 +1461,7 @@ def test_time_scale_preflight_rejects_bad_value(
     payload = _json.loads(capsys.readouterr().out.strip().splitlines()[-1])
     assert payload["ok"] is False
     assert payload["error"]["code"] == -1003
+    assert "value" in payload["error"]["message"]
 
 
 @pytest.mark.parametrize("bad_frames", ["0", "3601", "abc"])
@@ -1488,6 +1489,7 @@ def test_step_frames_preflight_rejects_bad_frames(
     payload = _json.loads(capsys.readouterr().out.strip().splitlines()[-1])
     assert payload["ok"] is False
     assert payload["error"]["code"] == -1003
+    assert "frames" in payload["error"]["message"]
 
 
 def test_daemon_stop_emits_json_envelope(

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -2088,6 +2088,39 @@ def test_daemon_start_idle_timeout_default_is_zero() -> None:
     assert ns.idle_timeout == "0"
 
 
+def test_daemon_start_time_scale_flag_parses() -> None:
+    """daemon start --time-scale 2.5 → ns.time_scale == 2.5（float）。"""
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["daemon", "start", "--time-scale", "2.5"])
+    assert ns.time_scale == 2.5
+
+
+def test_daemon_start_time_scale_default_is_none() -> None:
+    """不传 --time-scale 时 ns.time_scale is None。"""
+    from godot_cli_control.cli import build_parser
+    ns = build_parser().parse_args(["daemon", "start"])
+    assert ns.time_scale is None
+
+
+@pytest.mark.parametrize("bad_value", ["abc", "0", "-1", "101"])
+def test_daemon_start_time_scale_rejects_bad_value(
+    bad_value: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """daemon start --time-scale <bad> → exit 64 + -1003 信封（argparse type 校验）。"""
+    import json as _json
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    monkeypatch.setattr(sys, "argv", ["godot-cli-control", "daemon", "start", "--time-scale", bad_value])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == EXIT_USAGE
+    payload = _json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+
+
 def test_tree_accepts_max_nodes_flag() -> None:
     from godot_cli_control.cli import build_parser
 

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1408,6 +1408,88 @@ def test_scene_change_preflight_rejects_bad_timeout(
     assert "timeout" in payload["error"]["message"]
 
 
+# ── Time 命令组测试（#102）──
+
+
+def test_time_specs_registered() -> None:
+    """time-scale / pause / unpause / step-frames 四个 spec 在 RPC_BY_NAME；
+    time-scale 和 step-frames 带 preflight。"""
+    from godot_cli_control.cli import RPC_BY_NAME
+
+    for name in ("time-scale", "pause", "unpause", "step-frames"):
+        assert name in RPC_BY_NAME, f"{name} 未注册"
+    assert RPC_BY_NAME["time-scale"].preflight is not None, "time-scale 需要 preflight"
+    assert RPC_BY_NAME["step-frames"].preflight is not None, "step-frames 需要 preflight"
+    # pause / unpause 无参，不需要 preflight
+    assert RPC_BY_NAME["pause"].preflight is None
+    assert RPC_BY_NAME["unpause"].preflight is None
+
+
+def test_time_text_formatters() -> None:
+    """time-scale / pause / unpause / step-frames 的 text_formatter 输出符合预期。"""
+    from godot_cli_control.cli import RPC_BY_NAME
+
+    assert RPC_BY_NAME["time-scale"].text_formatter({"time_scale": 2.5}) == "time_scale = 2.5"
+    assert RPC_BY_NAME["pause"].text_formatter({"paused": True}) == "paused: True"
+    assert RPC_BY_NAME["unpause"].text_formatter({"paused": False}) == "paused: False"
+    assert RPC_BY_NAME["step-frames"].text_formatter({"stepped": 5, "paused": True}) == \
+        "stepped 5 frames (still paused)"
+
+
+@pytest.mark.parametrize("bad_value", ["0", "-1", "101", "abc"])
+def test_time_scale_preflight_rejects_bad_value(
+    bad_value: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """time-scale 非法 value 必须在连 daemon 之前报 EXIT_USAGE（-1003）。"""
+    import json as _json
+
+    import godot_cli_control.cli as cli_mod
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    class _ShouldNotConnect:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            raise AssertionError("preflight 失效：time-scale 非法 value 时不应连 daemon")
+
+    monkeypatch.setattr(cli_mod, "GameClient", _ShouldNotConnect)
+    monkeypatch.setattr(sys, "argv", ["godot-cli-control", "time-scale", bad_value])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == EXIT_USAGE
+    payload = _json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+
+
+@pytest.mark.parametrize("bad_frames", ["0", "3601", "abc"])
+def test_step_frames_preflight_rejects_bad_frames(
+    bad_frames: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """step-frames 非法 frames 必须在连 daemon 之前报 EXIT_USAGE（-1003）。"""
+    import json as _json
+
+    import godot_cli_control.cli as cli_mod
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    class _ShouldNotConnect:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            raise AssertionError("preflight 失效：step-frames 非法 frames 时不应连 daemon")
+
+    monkeypatch.setattr(cli_mod, "GameClient", _ShouldNotConnect)
+    monkeypatch.setattr(sys, "argv", ["godot-cli-control", "step-frames", bad_frames])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == EXIT_USAGE
+    payload = _json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+
+
 def test_daemon_stop_emits_json_envelope(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -767,3 +767,133 @@ async def test_scene_change_sends_correct_rpc_params() -> None:
     assert captured["params"] == {"path": "res://a.tscn", "timeout": 3.0}
     assert captured["timeout"] == 3.0 + 5.0
     assert result == {"scene_path": "res://a.tscn", "name": "A"}
+
+
+# ---- issue #102: time_scale / pause / unpause / step_frames client 包装 ----
+
+
+@pytest.mark.asyncio
+async def test_time_scale_no_arg_sends_empty_params() -> None:
+    """time_scale() 无参时 params 必须是 {}（不带 "value" 键）——GDScript 用 has("value") 区分读写。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        captured["timeout"] = timeout
+        return {"time_scale": 1.0}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.time_scale()
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "time_scale"
+    assert captured["params"] == {}, "无参时 params 必须是空字典，不得含 'value' 键"
+    assert result == {"time_scale": 1.0}
+
+
+@pytest.mark.asyncio
+async def test_time_scale_with_value_sends_value_param() -> None:
+    """time_scale(2.5) 发出 params={"value": 2.5}。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        return {"time_scale": 2.5}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        await client.time_scale(2.5)
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "time_scale"
+    assert captured["params"] == {"value": 2.5}
+
+
+@pytest.mark.asyncio
+async def test_pause_sends_correct_rpc() -> None:
+    """pause() 发出 method="pause"，params={}。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        return {"paused": True}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.pause()
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "pause"
+    assert captured["params"] == {}
+    assert result == {"paused": True}
+
+
+@pytest.mark.asyncio
+async def test_unpause_sends_correct_rpc() -> None:
+    """unpause() 发出 method="unpause"，params={}。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        return {"paused": False}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.unpause()
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "unpause"
+    assert captured["params"] == {}
+    assert result == {"paused": False}
+
+
+@pytest.mark.asyncio
+async def test_step_frames_sends_correct_params_and_calculates_timeout() -> None:
+    """step_frames 的 client timeout = max(30, frames/10 + 10)。"""
+    import godot_cli_control.client as client_mod
+
+    captured: list = []
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured.append({"method": method, "params": params, "timeout": timeout})
+        return {"stepped": params.get("frames", 0), "paused": True}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        # 5 frames: max(30, 5/10+10)=max(30, 10.5)=30
+        await client.step_frames(5)
+        # 600 frames: max(30, 600/10+10)=max(30, 70)=70
+        await client.step_frames(600, physics=True)
+    finally:
+        client_mod.GameClient.request = orig
+
+    assert captured[0]["method"] == "step_frames"
+    assert captured[0]["params"] == {"frames": 5, "physics": False}
+    assert captured[0]["timeout"] == 30.0
+
+    assert captured[1]["method"] == "step_frames"
+    assert captured[1]["params"] == {"frames": 600, "physics": True}
+    assert captured[1]["timeout"] == 70.0

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -794,6 +794,7 @@ async def test_time_scale_no_arg_sends_empty_params() -> None:
         client_mod.GameClient.request = orig
     assert captured["method"] == "time_scale"
     assert captured["params"] == {}, "无参时 params 必须是空字典，不得含 'value' 键"
+    assert captured["timeout"] == 30.0, "time_scale 不应传自定义 RPC timeout（用默认值）"
     assert result == {"time_scale": 1.0}
 
 

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -1372,3 +1372,85 @@ def test_start_registers_in_global_registry(
 
     daemon.stop()
     assert not record_file.exists(), "stop() 后注册表 JSON 应被 unregister 删掉"
+
+
+# ── time_scale 透传（#102）──
+
+
+def _make_popen_capture(pid: int) -> tuple[dict, Any]:
+    """返回 (captured, _FakeProc class)，_FakeProc.pid = pid。"""
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        returncode = None
+
+        def __init__(self) -> None:
+            self.pid = pid
+
+        def poll(self) -> None:
+            return None
+
+    def _record_popen(args: list[str], **kwargs: Any) -> _FakeProc:
+        captured["args"] = args
+        return _FakeProc()
+
+    return captured, _record_popen
+
+
+def _patch_start_env_for_time_scale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> "Daemon":
+    """共用的 monkeypatch 设置，返回 Daemon 实例。"""
+    _touch_godot_project(tmp_path)
+    fake_bin = tmp_path / "fake_godot_ts"
+    fake_bin.write_text("")
+    fake_bin.chmod(0o755)
+    monkeypatch.setattr("godot_cli_control.daemon.find_godot_binary", lambda: str(fake_bin))
+    monkeypatch.setattr("godot_cli_control.daemon._ensure_imported", lambda *a, **k: None)
+    monkeypatch.setattr("godot_cli_control.daemon.time.sleep", lambda *_: None)
+    monkeypatch.setattr("godot_cli_control.daemon._wait_port_ready", lambda *a, **k: True)
+    return Daemon(tmp_path)
+
+
+def test_start_passes_time_scale_to_popen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """daemon.start(time_scale=2.5) → Popen argv 含 --cli-time-scale=2.5。"""
+    daemon = _patch_start_env_for_time_scale(tmp_path, monkeypatch)
+    captured, record_popen = _make_popen_capture(999_999_200)
+    monkeypatch.setattr("godot_cli_control.daemon.subprocess.Popen", record_popen)
+    daemon.start(port=0, time_scale=2.5)
+    assert "--cli-time-scale=2.5" in captured["args"], \
+        f"argv 应含 --cli-time-scale=2.5（实际：{captured['args']}）"
+
+
+def test_start_omits_time_scale_when_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """不传 time_scale 时 argv 不含 --cli-time-scale 前缀。"""
+    daemon = _patch_start_env_for_time_scale(tmp_path, monkeypatch)
+    captured, record_popen = _make_popen_capture(999_999_201)
+    monkeypatch.setattr("godot_cli_control.daemon.subprocess.Popen", record_popen)
+    daemon.start(port=0)
+    assert not any(a.startswith("--cli-time-scale=") for a in captured["args"]), \
+        f"不传 time_scale 时 argv 不应含 --cli-time-scale=（实际：{captured['args']}）"
+
+
+def test_start_rejects_time_scale_zero(tmp_path: Path) -> None:
+    """time_scale=0 → 抛 DaemonError（spawn 前域校验）。"""
+    from godot_cli_control.daemon import DaemonError
+
+    _touch_godot_project(tmp_path)
+    daemon = Daemon(tmp_path)
+    with pytest.raises(DaemonError, match="time-scale"):
+        daemon.start(time_scale=0)
+
+
+def test_start_rejects_time_scale_above_max(tmp_path: Path) -> None:
+    """time_scale=101 → 抛 DaemonError（spawn 前域校验）。"""
+    from godot_cli_control.daemon import DaemonError
+
+    _touch_godot_project(tmp_path)
+    daemon = Daemon(tmp_path)
+    with pytest.raises(DaemonError, match="time-scale"):
+        daemon.start(time_scale=101)

--- a/python/tests/test_e2e_time.py
+++ b/python/tests/test_e2e_time.py
@@ -97,18 +97,22 @@ def daemon(demo_project: Path) -> Any:
 
 
 def test_pause_freezes_and_step_frames_advances_physics(daemon: Any) -> None:
-    """pause 冻结物理 → step-frames --physics 确定性推进 → unpause。
+    """pause 冻结物理 → 空中传送 → step-frames --physics 确定性下落 → unpause。
 
-    Headless Godot 跑得极快（0.05s 内 player 已落地），所以点 Start 后立即 pause，
-    不加任何 wait-time，确保捕捉到 mid-fall 状态（player starts at y=80, ground ≈y=280）。
+    去竞态设计：不依赖「pause 抢在落地前」——pause 后用 set 把 player 传送回
+    空中（paused 下属性写照常生效），step 的重力下落就与机器速度无关。
     """
     project = daemon
     assert _run_cli(project, "wait-node", "/root/Main/UI/StartButton")["result"]["found"]
-    # 点 Start 让 player 激活；立即 pause，截住下落中途（不加 wait-time）
     assert _run_cli(project, "click", "/root/Main/UI/StartButton")["ok"]
+    assert _run_cli(project, "wait-node", "/root/Main/World/Player")["result"]["found"]
     assert _run_cli(project, "pause")["result"]["paused"] is True
+    # 传送回空中（y=80 远离地面 y≈280），paused 下 set 直接写属性
+    assert _run_cli(project, "set", "/root/Main/World/Player", "position", "[320, 80]")["ok"]
     y1 = _run_cli(project, "get", "/root/Main/World/Player", "position:y")["result"]["value"]
-    _run_cli(project, "wait-time", "0.3")  # 墙钟流逝，但树已 pause
+    assert y1 == 80.0, f"传送后应在空中：{y1}"
+    # paused 下墙钟流逝，位置必须冻结
+    _run_cli(project, "wait-time", "0.3")
     y2 = _run_cli(project, "get", "/root/Main/World/Player", "position:y")["result"]["value"]
     assert y2 == y1, f"paused 下位置不得变化：{y1} -> {y2}"
     # 确定性推进 10 个物理帧：重力必须使 y 增大

--- a/python/tests/test_e2e_time.py
+++ b/python/tests/test_e2e_time.py
@@ -1,0 +1,151 @@
+"""端到端回归：时间控制全链路（pause / step-frames / time-scale / 启动倍速）。
+
+验证点：
+  - pause 冻结物理帧 → step-frames --physics 确定性推进 → unpause
+  - step-frames 未 pause 前置 → 信封 ok=false error.code==1009
+  - time-scale 读写往返正确
+  - daemon start --time-scale 2 → 连上即读到 2.0（第 0 帧生效）
+
+需要真实 Godot 4：PATH 里有 godot（或设 GODOT_BIN），否则整文件 skip。
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from godot_cli_control.daemon import find_godot_binary
+
+# 与生产 daemon 用同一套 godot 检测（GODOT_BIN > macOS .app > PATH > Windows）。
+_GODOT_BIN = find_godot_binary()
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEMO_SRC = _REPO_ROOT / "examples" / "platformer-demo"
+_ADDON_SRC = _REPO_ROOT / "addons" / "godot_cli_control"
+
+pytestmark = pytest.mark.skipif(
+    not _GODOT_BIN,
+    reason="需要真实 Godot 4：把 godot 装进 PATH 或设 GODOT_BIN，否则整文件 skip",
+)
+
+# 用 `python -m godot_cli_control` 调 CLI：与 PATH 无关，always 命中当前环境。
+_CLI = [sys.executable, "-m", "godot_cli_control"]
+
+# demo 的 project.godot 故意不含这两段（留给 init）。测试里直接 append，等价于
+# init 的 patch，但不依赖 init 的 godot 探测 / 重导入，更可控、与其它 e2e 一致。
+_BRIDGE_SECTIONS = """
+[autoload]
+
+GameBridgeNode="*res://addons/godot_cli_control/bridge/game_bridge.gd"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/godot_cli_control/plugin.cfg")
+"""
+
+
+def _run_cli(project: Path, *args: str, timeout: float = 60.0) -> dict[str, Any]:
+    """跑一条 CLI 子命令（独立进程 = 独立连接），解析最后一行 JSON 信封。"""
+    proc = subprocess.run(
+        _CLI + list(args),
+        cwd=project,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    json_lines = [ln for ln in proc.stdout.splitlines() if ln.strip().startswith("{")]
+    assert json_lines, f"无 JSON 输出：args={args} stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    return json.loads(json_lines[-1])
+
+
+@pytest.fixture(scope="module")
+def demo_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """把 examples/platformer-demo 拷到 tmp，接上 addon + bridge 段，导入一次。"""
+    proj = tmp_path_factory.mktemp("gcc_time")
+    for name in ("project.godot", "main.tscn", "main.gd", "player.gd"):
+        shutil.copy(_DEMO_SRC / name, proj / name)
+    (proj / "addons").mkdir()
+    shutil.copytree(_ADDON_SRC, proj / "addons" / "godot_cli_control")
+    with (proj / "project.godot").open("a", encoding="utf-8") as f:
+        f.write(_BRIDGE_SECTIONS)
+
+    # 先跑一次编辑器导入，注册全局 class + 资源 .import（headless 导入即可）。
+    imp = subprocess.run(
+        [_GODOT_BIN, "--headless", "--editor", "--quit", "--path", str(proj)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert imp.returncode == 0, f"Godot 导入失败：{imp.stdout}\n{imp.stderr}"
+    return proj
+
+
+@pytest.fixture
+def daemon(demo_project: Path) -> Any:
+    """每个用例起 / 停一个真实 headless daemon。"""
+    start = _run_cli(demo_project, "daemon", "start", "--headless", timeout=90)
+    assert start["ok"] is True and start["result"]["started"], start
+    try:
+        yield demo_project
+    finally:
+        _run_cli(demo_project, "daemon", "stop", timeout=30)
+
+
+def test_pause_freezes_and_step_frames_advances_physics(daemon: Any) -> None:
+    """pause 冻结物理 → step-frames --physics 确定性推进 → unpause。
+
+    Headless Godot 跑得极快（0.05s 内 player 已落地），所以点 Start 后立即 pause，
+    不加任何 wait-time，确保捕捉到 mid-fall 状态（player starts at y=80, ground ≈y=280）。
+    """
+    project = daemon
+    assert _run_cli(project, "wait-node", "/root/Main/UI/StartButton")["result"]["found"]
+    # 点 Start 让 player 激活；立即 pause，截住下落中途（不加 wait-time）
+    assert _run_cli(project, "click", "/root/Main/UI/StartButton")["ok"]
+    assert _run_cli(project, "pause")["result"]["paused"] is True
+    y1 = _run_cli(project, "get", "/root/Main/World/Player", "position:y")["result"]["value"]
+    _run_cli(project, "wait-time", "0.3")  # 墙钟流逝，但树已 pause
+    y2 = _run_cli(project, "get", "/root/Main/World/Player", "position:y")["result"]["value"]
+    assert y2 == y1, f"paused 下位置不得变化：{y1} -> {y2}"
+    # 确定性推进 10 个物理帧：重力必须使 y 增大
+    r = _run_cli(project, "step-frames", "10", "--physics")
+    assert r["ok"] is True, r
+    assert r["result"]["stepped"] == 10
+    assert r["result"]["paused"] is True
+    y3 = _run_cli(project, "get", "/root/Main/World/Player", "position:y")["result"]["value"]
+    assert y3 > y2, f"10 个物理帧后应下落：{y2} -> {y3}"
+    assert _run_cli(project, "unpause")["result"]["paused"] is False
+
+
+def test_step_frames_without_pause_returns_1009(daemon: Any) -> None:
+    project = daemon
+    assert _run_cli(project, "wait-node", "/root/Main")["result"]["found"]
+    r = _run_cli(project, "step-frames", "3")
+    assert r["ok"] is False
+    assert r["error"]["code"] == 1009
+
+
+def test_time_scale_roundtrip(daemon: Any) -> None:
+    project = daemon
+    assert _run_cli(project, "wait-node", "/root/Main")["result"]["found"]
+    assert _run_cli(project, "time-scale")["result"]["time_scale"] == 1.0
+    assert _run_cli(project, "time-scale", "5")["result"]["time_scale"] == 5.0
+    assert _run_cli(project, "time-scale")["result"]["time_scale"] == 5.0
+    # 还原，避免影响同 daemon 的后续操作（虽然 daemon 是 function-scope，防御性）
+    assert _run_cli(project, "time-scale", "1")["ok"]
+
+
+def test_daemon_start_time_scale_applies_at_startup(demo_project: Path) -> None:
+    """daemon start --time-scale 2：连上即读到 2.0（第 0 帧生效路径）。"""
+    project = demo_project
+    start = _run_cli(project, "daemon", "start", "--headless", "--time-scale", "2", timeout=90)
+    assert start["ok"] is True and start["result"]["started"], start
+    try:
+        r = _run_cli(project, "time-scale")
+        assert r["result"]["time_scale"] == 2.0
+    finally:
+        _run_cli(project, "daemon", "stop", timeout=30)

--- a/python/tests/test_e2e_time.py
+++ b/python/tests/test_e2e_time.py
@@ -6,6 +6,10 @@
   - time-scale 读写往返正确
   - daemon start --time-scale 2 → 连上即读到 2.0（第 0 帧生效）
 
+非显然前置：wait-time 内部是 process_always=true 的 SceneTree 计时器，
+paused 下按墙钟照常计时——所以「pause 后 wait-time 再断言位置不变」是合法
+序列，不是 bug（见 wait_api.gd 的 wait_game_time_async 注释）。
+
 需要真实 Godot 4：PATH 里有 godot（或设 GODOT_BIN），否则整文件 skip。
 """
 
@@ -144,7 +148,11 @@ def test_time_scale_roundtrip(daemon: Any) -> None:
 
 
 def test_daemon_start_time_scale_applies_at_startup(demo_project: Path) -> None:
-    """daemon start --time-scale 2：连上即读到 2.0（第 0 帧生效路径）。"""
+    """daemon start --time-scale 2：连上即读到 2.0（第 0 帧生效路径）。
+
+    不用 daemon fixture：本用例要以 --time-scale 2 启动，fixture 不传该参数，
+    故直接依赖 demo_project 自管 start/stop（finally 兜底）。
+    """
     project = demo_project
     start = _run_cli(project, "daemon", "start", "--headless", "--time-scale", "2", timeout=90)
     assert start["ok"] is True and start["result"]["started"], start

--- a/python/tests/test_pytest_plugin.py
+++ b/python/tests/test_pytest_plugin.py
@@ -441,3 +441,88 @@ def test_fresh_scene_fixture(pytester: pytest.Pytester) -> None:
     output = result.stdout.str()
     # 两个测试各调 1 次 scene_reload，合计 2 次
     assert "RELOAD_COUNT=[1, 1]" in output, f"expected 2 reloads, got: {output}"
+
+
+# ---------------------------------------------------------------------------
+# --godot-cli-time-scale 选项透传（#102）
+# ---------------------------------------------------------------------------
+
+
+def test_time_scale_option_registered_in_help(pytester: pytest.Pytester) -> None:
+    """--godot-cli-time-scale 出现在 --help 的 godot-cli-control 组。"""
+    result = pytester.runpytest("--help")
+    result.stdout.fnmatch_lines(["*--godot-cli-time-scale*"])
+
+
+def test_godot_daemon_passes_time_scale_to_start(pytester: pytest.Pytester) -> None:
+    """--godot-cli-time-scale 3 → daemon.start(time_scale=3.0)。"""
+    pytester.makeconftest(
+        """
+        import godot_cli_control.pytest_plugin as plugin
+
+        OBSERVED: list = []
+
+        class FakeDaemon:
+            def __init__(self, *a, **kw): pass
+            def is_running(self): return False
+            def start(self, **kw): OBSERVED.append(kw.get("time_scale"))
+            def stop(self): return 0
+            def current_port(self): return 5555
+
+        class FakeBridge:
+            def __init__(self, port): pass
+            def release_all(self): pass
+            def close(self): pass
+
+        plugin.Daemon = FakeDaemon
+        plugin.GameBridge = FakeBridge
+
+        def pytest_sessionfinish(session, exitstatus):
+            assert OBSERVED[0] == 3.0, f"expected time_scale=3.0, got {OBSERVED}"
+        """
+    )
+    pytester.makepyfile(
+        test_x="""
+        def test_x(godot_daemon, bridge): pass
+        """
+    )
+    result = pytester.runpytest("-v", "--godot-cli-time-scale", "3")
+    assert result.ret == 0
+
+
+def test_godot_daemon_passes_time_scale_none_when_not_given(
+    pytester: pytest.Pytester,
+) -> None:
+    """不传 --godot-cli-time-scale → daemon.start(time_scale=None)。"""
+    pytester.makeconftest(
+        """
+        import godot_cli_control.pytest_plugin as plugin
+
+        OBSERVED: list = []
+
+        class FakeDaemon:
+            def __init__(self, *a, **kw): pass
+            def is_running(self): return False
+            def start(self, **kw): OBSERVED.append(kw.get("time_scale"))
+            def stop(self): return 0
+            def current_port(self): return 5555
+
+        class FakeBridge:
+            def __init__(self, port): pass
+            def release_all(self): pass
+            def close(self): pass
+
+        plugin.Daemon = FakeDaemon
+        plugin.GameBridge = FakeBridge
+
+        def pytest_sessionfinish(session, exitstatus):
+            assert OBSERVED[0] is None, f"expected time_scale=None, got {OBSERVED}"
+        """
+    )
+    pytester.makepyfile(
+        test_x="""
+        def test_x(godot_daemon, bridge): pass
+        """
+    )
+    result = pytester.runpytest("-v")
+    assert result.ret == 0

--- a/python/tests/test_pytest_plugin.py
+++ b/python/tests/test_pytest_plugin.py
@@ -526,3 +526,13 @@ def test_godot_daemon_passes_time_scale_none_when_not_given(
     )
     result = pytester.runpytest("-v")
     assert result.ret == 0
+
+
+def test_time_scale_invalid_float_gives_usage_error(pytester: pytest.Pytester) -> None:
+    """--godot-cli-time-scale abc → pytest 以 usage error（exit 4）退出，
+    stderr 含 'invalid float value'（由 argparse type=float 触发，不再进 fixture 内部）。
+    """
+    result = pytester.runpytest("--godot-cli-time-scale", "abc")
+    # pytest argparse usage error 退出码为 4
+    assert result.ret == 4
+    result.stderr.fnmatch_lines(["*invalid float value*"])


### PR DESCRIPTION
## Summary

issue #102 时间控制：给 e2e 提供整体倍速与确定性帧推进，消灭「等足够久再读」式的调度器赛跑。

### RPC / GDScript
- 新建 `bridge/time_api.gd`（对齐 wait_api/scene_api 拆分先例）：
  - **`time_scale`**：读（无参）/ 写 `Engine.time_scale`，合法域 `(0, 100]`——拒收 0（冻死 wait-time 且与 pause 职责重叠）
  - **`pause` / `unpause`**：`get_tree().paused`，幂等
  - **`step_frames`**：paused 前置（否则新业务码 **1009 NOT_PAUSED**，fail-loud 教学「pause → step → 断言」模型）→ unpause → await N 个 process/physics 帧 → **恒写回 paused**
- 启动倍速：`--cli-time-scale=<x>` cmdline arg（`_parse_port_from_args` 同构静态解析，**在首帧 gate 前生效**——第 0 帧即倍速）

### CLI / daemon / plugin
- 平铺 `time-scale [value]`、`pause`、`unpause`、`step-frames <n> [--physics]`（preflight 先行，`_require_frames` 与 wait-frames 共享）
- `daemon start --time-scale N`（argparse type 走 -1003 信封；`run` 模式不支持该 flag——脚本内 `bridge.time_scale(5)` 等效，SKILL.md 已写明不对称）
- pytest plugin `--godot-cli-time-scale`（type=float，解析期拒绝非数字）

### 过程中附带修复（调查产物）
- **test_wait_api 帧差测量缺陷**：Godot `await signal` 在发射周期内同帧解析，前驱 async 测试会让帧差少算 1（稳定复现的伪 flaky，Task 1 的「全绿」是节拍碰巧对齐的假阳性）——帧差用例加帧边界 guard，阈值未放松
- `wait_api.gd` 钉死 `create_timer` 对 `process_always=true` 默认值的隐式依赖（paused 下 wait-time 照常计时是 e2e 验证冻结的机制基础）

### 文档（契约 7）
- SKILL.md：Time 命令组、1009 错误码行、daemon `--time-scale`、plugin 选项表、pitfalls ×3（record 下录出加速画面——Movie Maker 帧数不变每帧含更多 game-time；wait-time 别补偿；step 须先 pause）
- addon README 同步；spec/plan 入库

Fixes #102

## Test plan
- [x] GUT 167/167（test_time_api 13 用例 + 注册表 + 帧差 guard 后连续两次全绿）
- [x] Python 全量 515 passed / 2 skipped，覆盖率 89%（门槛 80%）
- [x] e2e 真 Godot 4/4：pause 冻结 + 空中传送去竞态 + step 物理推进、1009、time-scale 往返、daemon start --time-scale 启动即生效（连续两次稳定）
- [x] `format_full_help()` 渲染 + `test_skills_install.py` 11/11
- [x] 最终全量 review READY TO MERGE（(0,100] 四处一致、1009 单一情形、无新攻击面）

🤖 Generated with [Claude Code](https://claude.com/claude-code)