### PR TITLE
feat(render): sprite-info 聚合查询 + screenshot --node 节点裁剪（#101）

### DIFF
--- a/.claude/skills/godot-cli-control/SKILL.md
+++ b/.claude/skills/godot-cli-control/SKILL.md
@@ -130,6 +130,8 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 | `1007` | Signal not found on the node (`wait-signal` schema error — signal name typo or the node doesn't define it). Permanent — don't retry; inspect with `tree` to list available signals. |
 | `1008` | Scene unavailable (`scene-reload` / `scene-change`): no current scene, scene file missing / failed to load, or timed out waiting for the new scene to become ready. Missing file is permanent — fix the path; timeout usually means the scene itself fails to load — inspect the daemon log. |
 | `1009` | NOT_PAUSED: `step-frames` was called while the scene tree is not paused. This is a state precondition error, not a parameter error — the frames value is valid, but the world state doesn't satisfy the prerequisite. Call `pause` first, then `step-frames`. Don't confuse with `-32602` (bad param value) or `-1003` (CLI usage error). |
+| `1010` | UNSUPPORTED_NODE_TYPE: `sprite-info` on a node that isn't `Sprite2D` / `AnimatedSprite2D` / `TextureRect`, or `screenshot --node` on a node whose bounds can't be determined (not a CanvasItem, or no size/rect/texture to measure). Schema-class permanent error — pick a different node (often a child sprite of the one you tried) or a different command; retrying is pointless. |
+| `1011` | NODE_NOT_ON_SCREEN: `screenshot --node` resolved the node and computed its rect, but the rect doesn't intersect the viewport (off-screen, or zero visible size). State-class error (like `1009`): the arguments are fine, the world isn't — move the camera / the node, or wait for it to enter view, then retry. |
 
 **JSON-RPC standard — negative integers `-32xxx`:**
 
@@ -199,7 +201,12 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 - `step-frames <n> [--physics]` — while paused, advance exactly N frames (1..3600) then stop (deterministic stepping for physics assertions). Requires `pause` first — otherwise error `1009`, exit 1. Returns `{"stepped": N, "paused": true}`.
 
 **Render:**
-- `screenshot <path>` — write PNG (path is **required** as of 0.2.0)
+- `screenshot <path> [--node <node-path>]` — write PNG (path is **required** as of 0.2.0). With `--node`, the full screenshot is cropped to that node's screen-space AABB (canvas/camera transform included) and the envelope reports the actual crop: `{"path": ..., "bytes": N, "node": ..., "region": [x, y, w, h]}` (viewport pixels, already clipped to the viewport). Errors: `1001` unknown node, `1010` bounds undeterminable, `1011` off-screen. Like any screenshot it needs a real renderer — headless daemons return `1006`.
+- `sprite-info <node-path>` — aggregate "what is this node actually rendering" query for `Sprite2D` / `AnimatedSprite2D` / `TextureRect` (error `1010` for anything else). Pure property read — **works headless**. Key fields:
+  - common: `type`, `visible`, `visible_in_tree`, `modulate` `[r,g,b,a]`; textures are reported as `{"path": "res://..."|null, "size": [w,h]}` (+ `atlas`/`atlas_region` when it's an `AtlasTexture`); `path` is `null` for runtime-built textures.
+  - `Sprite2D`: `texture`, `flip_h/v`, `frame`, `frame_coords`, `hframes/vframes`, `region_enabled`, `region_rect`, and **`effective_region` `[x,y,w,h]`** — the atlas rect actually being drawn (region wins when enabled, else computed from the frame grid). Assert "the sprite shows frame N" against this instead of reading internal bookkeeping fields.
+  - `AnimatedSprite2D`: `sprite_frames`, `animation`, `frame`, `playing`, `speed_scale`, `flip_h/v`, and **`frame_texture`** — the texture of the *current* frame (distinguishes FRONT vs BACK frames that no plain property exposes).
+  - `TextureRect`: `texture`, `flip_h/v`, `stretch_mode`, `expand_mode`, `size`.
 
 ### `set` / `call` security blacklist
 
@@ -348,6 +355,10 @@ positional arguments:
     click         对 Control/Button 节点触发点击。
     screenshot    截屏并写 PNG 文件。**路径必填**（旧版本可省、把 base64 喷到 stdout —— 已删，避免撑爆 AI
                   上下文）。
+    sprite-info   渲染态聚合查询（issue #101）：Sprite2D / AnimatedSprite2D /
+                  TextureRect 的 texture、实际图集区域（effective_region /
+                  frame_texture）、翻转、帧号、modulate、visible 一次拿齐。纯属性读，headless
+                  可用。非 sprite 类节点 → 1010。
     tree          dump 当前场景树为 JSON。
     press         按下输入动作（持续按住，需配 release 释放）。
     release       释放之前 press 按下的输入动作。
@@ -412,11 +423,11 @@ options:
     init            在 Godot 项目根一键复制插件、patch project.godot
 
   RPC 一发命令（需先 daemon 在跑）:
-    读：     get / text / exists / visible / children / tree / pressed / actions
+    读：     get / text / exists / visible / children / tree / pressed / actions / sprite-info
     写：     set / call / click
     输入：   press / release / tap / hold / combo / combo-cancel / release-all
     等待：   wait-node / wait-time
-    截图：   screenshot
+    截图：   screenshot（--node 按节点裁剪）
 
 输出契约（默认 --json，AI 友好）:
   成功： {"ok": true, "result": <data>}        单行 stdout，exit 0
@@ -607,22 +618,43 @@ options:
   godot-cli-control click /root/Main/StartButton
 
 $ godot-cli-control screenshot --help
-usage: godot-cli-control screenshot [-h] [--json] [--text] [--no-json]
+usage: godot-cli-control screenshot [-h] [--node NODE_PATH] [--json] [--text]
+                                    [--no-json]
                                     output_path
 
 截屏并写 PNG 文件。**路径必填**（旧版本可省、把 base64 喷到 stdout —— 已删，避免撑爆 AI 上下文）。
 
 positional arguments:
-  output_path  PNG 输出路径（必填）
+  output_path       PNG 输出路径（必填）
 
 options:
-  -h, --help   show this help message and exit
-  --json       输出 JSON 信封（默认）
-  --text       输出旧的人类可读字符串（不再加信封；errors 走 stderr）
-  --no-json    --text 别名
+  -h, --help        show this help message and exit
+  --node NODE_PATH  按该节点的屏幕 AABB 裁剪截图（issue #101），产出小图供像素级断言。节点在屏幕外/零尺寸 →
+                    1011；非 CanvasItem/算不出边界 → 1010。
+  --json            输出 JSON 信封（默认）
+  --text            输出旧的人类可读字符串（不再加信封；errors 走 stderr）
+  --no-json         --text 别名
 
 示例:
-  godot-cli-control screenshot out.png
+  godot-cli-control screenshot out.png --node /root/Game/Player/Sprite
+
+$ godot-cli-control sprite-info --help
+usage: godot-cli-control sprite-info [-h] [--json] [--text] [--no-json]
+                                     node_path
+
+渲染态聚合查询（issue #101）：Sprite2D / AnimatedSprite2D / TextureRect 的 texture、实际图集区域（effective_region / frame_texture）、翻转、帧号、modulate、visible 一次拿齐。纯属性读，headless 可用。非 sprite 类节点 → 1010。
+
+positional arguments:
+  node_path   绝对节点路径，如 /root/Game/Player/Sprite
+
+options:
+  -h, --help  show this help message and exit
+  --json      输出 JSON 信封（默认）
+  --text      输出旧的人类可读字符串（不再加信封；errors 走 stderr）
+  --no-json   --text 别名
+
+示例:
+  godot-cli-control sprite-info /root/Game/Player/Sprite
 
 $ godot-cli-control tree --help
 usage: godot-cli-control tree [-h] [--max-nodes MAX_NODES] [--json] [--text]
@@ -1177,7 +1209,9 @@ Errors raise `RpcError(code, message)` (a `RuntimeError` subclass) that preserve
 | `await client.node_exists(path)` | `exists <path>` |
 | `await client.is_visible(path)` | `visible <path>` |
 | `await client.get_children(path)` | `children <path>` |
-| `await client.screenshot()` | `screenshot <path>` |
+| `await client.screenshot(node=None)` | `screenshot <path> [--node <node-path>]` — returns PNG bytes; pass `node` to crop to that node's screen rect |
+| `await client.screenshot_raw(node=None)` | raw response incl. `region` (the actual crop rect the CLI envelope shows) |
+| `await client.sprite_info(path)` | `sprite-info <node-path>` |
 | `await client.get_scene_tree(depth, max_nodes=None)` | `tree [depth] [--max-nodes N]` |
 | `await client.wait_for_node(path, timeout)` | `wait-node <path> [timeout]` |
 | `await client.wait_game_time(seconds)` | `wait-time <seconds>` |
@@ -1290,6 +1324,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **Sub-path reading a non-existent leaf returns `null` — indistinguishable from a real `null` value (typo only detected at the top-level name).** `get /root/Node position:typo` returns `{"value": null}` with no error — the `":" `suffix is not validated beyond checking that `"position"` exists as a top-level property. Verify your leaf name carefully; the only error you'll get is `1002` if the part before `":"` itself doesn't exist.
 - **Python API (`bridge.get_property` / `bridge.get_properties`) returns bare values only — no `type` field.** These convenience methods strip the `type` from the server response to reduce boilerplate. When you need the `type` field (e.g. to distinguish `Vector2` from a plain 2-element array), go through `client.request("get_property", {"path": ..., "property": ...})` directly.
 - **After `scene-change` / `scene-reload`, all node paths from the previous scene are stale** — re-locate nodes with `wait-node` before touching them. The new scene root is a brand-new tree; any path cached from the old scene will return `1001 "node not found"`.
+- **Asserting "what does this sprite actually show" — use `sprite-info` (headless-safe), not internal bookkeeping fields; use `screenshot --node` only when you truly need pixels.** `sprite-info`'s `effective_region` / `frame_texture` tell you which atlas rect / frame texture is being drawn — that covers most "is it facing left / showing frame N / mirrored" assertions without a renderer. `screenshot --node` needs a real renderer (headless → `1006` like any screenshot) and is for pixel-level comparison; its `1010` (can't bound the node) usually means you pointed at a container — aim at the child sprite instead; `1011` means the node is off-screen right now.
 - **`scene-reload` returning means the OLD scene instance was freed — never reuse node references/paths cached before the reload.** The command blocks until the new scene is ready, but the path strings that were valid in the old scene may now point to different nodes or nothing at all. Always re-query after a reload.
 - **`fresh_scene` (pytest fixture) errors with `1008` before the test body even runs — the project has no current scene.** Autoload-only / no-main-scene startup states have `get_tree().current_scene == null`, and the fixture's setup calls `scene_reload`, which then fails loudly with `1008`. This is intended (the fixture's contract is "this test starts with a clean *scene*"), not a daemon problem. Either drive the project into a scene first (`scene-change res://...`) or don't request `fresh_scene` for those tests.
 - **`step-frames` requires `pause` first (error `1009`) — the intended pattern is `pause` → `step-frames` → assert → `unpause`.** Error `1009` means the precondition (tree is paused) was not met; it is distinct from `-32602` (bad param value) and `-1003` (CLI usage error). If you get `1009`, call `pause` before `step-frames`.
@@ -1299,4 +1334,4 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 
 ---
 
-Generated from godot-cli-control v0.2.15.dev44+ga868fbce7. Re-run `godot-cli-control init --skills-only` to refresh.
+Generated from godot-cli-control v0.2.15.dev45+ge18d90810.d20260605. Re-run `godot-cli-control init --skills-only` to refresh.

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -92,7 +92,8 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 | `is_visible(path)` | `await client.is_visible("/root/UI/Panel")` |
 | `get_children(path, type_filter?)` | `await client.get_children("/root/Map", "Node2D")` |
 | `get_scene_tree(depth)` | `await client.get_scene_tree(depth=3)` |
-| `screenshot()` | `png_bytes = await client.screenshot()` |
+| `screenshot(node=None)` | `png_bytes = await client.screenshot()`; pass `node="/root/Game/Sprite"` to crop to that node's screen-space AABB; CLI: `screenshot <path> [--node <node-path>]` (errors: `1010` bounds undeterminable, `1011` off-screen) |
+| `sprite_info(path)` | `await client.sprite_info("/root/Game/Sprite")` — aggregate render-state query for `Sprite2D` / `AnimatedSprite2D` / `TextureRect` (texture, `effective_region`, `frame_texture`, flips, frame, modulate); headless-safe; CLI: `sprite-info <node-path>`; error `1010` for other node types |
 | `wait_for_node(path, timeout)` | `await client.wait_for_node("/root/Boss", timeout=10.0)` |
 | `wait_game_time(seconds)` | `await client.wait_game_time(2.5)` |
 | `wait_property(path, prop, value, op, timeout, tolerance)` | `await client.wait_property("/root/Player", "position:x", 500, op="gt", timeout=3.0)` |
@@ -141,6 +142,8 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `1007` | server | Signal not found on the node (`wait-signal` schema error — signal name typo or the node doesn't define it). Permanent — don't retry; inspect with `tree` or `children` to find valid signals. |
 | `1008` | server | Scene unavailable (`scene-reload` / `scene-change`): no current scene, scene file missing / failed to load, or timed out waiting for the new scene to become ready. Fix the path (permanent) or inspect the daemon log (timeout). |
 | `1009` | server | NOT_PAUSED: `step-frames` called while the scene tree is not paused. Call `pause` first. Precondition error — not a param error (distinct from `-32602`). |
+| `1010` | server | UNSUPPORTED_NODE_TYPE: `sprite-info` on a non-sprite node, or `screenshot --node` on a node whose bounds can't be determined. Schema-class — pick another node/command, don't retry. |
+| `1011` | server | NODE_NOT_ON_SCREEN: `screenshot --node` crop rect doesn't intersect the viewport (off-screen / zero size). State-class — bring the node into view, then retry. |
 | `-32600` | server | Malformed JSON-RPC request |
 | `-32601` | server | Unknown method name |
 | `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements, or `hold` given `duration ≤ 0` — use `press` for an indefinite hold; also out-of-range values like a scene `timeout` outside `(0, 3600]` sent directly via `GameClient`) |

--- a/addons/godot_cli_control/bridge/error_codes.gd
+++ b/addons/godot_cli_control/bridge/error_codes.gd
@@ -32,6 +32,14 @@ const SCENE_UNAVAILABLE: int = 1008
 # step_frames 的状态前置错（issue #102）：tree 未 paused 时调 step_frames。
 # 与 -32602 区分：参数本身没问题，是世界状态不满足前置——agent 应先 pause。
 const NOT_PAUSED: int = 1009
+# 节点类型不支持该可视化操作（issue #101）：sprite_info 打在非 sprite 类节点、
+# screenshot --node 算不出节点边界（非 CanvasItem / 无法确定 local rect）。
+# schema 类永久错（与 1002/1003/1007 同族）——agent 应换节点或换操作，重试无意义。
+const UNSUPPORTED_NODE_TYPE: int = 1010
+# screenshot --node 的裁剪框与视口交集为空（issue #101）：节点在屏幕外或
+# 变换后尺寸为零。状态类错（与 1009 同族）——参数没问题，是世界状态不满足；
+# agent 应先把节点挪进视口（移动 camera / 改 position / 等动画到位）再截。
+const NODE_NOT_ON_SCREEN: int = 1011
 
 const INVALID_PARAMS: int = -32602
 const INVALID_REQUEST: int = -32600

--- a/addons/godot_cli_control/bridge/game_bridge.gd
+++ b/addons/godot_cli_control/bridge/game_bridge.gd
@@ -30,6 +30,7 @@ var _input_sim_api: InputSimulationApi = null
 var _wait_api: WaitApi = null
 var _scene_api: SceneApi = null
 var _time_api: TimeApi = null
+var _render_api: RenderApi = null
 # 方法注册表：{method_name: {"callable": Callable, "kind": "sync"|"async"|"async_with_id"}}
 # - sync: handler(params) -> Dictionary，dispatcher 立即 send response
 # - async: handler(params) -> await Dictionary，dispatcher await 后 send response
@@ -67,6 +68,9 @@ func _ready() -> void:
 	_time_api = TimeApi.new()
 	_time_api.name = "TimeApi"
 	add_child(_time_api)
+	_render_api = RenderApi.new()
+	_render_api.name = "RenderApi"
+	add_child(_render_api)
 	# 启动倍速（issue #102）：非法值 parse 内已 printerr + 忽略，不挡启动
 	# 必须在 await _wait_first_frame_ready() 之前，保证「第 0 帧即倍速」
 	var startup_scale: float = TimeApi.parse_cmdline_time_scale(OS.get_cmdline_args())
@@ -233,15 +237,17 @@ func _register_methods() -> void:
 	_methods["scene_reload"] = {"callable": _scene_api.scene_reload_async, "kind": "async"}
 	_methods["scene_change"] = {"callable": _scene_api.scene_change_async, "kind": "async"}
 	# Time API（issue #102）
+	_methods["sprite_info"] = {"callable": _render_api.handle_sprite_info, "kind": "sync"}
+
 	_methods["time_scale"] = {"callable": _time_api.handle_time_scale, "kind": "sync"}
 	_methods["pause"] = {"callable": _time_api.handle_pause, "kind": "sync"}
 	_methods["unpause"] = {"callable": _time_api.handle_unpause, "kind": "sync"}
 	_methods["step_frames"] = {"callable": _time_api.step_frames_async, "kind": "async"}
 
 
-# screenshot wrapper：take_screenshot_async 不接 params，统一签名为 (params) -> Dictionary
-func _wrap_screenshot(_params: Dictionary) -> Dictionary:
-	return await _low_level_api.take_screenshot_async()
+# screenshot wrapper：params 透传（issue #101 起带可选 "node" 裁剪参数）
+func _wrap_screenshot(params: Dictionary) -> Dictionary:
+	return await _low_level_api.take_screenshot_async(params)
 
 
 func _handle_message(raw: String) -> void:

--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -448,7 +448,19 @@ func handle_get_scene_tree(params: Dictionary) -> Dictionary:
 	return response
 
 
-func take_screenshot_async() -> Dictionary:
+func take_screenshot_async(params: Dictionary = {}) -> Dictionary:
+	# 可选 node 裁剪（issue #101）：node 解析 / 边界计算放在取图 *之前*，
+	# schema 错（1001/1010）不必白等帧循环；交集判定（1011）只能在拿到
+	# image 之后做（需要视口像素尺寸）。
+	var crop_node: Node = null
+	var node_path: String = params.get("node", "") as String
+	if not node_path.is_empty():
+		crop_node = get_tree().root.get_node_or_null(node_path)
+		if crop_node == null:
+			return _node_not_found(node_path)
+		var probe: Variant = RenderApi.compute_node_screen_rect(crop_node)
+		if probe is Dictionary:
+			return probe as Dictionary
 	# dummy renderer (--headless) 下 RenderingServer.frame_post_draw 永不发射，
 	# await 会永久挂死。RenderingServer.get_rendering_device() 在 dummy driver
 	# 下返回 null，用它检测后改走 process_frame 推进路径。
@@ -474,9 +486,28 @@ func take_screenshot_async() -> Dictionary:
 	if image == null:
 		# 1006 (transient) ≠ 1003 (schema)：agent 可短重试，等下一帧 viewport 就绪。
 		return _err(CliControlErrorCodes.RESOURCE_UNAVAILABLE, "Screenshot unavailable (viewport texture is null)")
+	var response: Dictionary = {}
+	if crop_node != null:
+		# 边界重算一次：帧循环 await 期间节点可能移动/变换，取图后的位置才是
+		# 与 image 内容一致的位置。
+		var rect_or_err: Variant = RenderApi.compute_node_screen_rect(crop_node)
+		if rect_or_err is Dictionary:
+			return rect_or_err as Dictionary
+		var img_rect := Rect2(0, 0, image.get_width(), image.get_height())
+		var clipped: Rect2 = (rect_or_err as Rect2).intersection(img_rect)
+		var region := Rect2i(clipped)
+		if region.size.x < 1 or region.size.y < 1:
+			return _err(
+				CliControlErrorCodes.NODE_NOT_ON_SCREEN,
+				"screenshot node: %s is off-screen or has zero visible size (rect=%s, viewport=%s)"
+					% [node_path, rect_or_err, img_rect.size],
+			)
+		image = image.get_region(region)
+		response["region"] = [region.position.x, region.position.y, region.size.x, region.size.y]
 	var png_buffer: PackedByteArray = image.save_png_to_buffer()
 	var base64_str: String = Marshalls.raw_to_base64(png_buffer)
-	return {"image": base64_str}
+	response["image"] = base64_str
+	return response
 
 
 func _get_node_or_error(params: Dictionary) -> Node:

--- a/addons/godot_cli_control/bridge/render_api.gd
+++ b/addons/godot_cli_control/bridge/render_api.gd
@@ -1,0 +1,197 @@
+class_name RenderApi
+extends Node
+## 渲染态查询 API：sprite_info + screenshot --node 的边界计算（issue #101）
+##
+## 设计动机：bridge 能逐个读基本属性，但「这个节点实际渲染成什么样」
+## 需要聚合查询（texture / 图集区域 / 翻转 / 帧号），否则视觉类 e2e 只能
+## 退化为读内部记账字段 + 人工视觉自查兜底。
+##
+## sprite_info 纯读属性，headless（dummy renderer）下完全可用；
+## compute_node_screen_rect 只做坐标变换，同样不依赖真渲染——
+## 真正需要 GPU 的只有 screenshot 的取图部分（low_level_api 负责）。
+
+
+func handle_sprite_info(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "") as String
+	var node: Node = get_tree().root.get_node_or_null(path)
+	if node == null:
+		return _err(CliControlErrorCodes.NODE_NOT_FOUND, "Node not found: %s" % path)
+	# 注意顺序无依赖：Sprite2D / AnimatedSprite2D / TextureRect 互不为子类
+	if node is Sprite2D:
+		return _sprite2d_info(node as Sprite2D)
+	if node is AnimatedSprite2D:
+		return _animated_sprite2d_info(node as AnimatedSprite2D)
+	if node is TextureRect:
+		return _texture_rect_info(node as TextureRect)
+	return _err(
+		CliControlErrorCodes.UNSUPPORTED_NODE_TYPE,
+		"sprite_info: unsupported node type %s (supported: Sprite2D, AnimatedSprite2D, TextureRect)"
+			% node.get_class(),
+	)
+
+
+## screenshot --node 的边界计算：节点 local rect → 经 canvas/camera 变换的
+## 视口像素坐标 AABB。返回 Rect2，失败返回 error Dictionary（1010）。
+## static：只依赖传入节点自身的变换链，便于 GUT 直接单测（无需真渲染）。
+static func compute_node_screen_rect(node: Node) -> Variant:
+	if not (node is CanvasItem):
+		return {
+			"error": {
+				"code": CliControlErrorCodes.UNSUPPORTED_NODE_TYPE,
+				"message": "screenshot node: %s is not a CanvasItem (2D/Control only)"
+					% node.get_class(),
+			}
+		}
+	var local_rect_or_null: Variant = _local_rect_of(node as CanvasItem)
+	if local_rect_or_null == null:
+		return {
+			"error": {
+				"code": CliControlErrorCodes.UNSUPPORTED_NODE_TYPE,
+				"message": "screenshot node: cannot determine bounds for %s (no size/rect/texture)"
+					% node.get_class(),
+			}
+		}
+	# get_global_transform_with_canvas 含 CanvasLayer / Camera2D 变换，
+	# 结果即视口像素坐标；Transform2D * Rect2 返回旋转后四角的 AABB。
+	var xform: Transform2D = (node as CanvasItem).get_global_transform_with_canvas()
+	return xform * (local_rect_or_null as Rect2)
+
+
+## 节点自身坐标系下的绘制边界。返回 Rect2 或 null（无法确定）。
+## Control 必须先于 has_method("get_rect") 判断：Control.get_rect() 返回的是
+## 父坐标系 rect（position+size），不是 local——直接用会双重叠加自身位移。
+static func _local_rect_of(item: CanvasItem) -> Variant:
+	if item is Control:
+		return Rect2(Vector2.ZERO, (item as Control).size)
+	if item is AnimatedSprite2D:
+		return _animated_sprite2d_local_rect(item as AnimatedSprite2D)
+	if item.has_method("get_rect"):
+		# Sprite2D（含 centered/offset/region 折算）、TouchScreenButton 等
+		return item.call("get_rect")
+	return null
+
+
+## AnimatedSprite2D 没有 get_rect()——按当前帧贴图尺寸 + centered/offset
+## 镜像 Sprite2D.get_rect 的语义手工折算。
+static func _animated_sprite2d_local_rect(sprite: AnimatedSprite2D) -> Variant:
+	var frames: SpriteFrames = sprite.sprite_frames
+	if frames == null or not frames.has_animation(sprite.animation):
+		return null
+	if sprite.frame < 0 or sprite.frame >= frames.get_frame_count(sprite.animation):
+		return null
+	var tex: Texture2D = frames.get_frame_texture(sprite.animation, sprite.frame)
+	if tex == null:
+		return null
+	var size: Vector2 = tex.get_size()
+	var pos: Vector2 = sprite.offset
+	if sprite.centered:
+		pos -= size / 2.0
+	return Rect2(pos, size)
+
+
+# ── 各类型的聚合 payload ──────────────────────────────────────────────
+
+
+func _sprite2d_info(sprite: Sprite2D) -> Dictionary:
+	var info: Dictionary = _common_info(sprite)
+	info["texture"] = _texture_info(sprite.texture)
+	info["flip_h"] = sprite.flip_h
+	info["flip_v"] = sprite.flip_v
+	info["frame"] = sprite.frame
+	info["frame_coords"] = [sprite.frame_coords.x, sprite.frame_coords.y]
+	info["hframes"] = sprite.hframes
+	info["vframes"] = sprite.vframes
+	info["region_enabled"] = sprite.region_enabled
+	info["region_rect"] = _rect_to_array(sprite.region_rect)
+	# effective_region：实际绘制用到的图集区域（视觉断言的核心字段）。
+	# region_enabled 时 region 即源（Godot 此时忽略 frame 网格）；
+	# 否则按 frame_coords 在 hframes×vframes 网格上折算。
+	if sprite.texture != null:
+		if sprite.region_enabled:
+			info["effective_region"] = _rect_to_array(sprite.region_rect)
+		else:
+			var fw: float = float(sprite.texture.get_width()) / sprite.hframes
+			var fh: float = float(sprite.texture.get_height()) / sprite.vframes
+			info["effective_region"] = [
+				sprite.frame_coords.x * fw, sprite.frame_coords.y * fh, fw, fh,
+			]
+	else:
+		info["effective_region"] = null
+	return info
+
+
+func _animated_sprite2d_info(sprite: AnimatedSprite2D) -> Dictionary:
+	var info: Dictionary = _common_info(sprite)
+	var frames: SpriteFrames = sprite.sprite_frames
+	info["sprite_frames"] = _resource_path_or_null(frames)
+	info["animation"] = String(sprite.animation)
+	info["frame"] = sprite.frame
+	info["playing"] = sprite.is_playing()
+	info["speed_scale"] = sprite.speed_scale
+	info["flip_h"] = sprite.flip_h
+	info["flip_v"] = sprite.flip_v
+	# frame_texture：当前帧实际贴图（FRONT/BACK 这类「换帧不换属性」的
+	# 视觉态区分就靠它——内部记账字段读不到的部分）。
+	var frame_tex: Texture2D = null
+	if (
+		frames != null
+		and frames.has_animation(sprite.animation)
+		and sprite.frame >= 0
+		and sprite.frame < frames.get_frame_count(sprite.animation)
+	):
+		frame_tex = frames.get_frame_texture(sprite.animation, sprite.frame)
+	info["frame_texture"] = _texture_info(frame_tex)
+	return info
+
+
+func _texture_rect_info(rect: TextureRect) -> Dictionary:
+	var info: Dictionary = _common_info(rect)
+	info["texture"] = _texture_info(rect.texture)
+	info["flip_h"] = rect.flip_h
+	info["flip_v"] = rect.flip_v
+	info["stretch_mode"] = rect.stretch_mode
+	info["expand_mode"] = rect.expand_mode
+	info["size"] = [rect.size.x, rect.size.y]
+	return info
+
+
+func _common_info(item: CanvasItem) -> Dictionary:
+	return {
+		"type": item.get_class(),
+		"visible": item.visible,
+		"visible_in_tree": item.is_visible_in_tree(),
+		"modulate": [
+			item.modulate.r, item.modulate.g, item.modulate.b, item.modulate.a,
+		],
+	}
+
+
+## Texture2D → {"path", "size"}；AtlasTexture 额外给 atlas + atlas_region
+## （SpriteFrames 常用图集切片建帧，此时帧贴图自身无 resource_path，
+## 真正可断言的是「哪张图集的哪块区域」）。无贴图返回 null。
+static func _texture_info(tex: Texture2D) -> Variant:
+	if tex == null:
+		return null
+	var info: Dictionary = {
+		"path": _resource_path_or_null(tex),
+		"size": [tex.get_width(), tex.get_height()],
+	}
+	if tex is AtlasTexture:
+		var atlas_tex: AtlasTexture = tex as AtlasTexture
+		info["atlas"] = _resource_path_or_null(atlas_tex.atlas)
+		info["atlas_region"] = _rect_to_array(atlas_tex.region)
+	return info
+
+
+static func _resource_path_or_null(res: Resource) -> Variant:
+	if res == null or res.resource_path.is_empty():
+		return null
+	return res.resource_path
+
+
+static func _rect_to_array(rect: Rect2) -> Array:
+	return [rect.position.x, rect.position.y, rect.size.x, rect.size.y]
+
+
+func _err(code: int, message: String) -> Dictionary:
+	return {"error": {"code": code, "message": message}}

--- a/addons/godot_cli_control/tests/gut/test_game_bridge.gd
+++ b/addons/godot_cli_control/tests/gut/test_game_bridge.gd
@@ -106,6 +106,7 @@ var _input: StubInputSimulationApi
 var _wait: StubWaitApi
 var _scene: SceneApi
 var _time: TimeApi
+var _render: RenderApi
 
 
 func before_each() -> void:
@@ -133,11 +134,16 @@ func before_each() -> void:
 	_time.name = "TimeApi"
 	add_child_autofree(_time)
 
+	_render = RenderApi.new()
+	_render.name = "RenderApi"
+	add_child_autofree(_render)
+
 	_bridge._low_level_api = _low
 	_bridge._input_sim_api = _input
 	_bridge._wait_api = _wait
 	_bridge._scene_api = _scene
 	_bridge._time_api = _time
+	_bridge._render_api = _render
 	# InputSim 的 callback：bridge 的 _on_async_response 把 (id, result) 转回 dispatch
 	_input.setup(_bridge._on_async_response)
 	_bridge._register_methods()
@@ -522,3 +528,8 @@ func test_registry_has_time_methods() -> void:
 		assert_eq(str(_bridge._methods[m]["kind"]), "sync")
 	assert_true(_bridge._methods.has("step_frames"), "step_frames 应已注册")
 	assert_eq(str(_bridge._methods["step_frames"]["kind"]), "async")
+
+
+func test_registry_has_sprite_info() -> void:
+	assert_true(_bridge._methods.has("sprite_info"), "sprite_info 应已注册（issue #101）")
+	assert_eq(str(_bridge._methods["sprite_info"]["kind"]), "sync")

--- a/addons/godot_cli_control/tests/gut/test_render_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_render_api.gd
@@ -1,0 +1,203 @@
+## GUT 单元测试：RenderApi sprite_info 聚合 + screenshot --node 边界计算（issue #101）
+##
+## 全部纯属性读 / 坐标变换，headless（dummy renderer）下可测；
+## 真正取图 + 裁剪像素的链路由 python/tests/test_e2e_screenshot_gui.py
+## （macOS GUI 格）兜底。
+extends GutTest
+
+const RenderApiScript := preload("res://addons/godot_cli_control/bridge/render_api.gd")
+
+var _api: Node
+
+
+func before_each() -> void:
+	_api = RenderApiScript.new()
+	_api.name = "RenderApi"
+	add_child_autofree(_api)
+
+
+## 8x4 棋盘格贴图：尺寸可被 hframes/vframes 整除，effective_region 断言用整数。
+func _make_texture(width: int = 8, height: int = 4) -> ImageTexture:
+	var img := Image.create_empty(width, height, false, Image.FORMAT_RGBA8)
+	img.fill(Color.RED)
+	return ImageTexture.create_from_image(img)
+
+
+func _add_sprite(tex: Texture2D) -> Sprite2D:
+	var sprite := Sprite2D.new()
+	sprite.texture = tex
+	add_child_autofree(sprite)
+	return sprite
+
+
+# ── sprite_info：Sprite2D ────────────────────────────────────────────
+
+
+func test_sprite_info_node_not_found_returns_1001() -> void:
+	var result: Dictionary = _api.handle_sprite_info({"path": "/root/__missing__"})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1001)
+
+
+func test_sprite_info_unsupported_type_returns_1010() -> void:
+	var plain := Node2D.new()
+	plain.name = "PlainNode2D"
+	add_child_autofree(plain)
+	var result: Dictionary = _api.handle_sprite_info({"path": str(plain.get_path())})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1010)
+	assert_string_contains(str(result.error.message), "Node2D")
+
+
+func test_sprite_info_sprite2d_basic_fields() -> void:
+	var sprite := _add_sprite(_make_texture())
+	sprite.flip_h = true
+	sprite.modulate = Color(1.0, 0.5, 0.25, 1.0)
+	var info: Dictionary = _api.handle_sprite_info({"path": str(sprite.get_path())})
+	assert_does_not_have(info, "error")
+	assert_eq(str(info.type), "Sprite2D")
+	assert_true(bool(info.visible))
+	assert_true(bool(info.flip_h))
+	assert_false(bool(info.flip_v))
+	assert_almost_eq(float(info.modulate[1]), 0.5, 0.001)
+	assert_eq(info.texture.size, [8, 4])
+	# 运行时建的贴图无 resource_path → null（与「忘了设贴图」可区分：texture 本身非 null）
+	assert_null(info.texture.path)
+
+
+func test_sprite_info_frame_grid_effective_region() -> void:
+	# 8x4 贴图切 4x2 网格 → 每帧 2x2；frame=5 → 坐标 (1,1) → region [2,2,2,2]
+	var sprite := _add_sprite(_make_texture())
+	sprite.hframes = 4
+	sprite.vframes = 2
+	sprite.frame = 5
+	var info: Dictionary = _api.handle_sprite_info({"path": str(sprite.get_path())})
+	assert_eq(int(info.frame), 5)
+	assert_eq(info.frame_coords, [1, 1])
+	assert_false(bool(info.region_enabled))
+	assert_eq(info.effective_region, [2.0, 2.0, 2.0, 2.0])
+
+
+func test_sprite_info_region_wins_over_frame_grid() -> void:
+	var sprite := _add_sprite(_make_texture())
+	sprite.hframes = 4
+	sprite.region_enabled = true
+	sprite.region_rect = Rect2(1, 0, 3, 4)
+	var info: Dictionary = _api.handle_sprite_info({"path": str(sprite.get_path())})
+	assert_true(bool(info.region_enabled))
+	assert_eq(info.effective_region, [1.0, 0.0, 3.0, 4.0])
+
+
+func test_sprite_info_no_texture_effective_region_null() -> void:
+	var sprite := _add_sprite(null)
+	var info: Dictionary = _api.handle_sprite_info({"path": str(sprite.get_path())})
+	assert_null(info.texture)
+	assert_null(info.effective_region)
+
+
+# ── sprite_info：AnimatedSprite2D ────────────────────────────────────
+
+
+func _add_animated(frame_count: int = 2) -> AnimatedSprite2D:
+	var frames := SpriteFrames.new()
+	# SpriteFrames.new() 自带 "default" 动画；直接往里填帧
+	for i in frame_count:
+		frames.add_frame("default", _make_texture(4 + i * 2, 4))
+	var sprite := AnimatedSprite2D.new()
+	sprite.sprite_frames = frames
+	add_child_autofree(sprite)
+	return sprite
+
+
+func test_sprite_info_animated_frame_texture_tracks_current_frame() -> void:
+	var sprite := _add_animated(2)
+	sprite.frame = 1
+	var info: Dictionary = _api.handle_sprite_info({"path": str(sprite.get_path())})
+	assert_eq(str(info.type), "AnimatedSprite2D")
+	assert_eq(str(info.animation), "default")
+	assert_eq(int(info.frame), 1)
+	assert_false(bool(info.playing))
+	# 帧 1 的贴图是 6x4 —— frame_texture 跟着当前帧走，这就是 FRONT/BACK 区分的抓手
+	assert_eq(info.frame_texture.size, [6, 4])
+
+
+func test_sprite_info_animated_atlas_frame_reports_atlas_region() -> void:
+	var atlas_source := _make_texture(8, 4)
+	var atlas_tex := AtlasTexture.new()
+	atlas_tex.atlas = atlas_source
+	atlas_tex.region = Rect2(4, 0, 4, 4)
+	var frames := SpriteFrames.new()
+	frames.add_frame("default", atlas_tex)
+	var sprite := AnimatedSprite2D.new()
+	sprite.sprite_frames = frames
+	add_child_autofree(sprite)
+	var info: Dictionary = _api.handle_sprite_info({"path": str(sprite.get_path())})
+	assert_eq(info.frame_texture.atlas_region, [4.0, 0.0, 4.0, 4.0])
+
+
+func test_sprite_info_animated_without_frames_resource() -> void:
+	var sprite := AnimatedSprite2D.new()
+	add_child_autofree(sprite)
+	var info: Dictionary = _api.handle_sprite_info({"path": str(sprite.get_path())})
+	assert_does_not_have(info, "error")
+	assert_null(info.sprite_frames)
+	assert_null(info.frame_texture)
+
+
+# ── sprite_info：TextureRect ─────────────────────────────────────────
+
+
+func test_sprite_info_texture_rect() -> void:
+	var rect := TextureRect.new()
+	rect.texture = _make_texture()
+	rect.flip_v = true
+	rect.size = Vector2(40, 20)
+	add_child_autofree(rect)
+	var info: Dictionary = _api.handle_sprite_info({"path": str(rect.get_path())})
+	assert_eq(str(info.type), "TextureRect")
+	assert_true(bool(info.flip_v))
+	assert_eq(info.texture.size, [8, 4])
+	assert_eq(info.size, [40.0, 20.0])
+	assert_has(info, "stretch_mode")
+
+
+# ── compute_node_screen_rect（screenshot --node 的边界计算） ──────────
+
+
+func test_screen_rect_control_uses_global_position_and_size() -> void:
+	var ctl := Control.new()
+	ctl.position = Vector2(10, 20)
+	ctl.size = Vector2(30, 40)
+	add_child_autofree(ctl)
+	var rect: Variant = RenderApiScript.compute_node_screen_rect(ctl)
+	assert_true(rect is Rect2, "Control 应能算出 Rect2，实际: %s" % [rect])
+	assert_eq(rect as Rect2, Rect2(10, 20, 30, 40))
+
+
+func test_screen_rect_sprite2d_centered_with_scale() -> void:
+	# 8x4 贴图 centered + position(100,50) + scale 2 → AABB (92,46,16,8)
+	var sprite := _add_sprite(_make_texture())
+	sprite.position = Vector2(100, 50)
+	sprite.scale = Vector2(2, 2)
+	var rect: Variant = RenderApiScript.compute_node_screen_rect(sprite)
+	assert_true(rect is Rect2)
+	assert_eq(rect as Rect2, Rect2(92, 46, 16, 8))
+
+
+func test_screen_rect_non_canvas_item_returns_1010() -> void:
+	var plain := Node.new()
+	plain.name = "PlainNode"
+	add_child_autofree(plain)
+	var result: Variant = RenderApiScript.compute_node_screen_rect(plain)
+	assert_true(result is Dictionary)
+	assert_eq(int((result as Dictionary).error.code), 1010)
+
+
+func test_screen_rect_sprite_without_texture_returns_1010() -> void:
+	# Sprite2D.get_rect() 无贴图时返回零尺寸 rect —— 仍是 Rect2，
+	# 1011（屏幕外/零尺寸）的判定留给截图交集阶段；这里只验证不崩。
+	var animated := AnimatedSprite2D.new()
+	add_child_autofree(animated)
+	var result: Variant = RenderApiScript.compute_node_screen_rect(animated)
+	assert_true(result is Dictionary, "无 frames 的 AnimatedSprite2D 算不出边界 → 1010")
+	assert_eq(int((result as Dictionary).error.code), 1010)

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -172,14 +172,22 @@ class GameBridge:
 
     # ── 截图 ──
 
-    def screenshot(self, path: str | None = None) -> bytes:
-        """截图，返回 PNG 字节。可选保存到文件。"""
-        data = self._run(self._client.screenshot())
+    def screenshot(self, path: str | None = None, node: str | None = None) -> bytes:
+        """截图，返回 PNG 字节。可选保存到文件。
+
+        ``node``（issue #101）：按节点屏幕 AABB 裁剪成小图（像素级断言用）。
+        屏幕外 → 1011，算不出边界 → 1010。
+        """
+        data = self._run(self._client.screenshot(node=node))
         if path:
             p = Path(path)
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_bytes(data)
         return data
+
+    def sprite_info(self, path: str) -> dict:
+        """渲染态聚合查询（issue #101）：texture/图集区域/翻转/帧号 一次拿齐。"""
+        return self._run(self._client.sprite_info(path))
 
     # ── 属性读写 ──
 

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import contextlib
 import json
 import sys
@@ -368,12 +369,25 @@ async def cmd_screenshot(client: GameClient, ns: argparse.Namespace) -> dict:
 
     展开 ``~`` 让 ``screenshot ~/foo.png`` 工作；不展开时 ``Path("~")`` 会
     创建字面 ``~`` 目录，是常见 footgun。
+
+    ``--node``（issue #101）：按节点屏幕 AABB 裁剪小图；信封带回实际裁剪
+    region（视口像素坐标）便于排查「裁到的不是我想的区域」。
     """
-    data = await client.screenshot()
+    node: str | None = getattr(ns, "node", None)
+    raw = await client.screenshot_raw(node)
+    data = base64.b64decode(raw.get("image", ""))
     output = Path(ns.output_path).expanduser()
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_bytes(data)
-    return {"path": str(output), "bytes": len(data)}
+    result: dict = {"path": str(output), "bytes": len(data)}
+    if node:
+        result["node"] = node
+        result["region"] = raw.get("region")
+    return result
+
+
+async def cmd_sprite_info(client: GameClient, ns: argparse.Namespace) -> dict:
+    return await client.sprite_info(ns.node_path)
 
 
 async def cmd_tree(client: GameClient, ns: argparse.Namespace) -> dict:
@@ -582,7 +596,27 @@ def _fmt_tree_text(tree: Any) -> str:
 
 
 def _fmt_screenshot_text(r: dict) -> str:
-    return f"screenshot saved: {r['path']} ({r['bytes']} bytes)"
+    base = f"screenshot saved: {r['path']} ({r['bytes']} bytes)"
+    if "region" in r:
+        base += f" [node={r.get('node')} region={r.get('region')}]"
+    return base
+
+
+def _fmt_sprite_info_text(r: dict) -> str:
+    # 聚合 payload 字段多且按类型变化，text 模式直接缩进 JSON（人读）
+    return json.dumps(r, ensure_ascii=False, indent=2)
+
+
+def _register_screenshot_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--node",
+        default=None,
+        metavar="NODE_PATH",
+        help=(
+            "按该节点的屏幕 AABB 裁剪截图（issue #101），产出小图供像素级断言。"
+            "节点在屏幕外/零尺寸 → 1011；非 CanvasItem/算不出边界 → 1010。"
+        ),
+    )
 
 
 def _fmt_wait_node_text(r: dict) -> str:
@@ -775,8 +809,26 @@ RPC_SPECS: tuple[RpcSpec, ...] = (
         positionals=(
             Positional("output_path", None, "PNG 输出路径（必填）"),
         ),
-        example="screenshot out.png",
+        example="screenshot out.png --node /root/Game/Player/Sprite",
+        extra_args=_register_screenshot_args,
         text_formatter=_fmt_screenshot_text,
+    ),
+    RpcSpec(
+        name="sprite-info",
+        handler=cmd_sprite_info,
+        description=(
+            "渲染态聚合查询（issue #101）：Sprite2D / AnimatedSprite2D / "
+            "TextureRect 的 texture、实际图集区域（effective_region / "
+            "frame_texture）、翻转、帧号、modulate、visible 一次拿齐。"
+            "纯属性读，headless 可用。非 sprite 类节点 → 1010。"
+        ),
+        positionals=(
+            Positional(
+                "node_path", None, "绝对节点路径，如 /root/Game/Player/Sprite"
+            ),
+        ),
+        example="sprite-info /root/Game/Player/Sprite",
+        text_formatter=_fmt_sprite_info_text,
     ),
     RpcSpec(
         name="tree",
@@ -1735,11 +1787,11 @@ _TOP_EPILOG = """\
     init            在 Godot 项目根一键复制插件、patch project.godot
 
   RPC 一发命令（需先 daemon 在跑）:
-    读：     get / text / exists / visible / children / tree / pressed / actions
+    读：     get / text / exists / visible / children / tree / pressed / actions / sprite-info
     写：     set / call / click
     输入：   press / release / tap / hold / combo / combo-cancel / release-all
     等待：   wait-node / wait-time
-    截图：   screenshot
+    截图：   screenshot（--node 按节点裁剪）
 
 输出契约（默认 --json，AI 友好）:
   成功： {"ok": true, "result": <data>}        单行 stdout，exit 0

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -306,10 +306,33 @@ class GameClient:
         )
         return result.get("children", [])
 
-    async def screenshot(self) -> bytes:
-        """Take a screenshot and return PNG bytes."""
-        result = await self.request("screenshot")
+    async def screenshot(self, node: str | None = None) -> bytes:
+        """Take a screenshot and return PNG bytes.
+
+        ``node``（issue #101）：传节点绝对路径时按该节点的屏幕 AABB 裁剪，
+        产出小图供像素级断言。节点在屏幕外 → 1011；算不出边界 → 1010。
+        只要裁剪 region 信息时用 :meth:`screenshot_raw`。
+        """
+        result = await self.screenshot_raw(node)
         return base64.b64decode(result.get("image", ""))
+
+    async def screenshot_raw(self, node: str | None = None) -> dict:
+        """screenshot 的原始响应：``{"image": <base64>, "region": [x,y,w,h]?}``。
+
+        ``region`` 仅在传 ``node`` 时出现，是实际裁剪到的视口像素矩形
+        （已与视口求交，可能小于节点 AABB）。CLI 信封需要它，故与
+        :meth:`screenshot` 的 bytes 便捷形式拆开。
+        """
+        params: dict = {"node": node} if node else {}
+        return await self.request("screenshot", params)
+
+    async def sprite_info(self, path: str) -> dict:
+        """渲染态聚合查询（issue #101）：Sprite2D / AnimatedSprite2D / TextureRect。
+
+        返回 texture/图集区域/翻转/帧号/modulate/visible 聚合；非 sprite 类
+        节点 → 1010。headless 下可用（纯属性读，不依赖真渲染）。
+        """
+        return await self.request("sprite_info", {"path": path})
 
     async def get_scene_tree(
         self, depth: int = 5, max_nodes: int | None = None

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -130,6 +130,8 @@ Three numeric ranges cohabit in `error.code`. Knowing which is which lets you de
 | `1007` | Signal not found on the node (`wait-signal` schema error — signal name typo or the node doesn't define it). Permanent — don't retry; inspect with `tree` to list available signals. |
 | `1008` | Scene unavailable (`scene-reload` / `scene-change`): no current scene, scene file missing / failed to load, or timed out waiting for the new scene to become ready. Missing file is permanent — fix the path; timeout usually means the scene itself fails to load — inspect the daemon log. |
 | `1009` | NOT_PAUSED: `step-frames` was called while the scene tree is not paused. This is a state precondition error, not a parameter error — the frames value is valid, but the world state doesn't satisfy the prerequisite. Call `pause` first, then `step-frames`. Don't confuse with `-32602` (bad param value) or `-1003` (CLI usage error). |
+| `1010` | UNSUPPORTED_NODE_TYPE: `sprite-info` on a node that isn't `Sprite2D` / `AnimatedSprite2D` / `TextureRect`, or `screenshot --node` on a node whose bounds can't be determined (not a CanvasItem, or no size/rect/texture to measure). Schema-class permanent error — pick a different node (often a child sprite of the one you tried) or a different command; retrying is pointless. |
+| `1011` | NODE_NOT_ON_SCREEN: `screenshot --node` resolved the node and computed its rect, but the rect doesn't intersect the viewport (off-screen, or zero visible size). State-class error (like `1009`): the arguments are fine, the world isn't — move the camera / the node, or wait for it to enter view, then retry. |
 
 **JSON-RPC standard — negative integers `-32xxx`:**
 
@@ -199,7 +201,12 @@ Server vs client ranges never overlap, so a single `code` field is unambiguous.
 - `step-frames <n> [--physics]` — while paused, advance exactly N frames (1..3600) then stop (deterministic stepping for physics assertions). Requires `pause` first — otherwise error `1009`, exit 1. Returns `{"stepped": N, "paused": true}`.
 
 **Render:**
-- `screenshot <path>` — write PNG (path is **required** as of 0.2.0)
+- `screenshot <path> [--node <node-path>]` — write PNG (path is **required** as of 0.2.0). With `--node`, the full screenshot is cropped to that node's screen-space AABB (canvas/camera transform included) and the envelope reports the actual crop: `{"path": ..., "bytes": N, "node": ..., "region": [x, y, w, h]}` (viewport pixels, already clipped to the viewport). Errors: `1001` unknown node, `1010` bounds undeterminable, `1011` off-screen. Like any screenshot it needs a real renderer — headless daemons return `1006`.
+- `sprite-info <node-path>` — aggregate "what is this node actually rendering" query for `Sprite2D` / `AnimatedSprite2D` / `TextureRect` (error `1010` for anything else). Pure property read — **works headless**. Key fields:
+  - common: `type`, `visible`, `visible_in_tree`, `modulate` `[r,g,b,a]`; textures are reported as `{"path": "res://..."|null, "size": [w,h]}` (+ `atlas`/`atlas_region` when it's an `AtlasTexture`); `path` is `null` for runtime-built textures.
+  - `Sprite2D`: `texture`, `flip_h/v`, `frame`, `frame_coords`, `hframes/vframes`, `region_enabled`, `region_rect`, and **`effective_region` `[x,y,w,h]`** — the atlas rect actually being drawn (region wins when enabled, else computed from the frame grid). Assert "the sprite shows frame N" against this instead of reading internal bookkeeping fields.
+  - `AnimatedSprite2D`: `sprite_frames`, `animation`, `frame`, `playing`, `speed_scale`, `flip_h/v`, and **`frame_texture`** — the texture of the *current* frame (distinguishes FRONT vs BACK frames that no plain property exposes).
+  - `TextureRect`: `texture`, `flip_h/v`, `stretch_mode`, `expand_mode`, `size`.
 
 ### `set` / `call` security blacklist
 
@@ -355,7 +362,9 @@ Errors raise `RpcError(code, message)` (a `RuntimeError` subclass) that preserve
 | `await client.node_exists(path)` | `exists <path>` |
 | `await client.is_visible(path)` | `visible <path>` |
 | `await client.get_children(path)` | `children <path>` |
-| `await client.screenshot()` | `screenshot <path>` |
+| `await client.screenshot(node=None)` | `screenshot <path> [--node <node-path>]` — returns PNG bytes; pass `node` to crop to that node's screen rect |
+| `await client.screenshot_raw(node=None)` | raw response incl. `region` (the actual crop rect the CLI envelope shows) |
+| `await client.sprite_info(path)` | `sprite-info <node-path>` |
 | `await client.get_scene_tree(depth, max_nodes=None)` | `tree [depth] [--max-nodes N]` |
 | `await client.wait_for_node(path, timeout)` | `wait-node <path> [timeout]` |
 | `await client.wait_game_time(seconds)` | `wait-time <seconds>` |
@@ -468,6 +477,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **Sub-path reading a non-existent leaf returns `null` — indistinguishable from a real `null` value (typo only detected at the top-level name).** `get /root/Node position:typo` returns `{"value": null}` with no error — the `":" `suffix is not validated beyond checking that `"position"` exists as a top-level property. Verify your leaf name carefully; the only error you'll get is `1002` if the part before `":"` itself doesn't exist.
 - **Python API (`bridge.get_property` / `bridge.get_properties`) returns bare values only — no `type` field.** These convenience methods strip the `type` from the server response to reduce boilerplate. When you need the `type` field (e.g. to distinguish `Vector2` from a plain 2-element array), go through `client.request("get_property", {"path": ..., "property": ...})` directly.
 - **After `scene-change` / `scene-reload`, all node paths from the previous scene are stale** — re-locate nodes with `wait-node` before touching them. The new scene root is a brand-new tree; any path cached from the old scene will return `1001 "node not found"`.
+- **Asserting "what does this sprite actually show" — use `sprite-info` (headless-safe), not internal bookkeeping fields; use `screenshot --node` only when you truly need pixels.** `sprite-info`'s `effective_region` / `frame_texture` tell you which atlas rect / frame texture is being drawn — that covers most "is it facing left / showing frame N / mirrored" assertions without a renderer. `screenshot --node` needs a real renderer (headless → `1006` like any screenshot) and is for pixel-level comparison; its `1010` (can't bound the node) usually means you pointed at a container — aim at the child sprite instead; `1011` means the node is off-screen right now.
 - **`scene-reload` returning means the OLD scene instance was freed — never reuse node references/paths cached before the reload.** The command blocks until the new scene is ready, but the path strings that were valid in the old scene may now point to different nodes or nothing at all. Always re-query after a reload.
 - **`fresh_scene` (pytest fixture) errors with `1008` before the test body even runs — the project has no current scene.** Autoload-only / no-main-scene startup states have `get_tree().current_scene == null`, and the fixture's setup calls `scene_reload`, which then fails loudly with `1008`. This is intended (the fixture's contract is "this test starts with a clean *scene*"), not a daemon problem. Either drive the project into a scene first (`scene-change res://...`) or don't request `fresh_scene` for those tests.
 - **`step-frames` requires `pause` first (error `1009`) — the intended pattern is `pause` → `step-frames` → assert → `unpause`.** Error `1009` means the precondition (tree is paused) was not met; it is distinct from `-32602` (bad param value) and `-1003` (CLI usage error). If you get `1009`, call `pause` before `step-frames`.

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -94,8 +94,11 @@ class _StubClient:
     async def list_input_actions(self, include_builtin: bool = False) -> list[str]:
         return self._record("list_input_actions", (include_builtin,), {})
 
-    async def screenshot(self) -> bytes:
-        return self._record("screenshot", (), {})
+    async def screenshot(self, node: str | None = None) -> bytes:
+        return self._record("screenshot", (), {"node": node})
+
+    async def sprite_info(self, path: str) -> dict:
+        return self._record("sprite_info", (path,), {})
 
     async def get_property(self, path: str, prop: str) -> Any:
         return self._record("get_property", (path, prop), {})
@@ -428,6 +431,25 @@ def test_screenshot_with_path_writes_file(
     assert out.read_bytes() == b"\x89PNG\r\nfake"
     # 父目录自动创建
     assert out.parent.is_dir()
+    b.close()
+
+
+def test_screenshot_node_passes_through(stub_client: dict) -> None:
+    """screenshot(node=...) 把节点路径透传给 client（issue #101）。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["screenshot"] = b"\x89PNG"
+    b.screenshot(node="/root/Game/Sprite")
+    assert c.calls[-1] == ("screenshot", (), {"node": "/root/Game/Sprite"})
+    b.close()
+
+
+def test_sprite_info_returns_aggregate(stub_client: dict) -> None:
+    """sprite_info 透传路径并原样返回聚合 dict（issue #101）。"""
+    b, c = _make_bridge(stub_client)
+    c.returns["sprite_info"] = {"type": "Sprite2D", "frame": 3}
+    info = b.sprite_info("/root/Game/Sprite")
+    assert info == {"type": "Sprite2D", "frame": 3}
+    assert c.calls[-1] == ("sprite_info", ("/root/Game/Sprite",), {})
     b.close()
 
 

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1664,10 +1664,16 @@ def test_run_rpc_separates_local_io_error_from_connection(
     blocker = tmp_path / "blocker"
     blocker.write_bytes(b"")
     bad_path = blocker / "out.png"
-    ns = __import__("argparse").Namespace(output_path=str(bad_path))
+    ns = __import__("argparse").Namespace(output_path=str(bad_path), node=None)
 
     mock_client = AsyncMock()
-    mock_client.screenshot = AsyncMock(return_value=b"fake png bytes")
+    # cmd_screenshot 走 screenshot_raw（issue #101 起，为透出 region），
+    # 服务端响应是 {"image": <base64>}，写盘前解码。
+    mock_client.screenshot_raw = AsyncMock(
+        return_value={
+            "image": __import__("base64").b64encode(b"fake png bytes").decode()
+        }
+    )
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -898,3 +898,100 @@ async def test_step_frames_sends_correct_params_and_calculates_timeout() -> None
     assert captured[1]["method"] == "step_frames"
     assert captured[1]["params"] == {"frames": 600, "physics": True}
     assert captured[1]["timeout"] == 70.0
+
+
+# ---- issue #101: sprite_info / screenshot --node client 包装 ----
+
+
+@pytest.mark.asyncio
+async def test_sprite_info_sends_path() -> None:
+    """sprite_info 发出 method="sprite_info"，params={"path": ...}，原样返回聚合。"""
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        return {"type": "Sprite2D", "frame": 2}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        result = await client.sprite_info("/root/Game/Sprite")
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "sprite_info"
+    assert captured["params"] == {"path": "/root/Game/Sprite"}
+    assert result == {"type": "Sprite2D", "frame": 2}
+
+
+@pytest.mark.asyncio
+async def test_screenshot_without_node_keeps_empty_params() -> None:
+    """screenshot() 旧契约不破：params={}（不带 node 键），返回解码后的 bytes。"""
+    import base64 as _b64
+
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["method"] = method
+        captured["params"] = params
+        return {"image": _b64.b64encode(b"\x89PNGdata").decode()}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        data = await client.screenshot()
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["method"] == "screenshot"
+    assert captured["params"] == {}, "无 node 时不得带 node 键（老 addon 兼容）"
+    assert data == b"\x89PNGdata"
+
+
+@pytest.mark.asyncio
+async def test_screenshot_with_node_sends_node_param() -> None:
+    """screenshot(node=...) 发出 params={"node": ...}。"""
+    import base64 as _b64
+
+    import godot_cli_control.client as client_mod
+
+    captured: dict = {}
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        captured["params"] = params
+        return {"image": _b64.b64encode(b"crop").decode(), "region": [1, 2, 3, 4]}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        data = await client.screenshot(node="/root/S")
+    finally:
+        client_mod.GameClient.request = orig
+    assert captured["params"] == {"node": "/root/S"}
+    assert data == b"crop"
+
+
+@pytest.mark.asyncio
+async def test_screenshot_raw_exposes_region() -> None:
+    """screenshot_raw 返回原始响应（含 region），供 CLI 信封透出裁剪框。"""
+    import base64 as _b64
+
+    import godot_cli_control.client as client_mod
+
+    async def fake_request(self, method, params=None, timeout=30.0):
+        return {"image": _b64.b64encode(b"crop").decode(), "region": [10, 20, 30, 40]}
+
+    client = client_mod.GameClient(port=1)
+    orig = client_mod.GameClient.request
+    client_mod.GameClient.request = fake_request  # type: ignore
+    try:
+        raw = await client.screenshot_raw("/root/S")
+    finally:
+        client_mod.GameClient.request = orig
+    assert raw["region"] == [10, 20, 30, 40]

--- a/python/tests/test_e2e_render.py
+++ b/python/tests/test_e2e_render.py
@@ -1,0 +1,221 @@
+"""端到端回归：sprite-info 渲染态聚合查询（issue #101）。
+
+验证点（全部 headless 可跑——sprite_info 纯属性读，不依赖真渲染）：
+  - Sprite2D 帧网格：effective_region 折算正确（视觉断言的核心字段）
+  - AnimatedSprite2D：frame_texture 跟当前帧
+  - TextureRect：flip/texture 聚合
+  - 非 sprite 类节点 → 1010；不存在节点 → 1001
+  - screenshot --node 的错误路径（1001/1010 在取图前快速返回；
+    headless 下合法节点最终 1006——dummy renderer 拿不到 viewport texture）
+
+裁剪 happy path 需要真渲染，由 test_e2e_screenshot_gui.py（GCC_GUI_E2E
+门控，CI 的 macOS 格）兜底。
+
+fixture 项目自建（不复用 platformer-demo：它没有任何 Sprite 节点）；
+贴图全部运行时生成（ImageTexture），免去 .import 资源管线。
+
+需要真实 Godot 4：PATH 里有 godot（或设 GODOT_BIN），否则整文件 skip。
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from godot_cli_control.daemon import find_godot_binary
+
+_GODOT_BIN = find_godot_binary()
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ADDON_SRC = _REPO_ROOT / "addons" / "godot_cli_control"
+
+pytestmark = pytest.mark.skipif(
+    not _GODOT_BIN,
+    reason="需要真实 Godot 4：把 godot 装进 PATH 或设 GODOT_BIN，否则整文件 skip",
+)
+
+_CLI = [sys.executable, "-m", "godot_cli_control"]
+
+_PROJECT_GODOT = """\
+config_version=5
+
+[application]
+config/name="gcc-render-e2e"
+run/main_scene="res://main.tscn"
+config/features=PackedStringArray("4.4")
+
+[rendering]
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"
+
+[autoload]
+
+GameBridgeNode="*res://addons/godot_cli_control/bridge/game_bridge.gd"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/godot_cli_control/plugin.cfg")
+"""
+
+_MAIN_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://main.gd" id="1_main"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1_main")
+"""
+
+# 8x4 贴图：Sheet 切 4x2 网格（每帧 2x2）、frame=5 → frame_coords (1,1)
+_MAIN_GD = """\
+extends Node2D
+
+
+func _ready() -> void:
+	var img := Image.create_empty(8, 4, false, Image.FORMAT_RGBA8)
+	img.fill(Color.RED)
+	var tex := ImageTexture.create_from_image(img)
+
+	var sheet := Sprite2D.new()
+	sheet.name = "Sheet"
+	sheet.texture = tex
+	sheet.hframes = 4
+	sheet.vframes = 2
+	sheet.frame = 5
+	sheet.position = Vector2(100, 100)
+	add_child(sheet)
+
+	var frames := SpriteFrames.new()
+	frames.add_frame("default", tex)
+	var animated := AnimatedSprite2D.new()
+	animated.name = "Animated"
+	animated.sprite_frames = frames
+	animated.position = Vector2(200, 100)
+	add_child(animated)
+
+	var banner := TextureRect.new()
+	banner.name = "Banner"
+	banner.texture = tex
+	banner.flip_h = true
+	add_child(banner)
+
+	var plain := Node2D.new()
+	plain.name = "Plain"
+	add_child(plain)
+"""
+
+
+def _run_cli(project: Path, *args: str, timeout: float = 60.0) -> dict[str, Any]:
+    """跑一条 CLI 子命令（独立进程 = 独立连接），解析最后一行 JSON 信封。"""
+    proc = subprocess.run(
+        _CLI + list(args),
+        cwd=project,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    json_lines = [ln for ln in proc.stdout.splitlines() if ln.strip().startswith("{")]
+    assert json_lines, f"无 JSON 输出：args={args} stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    return json.loads(json_lines[-1])
+
+
+@pytest.fixture(scope="module")
+def render_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """自建带 Sprite2D/AnimatedSprite2D/TextureRect 的最小项目，导入一次。"""
+    proj = tmp_path_factory.mktemp("gcc_render")
+    (proj / "project.godot").write_text(_PROJECT_GODOT, encoding="utf-8")
+    (proj / "main.tscn").write_text(_MAIN_TSCN, encoding="utf-8")
+    (proj / "main.gd").write_text(_MAIN_GD, encoding="utf-8")
+    (proj / "addons").mkdir()
+    shutil.copytree(_ADDON_SRC, proj / "addons" / "godot_cli_control")
+
+    imp = subprocess.run(
+        [_GODOT_BIN, "--headless", "--editor", "--quit", "--path", str(proj)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert imp.returncode == 0, f"Godot 导入失败：{imp.stdout}\n{imp.stderr}"
+    return proj
+
+
+@pytest.fixture(scope="module")
+def daemon(render_project: Path) -> Any:
+    """module 级 daemon：本文件全部只读断言，无状态污染，起一次够用。"""
+    start = _run_cli(render_project, "daemon", "start", "--headless", timeout=90)
+    assert start["ok"] is True and start["result"]["started"], start
+    assert _run_cli(render_project, "wait-node", "/root/Main/Sheet")["result"]["found"]
+    try:
+        yield render_project
+    finally:
+        _run_cli(render_project, "daemon", "stop", timeout=30)
+
+
+def test_sprite_info_frame_grid(daemon: Any) -> None:
+    """4x2 网格 frame=5 → frame_coords (1,1)、effective_region [2,2,2,2]。"""
+    env = _run_cli(daemon, "sprite-info", "/root/Main/Sheet")
+    assert env["ok"] is True, env
+    info = env["result"]
+    assert info["type"] == "Sprite2D"
+    assert info["frame"] == 5
+    assert info["frame_coords"] == [1, 1]
+    assert info["hframes"] == 4 and info["vframes"] == 2
+    assert info["effective_region"] == [2.0, 2.0, 2.0, 2.0]
+    assert info["texture"]["size"] == [8, 4]
+    # 运行时生成的贴图无资源路径 → null
+    assert info["texture"]["path"] is None
+
+
+def test_sprite_info_animated_frame_texture(daemon: Any) -> None:
+    env = _run_cli(daemon, "sprite-info", "/root/Main/Animated")
+    assert env["ok"] is True, env
+    info = env["result"]
+    assert info["type"] == "AnimatedSprite2D"
+    assert info["animation"] == "default"
+    assert info["frame_texture"]["size"] == [8, 4]
+
+
+def test_sprite_info_texture_rect(daemon: Any) -> None:
+    env = _run_cli(daemon, "sprite-info", "/root/Main/Banner")
+    assert env["ok"] is True, env
+    info = env["result"]
+    assert info["type"] == "TextureRect"
+    assert info["flip_h"] is True
+    assert info["texture"]["size"] == [8, 4]
+
+
+def test_sprite_info_unsupported_type_1010(daemon: Any) -> None:
+    env = _run_cli(daemon, "sprite-info", "/root/Main/Plain")
+    assert env["ok"] is False
+    assert env["error"]["code"] == 1010
+
+
+def test_sprite_info_missing_node_1001(daemon: Any) -> None:
+    env = _run_cli(daemon, "sprite-info", "/root/Main/__missing__")
+    assert env["ok"] is False
+    assert env["error"]["code"] == 1001
+
+
+def test_screenshot_node_errors_precede_capture(daemon: Any, tmp_path: Path) -> None:
+    """--node 的 1001/1010 在取图之前快速返回（headless 下取图本身只会 1006）。"""
+    out = tmp_path / "x.png"
+    env = _run_cli(daemon, "screenshot", str(out), "--node", "/root/Main/__missing__")
+    assert env["ok"] is False and env["error"]["code"] == 1001
+    env = _run_cli(daemon, "screenshot", str(out), "--node", "/root/Main/Plain")
+    assert env["ok"] is False and env["error"]["code"] == 1010
+    assert not out.exists(), "错误路径不得写出文件"
+
+
+def test_screenshot_node_headless_hits_1006_after_node_ok(daemon: Any, tmp_path: Path) -> None:
+    """合法节点 + headless：node 校验通过后走取图 → dummy renderer 1006。
+
+    （非 bug，是 headless 截图的既有契约；裁剪 happy path 由 GUI e2e 覆盖。）
+    """
+    out = tmp_path / "y.png"
+    env = _run_cli(daemon, "screenshot", str(out), "--node", "/root/Main/Sheet")
+    assert env["ok"] is False and env["error"]["code"] == 1006

--- a/python/tests/test_e2e_screenshot_gui.py
+++ b/python/tests/test_e2e_screenshot_gui.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import struct
 import subprocess
 import sys
 from pathlib import Path
@@ -99,6 +100,14 @@ anchors_preset = 15
 layout_mode = 1
 anchors_preset = 15
 color = Color(0.2, 0.4, 0.8, 1)
+
+[node name="Patch" type="ColorRect" parent="."]
+layout_mode = 0
+offset_left = 40.0
+offset_top = 30.0
+offset_right = 140.0
+offset_bottom = 110.0
+color = Color(1, 0, 0, 1)
 """
 
 
@@ -182,3 +191,43 @@ def test_windowed_screenshot_returns_png_without_wait(
         assert payload["result"]["bytes"] == len(raw), (
             f"第 {i} 次 信封 bytes 与落盘大小不一致：{payload}"
         )
+
+
+def test_windowed_screenshot_node_crop(gui_daemon: Any, tmp_path: Path) -> None:
+    """--node 裁剪 happy path（issue #101）：region 信封与 PNG 实际尺寸一致。
+
+    Patch 是 (40,30) 起、100x80 的 ColorRect，窗口 320x240 无 stretch ——
+    裁剪 region 应逐像素等于其布局矩形；PNG IHDR 尺寸应等于 region 尺寸。
+    """
+    project = gui_daemon
+    out = tmp_path / "crop.png"
+    payload = _run_cli(project, "screenshot", str(out), "--node", "/root/Main/Patch")
+    assert payload["ok"] is True, payload
+    assert payload["result"]["node"] == "/root/Main/Patch"
+    assert payload["result"]["region"] == [40, 30, 100, 80], payload
+
+    raw = out.read_bytes()
+    assert raw.startswith(b"\x89PNG\r\n\x1a\n")
+    width, height = struct.unpack(">II", raw[16:24])  # IHDR 头的 w/h 字段
+    assert (width, height) == (100, 80), f"PNG 尺寸应等于裁剪 region：{(width, height)}"
+
+    # 对照组：全屏截图必须严格大于裁剪小图（证明真裁了，不是整屏改名）
+    full = tmp_path / "full.png"
+    full_payload = _run_cli(project, "screenshot", str(full))
+    assert full_payload["ok"] is True
+    assert full_payload["result"]["bytes"] > payload["result"]["bytes"]
+
+
+def test_windowed_screenshot_node_offscreen_1011(gui_daemon: Any, tmp_path: Path) -> None:
+    """节点挪到视口外 → 1011（NODE_NOT_ON_SCREEN），且不落盘。"""
+    project = gui_daemon
+    assert _run_cli(project, "set", "/root/Main/Patch", "position", "[-500, -500]")["ok"]
+    try:
+        out = tmp_path / "off.png"
+        payload = _run_cli(project, "screenshot", str(out), "--node", "/root/Main/Patch")
+        assert payload["ok"] is False and payload["error"]["code"] == 1011, payload
+        assert not out.exists()
+    finally:
+        # 还原位置，避免污染同 module 的其它用例（gui_daemon 是 function 级，
+        # 但 godot_project 是 module 级 —— daemon 重启不重建场景文件，保险起见还原）
+        _run_cli(project, "set", "/root/Main/Patch", "position", "[40, 30]")


### PR DESCRIPTION
## 一句话

视觉态断言两原语（issue #101 的两条建议方案都做了）：`sprite-info` 聚合查询 + `screenshot --node` 节点级裁剪，补掉「立绘换帧/镜像/图集切片的 e2e 只能读内部记账字段、人工视觉自查兜底」的覆盖洞。

## 设计

### `sprite-info <node-path>`（新 `render_api.gd`，headless 可用）

按类型聚合渲染态，两个为断言而生的**计算字段**：

- **`effective_region`**（Sprite2D）：实际绘制的图集区域——`region_enabled` 时即 region_rect（Godot 此时忽略帧网格），否则按 `frame_coords` 在 `hframes×vframes` 网格折算。「实际用的图集区域 == 预期帧」一行断言闭环。
- **`frame_texture`**（AnimatedSprite2D）：当前帧的实际贴图（含 AtlasTexture 的 `atlas` + `atlas_region`）——FRONT/BACK 这类「换帧不换属性」的区分抓手，正是 XGame 立绘 e2e 人工兜底的那个洞。

texture 统一报 `{"path": "res://..."|null, "size": [w,h]}`（运行时贴图 path=null）；TextureRect 给 stretch/expand/flip/size。

### `screenshot <path> --node <node-path>`

全屏取图后按 `get_global_transform_with_canvas`（含 CanvasLayer/Camera2D 变换）折算节点 local rect 的视口 AABB，与视口求交后裁剪；信封带回实际 `region [x,y,w,h]`。节点解析/边界计算放在取图**之前**（schema 错不白等帧循环）；取图后边界**重算一次**（await 期间节点可能移动）。

### 新错误码（三段制无撞码，error_codes.gd 注册）

| 码 | 语义 | 类别 |
|---|---|---|
| `1010` UNSUPPORTED_NODE_TYPE | sprite-info 打非 sprite 节点 / --node 算不出边界 | schema 类（换节点/换命令） |
| `1011` NODE_NOT_ON_SCREEN | 裁剪框与视口交集为空 | 状态类（移入视野再试，与 1009 同族） |

### 五步全走

client.py（`sprite_info` / `screenshot(node=)` / `screenshot_raw` 透出 region）→ bridge.py → cli.py（RpcSpec + `--node` flag + formatter）→ GDScript（render_api.gd + game_bridge 注册 + take_screenshot_async 裁剪）→ SKILL.md 模板（命令表/错误码表/Python API 表/pitfall「sprite-info 优先于 --node、1010 多半是打到了容器」）+ addon README。仓内渲染版 SKILL.md 已按规范环境（python3.12 + COLUMNS=80）重渲染。

## 验证

- **GUT 182/182**：test_render_api.gd 14 条（帧网格折算、region 优先、AtlasTexture、Control/Sprite2D 含 scale 的边界计算、1001/1010）+ registry 注册断言
- **pytest 531 passed / 覆盖率 88%**（门槛 80%）：test_e2e_render.py headless 全链路 7 条（effective_region/frame_texture/1010/1001/--node 错误先于取图/headless 1006 契约）；client/bridge 单测 6 条；test_cli 的 IO 错误测试适配 screenshot_raw
- **GUI e2e 3/3（真开窗）**：`--node` 裁剪 region 信封 == PNG IHDR 实际尺寸（100x80 逐像素一致）、全屏严格大于裁剪图、节点挪出视口 → 1011 且不落盘

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)