### PR TITLE
perf(wait): wait_property 免物化直比 + 属性存在性 memo（#109）

### DIFF
--- a/addons/godot_cli_control/bridge/low_level_api.gd
+++ b/addons/godot_cli_control/bridge/low_level_api.gd
@@ -532,6 +532,14 @@ func _err(code: int, message: String) -> Dictionary:
 
 
 func _has_property(node: Node, property: String) -> bool:
+	# #109 快拒：`in` 对 Object 是「可取成员」超集（属性/方法/信号/常量全 true，
+	# 实证见 PR）——false ⇒ 一定不在 property list，免掉整张 get_property_list()
+	# 的分配（wait_property 轮询缺失属性时逐帧打到这里）。true 不充分（方法名也
+	# true），仍需线性扫确认，保 1002 严格性。
+	# 顺带修掉一个潜伏缺陷：category/group 装饰条目（如 "Node2D"）以前会被线性扫
+	# 误判为属性（读出 null）；`in` 对它们是 false → 现在正确报 1002。
+	if not property in node:
+		return false
 	for prop: Dictionary in node.get_property_list():
 		if prop["name"] == property:
 			return true

--- a/addons/godot_cli_control/bridge/wait_api.gd
+++ b/addons/godot_cli_control/bridge/wait_api.gd
@@ -13,6 +13,15 @@ const _MAX_WAIT_SECONDS: float = 3600.0
 const _MAX_WAIT_FRAMES: int = 3600
 # wait_property 支持的比较操作符列表
 const _WAIT_PROP_OPS: PackedStringArray = ["eq", "ne", "gt", "lt", "ge", "le"]
+# encode_value 会递归重建的容器类型（#109：这些走免物化的结构化比较；
+# 其余类型 encode 都是 O(1)，直接编码走旧路径）
+const _CONTAINER_TYPES: PackedInt32Array = [
+	TYPE_ARRAY, TYPE_DICTIONARY,
+	TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY,
+	TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY, TYPE_PACKED_STRING_ARRAY,
+	TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, TYPE_PACKED_COLOR_ARRAY,
+	TYPE_PACKED_VECTOR4_ARRAY,
+]
 
 # 注入的 _read_property Callable（由 setup() 传入）
 var _read_property_fn: Callable = Callable()
@@ -123,30 +132,145 @@ func wait_property_async(params: Dictionary) -> Dictionary:
 		return _err(-32603, "WaitApi not wired: read_property unavailable")
 	var start_ms: int = Time.get_ticks_msec()
 	var reason: String = "timeout"
-	var last_value: Variant = null
+	var last_raw: Variant = null
+	var has_value: bool = false
+	# #109 memo：已确认「该属性存在」的节点实例 id。同实例后续帧走裸读，
+	# 跳过 _read_property 内 get_property_list 的逐帧整表分配 + 线性扫。
+	# 实例 id 不复用——节点中途被释放/替换时 memo 自动失效、回全检路径。
+	var verified_iid: int = 0
+	var is_sub_path: bool = ":" in property
+	var prop_np: NodePath = NodePath(property)  # 裸读预解析，避免逐帧构造
 	while true:
 		var node: Node = get_tree().root.get_node_or_null(path)
 		if node == null:
 			reason = "node_not_found"
-			last_value = null
+			has_value = false
 		else:
-			var read: Dictionary = _read_property_fn.call(node, property)
+			var read: Dictionary
+			if node.get_instance_id() == verified_iid:
+				# 裸读与 low_level_api._read_property 的取值路径对齐（sub-path 走
+				# get_indexed）。读到 null 时降级全检：null 无法区分「真 null 值」
+				# 与「属性中途消失（set_script 等）」，降级保住 reason 诊断精度。
+				var fast: Variant = node.get_indexed(prop_np) if is_sub_path else node.get(property)
+				read = {"value": fast} if fast != null else _read_property_fn.call(node, property)
+			else:
+				read = _read_property_fn.call(node, property)
 			if read.has("error"):
 				reason = "property_not_found"
-				last_value = null
+				has_value = false
+				verified_iid = 0
 			else:
+				verified_iid = node.get_instance_id()
 				reason = "timeout"
-				last_value = CliControlVariantCodec.encode_value(read["value"])
-				if _wait_compare(last_value, expected, op, tolerance):
+				last_raw = read["value"]
+				has_value = true
+				# #109：原始 Variant 直比（容器 miss 帧零分配、首差短路），
+				# 命中才编码做返回 payload
+				if _wait_compare_raw(last_raw, expected, op, tolerance):
 					return {
 						"matched": true,
-						"value": last_value,
+						"value": CliControlVariantCodec.encode_value(last_raw),
 						"waited": float(Time.get_ticks_msec() - start_ms) / 1000.0,
 					}
 		if float(Time.get_ticks_msec() - start_ms) / 1000.0 >= timeout:
 			break
 		await get_tree().process_frame
-	return {"matched": false, "reason": reason, "value": last_value}
+	# break 与最后一次读取同帧（中间无 await），此刻编码与旧版逐帧编码结果一致
+	return {
+		"matched": false,
+		"reason": reason,
+		"value": CliControlVariantCodec.encode_value(last_raw) if has_value else null,
+	}
+
+
+## #109 性能：与 `_wait_compare(CliControlVariantCodec.encode_value(actual_raw),
+## expected, op, tolerance)` 结果恒等，但容器不物化整棵编码树——miss 帧零分配、
+## 首差短路。等价性由 test_wait_api.gd 的 parity 矩阵测试钉死；改这里 / 改
+## variant_codec.encode_value / 改 _deep_equal 任意一处都必须重跑矩阵。
+func _wait_compare_raw(actual_raw: Variant, expected: Variant, op: String, tolerance: float) -> bool:
+	if not typeof(actual_raw) in _CONTAINER_TYPES:
+		# 非容器叶子 encode_value 是 O(1)（标量恒等 / 复合类型 → 定长小数组），原路走
+		return _wait_compare(CliControlVariantCodec.encode_value(actual_raw), expected, op, tolerance)
+	# 容器编码后仍是 Array/Dictionary（非数值）：旧路径下 ordering op 恒 false，
+	# eq/ne 走 _deep_equal——此处免物化镜像
+	var equal: bool = _encoded_eq_raw(actual_raw, expected, tolerance, false, 0)
+	if op == "eq":
+		return equal
+	if op == "ne":
+		return not equal
+	return false
+
+
+## `_deep_equal(encode_value(raw, depth), expected, tolerance)`（strict=false）或
+## `encode_value(raw, depth) == expected`（strict=true，引擎深比较）的免物化镜像。
+## strict 的来源：_deep_equal 对 Dictionary 对落引擎 `==`（精确、无 tolerance），
+## 所以进入 Dictionary 后整棵子树切 strict——与「编码后真比较」行为逐位一致。
+func _encoded_eq_raw(raw: Variant, expected: Variant, tolerance: float, strict: bool, depth: int) -> bool:
+	if depth > CliControlVariantCodec._MAX_ENCODE_DEPTH:
+		# 镜像 encode_value 超深降级哨兵；哨兵是 String，对非 String expected 恒 false
+		# （typeof 守卫：GDScript 跨类型 == 是运行期脚本错误，见 _safe_eq docstring）
+		return expected is String and (expected as String) == CliControlVariantCodec._DEPTH_SENTINEL
+	match typeof(raw):
+		TYPE_ARRAY:
+			if not expected is Array:
+				return false  # 编码后是 Array，与非 Array 比较两种模式下都为 false
+			var raw_arr: Array = raw as Array
+			var exp_arr: Array = expected as Array
+			if raw_arr.size() != exp_arr.size():
+				return false
+			for i in raw_arr.size():
+				if not _encoded_eq_raw(raw_arr[i], exp_arr[i], tolerance, strict, depth + 1):
+					return false
+			return true
+		TYPE_DICTIONARY:
+			if not expected is Dictionary:
+				return false
+			var raw_dict: Dictionary = raw as Dictionary
+			var exp_dict: Dictionary = expected as Dictionary
+			for key: Variant in raw_dict:
+				if not (key is String or key is StringName):
+					# 异类键经 str() 可能撞键折叠（后写覆盖），结构化镜像不划算：
+					# 兜底物化这棵子树走真编码（罕见路径，正确性优先）。
+					# String/StringName 键在 Dictionary 里本就同键（引擎语义），无碰撞。
+					return CliControlVariantCodec.encode_value(raw, depth) == expected
+			if raw_dict.size() != exp_dict.size():
+				return false
+			for key: Variant in raw_dict:
+				var skey: String = str(key)
+				if not exp_dict.has(skey):
+					return false
+				# Dictionary 内部恒 strict（见 docstring）
+				if not _encoded_eq_raw(raw_dict[key], exp_dict[skey], tolerance, true, depth + 1):
+					return false
+			return true
+		TYPE_PACKED_BYTE_ARRAY, TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY, TYPE_PACKED_STRING_ARRAY:
+			# encode_value 对这 4 种是 Array(v) 直转：元素（int/String）不经编码、
+			# 不耗 depth 层级——元素按 depth=0 比较（恒等、永不触哨兵），镜像直转语义
+			return _packed_elems_eq(raw, expected, tolerance, strict, 0)
+		TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY, TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, TYPE_PACKED_COLOR_ARRAY, TYPE_PACKED_VECTOR4_ARRAY:
+			# encode_value 对这 6 种逐元素 encode_value(item, depth + 1)，镜像之
+			return _packed_elems_eq(raw, expected, tolerance, strict, depth + 1)
+		_:
+			# 非容器叶子：O(1) 编码后按模式比较（含 float 的 nan/inf → 字符串降级）
+			var enc: Variant = CliControlVariantCodec.encode_value(raw, depth)
+			if strict:
+				# 引擎内部深比较是「类型严格」的：int 与 float 不互通
+				# （实证：{"a": 1} == {"a": 1.0} → false）。typeof 守卫同时挡掉
+				# GDScript 跨类型 == 的运行期脚本错误。
+				return typeof(enc) == typeof(expected) and enc == expected
+			return _deep_equal(enc, expected, tolerance)
+
+
+func _packed_elems_eq(raw: Variant, expected: Variant, tolerance: float, strict: bool, elem_depth: int) -> bool:
+	if not expected is Array:
+		return false
+	var exp_arr: Array = expected as Array
+	if raw.size() != exp_arr.size():
+		return false
+	for i in exp_arr.size():
+		if not _encoded_eq_raw(raw[i], exp_arr[i], tolerance, strict, elem_depth):
+			return false
+	return true
 
 
 ## 编码后值比较。数值走 6 op（eq/ne 带 tolerance）；其余类型仅 eq/ne 深比较
@@ -184,7 +308,21 @@ func _deep_equal(a: Variant, b: Variant, tolerance: float) -> bool:
 			if not _deep_equal(aa[i], ba[i], tolerance):
 				return false
 		return true
-	return a == b  # String / bool / null / Dictionary（引擎深比较）
+	return _safe_eq(a, b)  # String / bool / null / Dictionary（引擎深比较）
+
+
+## #109 顺手修存量雷：GDScript 层跨类型 `==`（如 Array == String、bool == int）
+## 是**运行期脚本错误**——打印错误、中止所在函数、向上抛 Nil，不是静默 false。
+## 旧版 _deep_equal 末行裸 `a == b` 在 expected 与属性类型不符时（agent typo
+## 常态）每帧刷一条脚本错误、还会污染 #103 errors 环形缓冲，结果只是靠
+## Nil→false 的二次错误侥幸正确。合法比较只有三类：同 typeof / int-float
+## 数值对 / 任一侧 null（恒 false）——其余直接判 false，结果不变、零错误输出。
+func _safe_eq(a: Variant, b: Variant) -> bool:
+	var ta: int = typeof(a)
+	var tb: int = typeof(b)
+	if ta == tb or ((ta == TYPE_INT or ta == TYPE_FLOAT) and (tb == TYPE_INT or tb == TYPE_FLOAT)):
+		return a == b
+	return false  # 含 null vs 非 null：引擎语义本就恒 false，这里短路掉
 
 
 ## issue #96：等 N 帧（确定性帧推进）。physics=true 等 physics_frame。

--- a/addons/godot_cli_control/tests/gut/test_low_level_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_low_level_api.gd
@@ -66,6 +66,30 @@ func test_get_property_nonexistent_returns_1002() -> void:
 	assert_eq(int(result.error.code), 1002)
 
 
+func test_get_property_method_name_returns_1002() -> void:
+	## #109 守卫：`in` 操作符对方法名也为 true，但 _has_property 的快拒后仍有
+	## 线性扫确认——方法名不是属性，必须保持 1002（防止未来把快拒升级成单独判定，
+	## 否则 get("get_name") 会读出 Callable，破坏 get-property 严格性）。
+	var result: Dictionary = _api.handle_get_property({
+		"path": str(_target.get_path()),
+		"property": "get_name",
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1002)
+
+
+func test_get_property_category_entry_returns_1002() -> void:
+	## #109 顺手修复 pin：get_property_list 里的 category 装饰条目（如 "Node"，
+	## usage=PROPERTY_USAGE_CATEGORY）不是真属性。旧版线性扫会误判存在并读出
+	## null；`in` 快拒后正确报 1002。
+	var result: Dictionary = _api.handle_get_property({
+		"path": str(_target.get_path()),
+		"property": "Node",
+	})
+	assert_has(result, "error")
+	assert_eq(int(result.error.code), 1002)
+
+
 func test_get_property_missing_param_returns_minus_32602() -> void:
 	var result: Dictionary = _api.handle_get_property({
 		"path": str(_target.get_path()),

--- a/addons/godot_cli_control/tests/gut/test_wait_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_wait_api.gd
@@ -276,3 +276,163 @@ func test_wait_signal_emitted_has_no_reason() -> void:
 	})
 	assert_true(result["emitted"])
 	assert_does_not_have(result, "reason", "命中信号时不应有 reason 字段")
+
+
+# ── issue #109：raw 直比免物化路径 ──
+
+func test_wait_compare_raw_parity_matrix() -> void:
+	## 核心等价性守卫：_wait_compare_raw(raw, …) 必须与
+	## _wait_compare(encode_value(raw), …) 逐位一致。全类型 corpus ×
+	## corpus 编码形 + 殊形 × 6 op × 3 tolerance 笛卡尔积，分歧数必须为 0。
+	## 改 _wait_compare_raw / _encoded_eq_raw / encode_value / _deep_equal
+	## 任意一处，这个矩阵就是回归网。
+	var corpus: Array = [
+		null, true, false, 42, 3.5, -0.0, "s", "", NAN, INF, -INF,
+		&"sn", NodePath("/a/b"),
+		Vector2(1.5, 2.0), Vector2i(1, 2), Vector3(1.0, 2.0, 3.0), Vector3i(1, 2, 3),
+		Color(0.1, 0.2, 0.3, 1.0), Rect2(1.0, 2.0, 3.0, 4.0),
+		Quaternion(0.0, 0.0, 0.0, 1.0), Transform2D.IDENTITY,
+		[], [1, 2.0, "x"], [Vector2(1.0, 2.0), [3, [4]]], [NAN, INF],
+		{}, {"hp": 10.0, "pos": Vector2(1.0, 2.0)}, {"tags": ["a", "b"], "nest": {"k": 1}},
+		{1: "int-key", "s": 2}, {&"sn_key": 7},
+		{"pf": PackedFloat32Array([1.5]), "pi": PackedInt32Array([1])},
+		PackedByteArray([1, 2]), PackedInt32Array([1, 2, 3]), PackedInt64Array([9]),
+		PackedFloat32Array([1.5, 2.5]), PackedFloat64Array([1.5, INF]),
+		PackedStringArray(["a", "b"]),
+		PackedVector2Array([Vector2(1.0, 2.0)]), PackedVector3Array([Vector3(1.0, 2.0, 3.0)]),
+		PackedColorArray([Color(1.0, 0.0, 0.0, 1.0)]),
+	]
+	# >_MAX_ENCODE_DEPTH 嵌套：覆盖哨兵降级路径的镜像一致性
+	corpus.append(_build_deep_array(CliControlVariantCodec._MAX_ENCODE_DEPTH + 6))
+	var expecteds: Array = []
+	for raw: Variant in corpus:
+		expecteds.append(CliControlVariantCodec.encode_value(raw))
+	# 数值近差（tolerance 边界两侧）+ int/float 互通边界（数组吃、字典不吃）
+	# + 类型错配殊形
+	expecteds.append_array([
+		42.0005, 3.5005, [1, 2.0005, "x"], {"hp": 10.0005, "pos": [1.0, 2.0]},
+		{"hp": 10.0}, [1.0, 2.0], "nan", "inf", 5, 42.0,
+		[1.0, 2.0, "x"], {"hp": 10, "pos": [1.0, 2.0]},
+		{"tags": ["a", "b"], "nest": {"k": 1.0}},
+		{"pf": [1.5], "pi": [1.0]},
+	])
+	var checked: int = 0
+	var mismatches: Array = []
+	for raw: Variant in corpus:
+		var encoded: Variant = CliControlVariantCodec.encode_value(raw)
+		for expected: Variant in expecteds:
+			for op: String in ["eq", "ne", "gt", "lt", "ge", "le"]:
+				for tol: float in [0.0, 0.001, 0.5]:
+					checked += 1
+					var fast: bool = _api._wait_compare_raw(raw, expected, op, tol)
+					var slow: bool = _api._wait_compare(encoded, expected, op, tol)
+					if fast != slow:
+						mismatches.append("raw=%s expected=%s op=%s tol=%s fast=%s slow=%s" % [
+							raw, expected, op, tol, fast, slow,
+						])
+	assert_gt(checked, 30000, "矩阵规模异常缩水")
+	assert_eq(mismatches, [], "raw 直比与编码后比较出现分歧")
+
+
+func _build_deep_array(levels: int) -> Array:
+	var root: Array = []
+	var cur: Array = root
+	for _i in levels:
+		var nxt: Array = []
+		cur.append(nxt)
+		cur = nxt
+	cur.append(1)
+	return root
+
+
+func test_wait_compare_raw_tolerance_in_array_not_in_dictionary() -> void:
+	## 契约 pin（现状语义，免物化路径必须保持）：数组元素吃 tolerance 且
+	## int/float 数值互通；Dictionary 值不吃 tolerance（_deep_equal 对
+	## Dictionary 落引擎 ==，类型严格——int 与 float 在引擎深比较里**不**互通，
+	## 实证 {"a": 1} == {"a": 1.0} → false）。
+	assert_true(_api._wait_compare_raw([10.0005], [10.0], "eq", 0.001))
+	assert_true(_api._wait_compare_raw([10], [10.0], "eq", 0.0))
+	assert_false(_api._wait_compare_raw({"hp": 10.0005}, {"hp": 10.0}, "eq", 0.001))
+	assert_false(_api._wait_compare_raw({"hp": 10}, {"hp": 10.0}, "eq", 0.0))
+	assert_true(_api._wait_compare_raw({"hp": 10.0}, {"hp": 10.0}, "eq", 0.0))
+
+
+func test_wait_compare_cross_type_is_false_not_abort() -> void:
+	## #109 顺手修存量雷 pin：跨类型比较必须「干净地」返回 false——
+	## 旧版裸 `a == b` 是运行期脚本错误（中止函数、抛 Nil、每帧刷错误日志、
+	## 污染 #103 errors 缓冲）。assert_eq 严格比对 false（中止时会拿到 Nil，
+	## 能与 false 区分开）。
+	assert_eq(_api._wait_compare("str", 5, "eq", 0.0), false)
+	assert_eq(_api._wait_compare(true, 1, "eq", 0.0), false)
+	assert_eq(_api._wait_compare([1, 2], "x", "eq", 0.0), false)
+	assert_eq(_api._wait_compare(["a", 1], [1, "a"], "eq", 0.0), false)
+	assert_eq(_api._wait_compare_raw({"k": [1]}, {"k": "x"}, "eq", 0.0), false)
+	assert_eq(_api._wait_compare_raw(PackedStringArray(["a"]), [1], "eq", 0.0), false)
+
+
+func test_wait_property_dictionary_eq_end_to_end() -> void:
+	## 容器属性走免物化路径后，端到端 matched=true 且返回 payload 仍是编码形
+	## （Vector2 → [x, y]）。
+	var s := GDScript.new()
+	s.source_code = "extends Node2D\nvar stats: Dictionary = {\"hp\": 10.0, \"pos\": Vector2(1.0, 2.0)}\n"
+	s.reload()
+	var node: Node2D = s.new()
+	add_child_autofree(node)
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "stats",
+		"value": {"hp": 10.0, "pos": [1.0, 2.0]}, "timeout": 1.0,
+	})
+	assert_true(result["matched"])
+	assert_eq(result["value"], {"hp": 10.0, "pos": [1.0, 2.0]})
+
+
+func test_wait_property_memo_survives_node_swap() -> void:
+	## #109 memo 按实例 id：等待中把节点换成同名新实例（新 iid），
+	## memo 必须自动失效、回全检路径并照常命中。
+	var old := Node2D.new()
+	old.name = "SwapTarget"
+	old.position = Vector2(0.0, 0.0)
+	add_child(old)  # 不 autofree：50ms 后手动 free 换新
+	var parent: Node = old.get_parent()
+	var path: String = str(old.get_path())
+	get_tree().create_timer(0.05).timeout.connect(func() -> void:
+		old.free()
+		var fresh := Node2D.new()
+		fresh.name = "SwapTarget"
+		fresh.position = Vector2(7.0, 0.0)
+		parent.add_child(fresh)
+		autofree(fresh)
+	)
+	var result: Dictionary = await _api.wait_property_async({
+		"path": path, "property": "position:x", "value": 7.0, "timeout": 2.0,
+	})
+	assert_true(result["matched"])
+
+
+func test_wait_property_null_then_value_transition() -> void:
+	## 裸读读到 null 时降级全检：属性真值为 null 期间不误判 property_not_found，
+	## 变值后正常命中（覆盖 fast-read-null → 全检 fallback 分支）。
+	var s := GDScript.new()
+	s.source_code = "extends Node2D\nvar payload = null\n"
+	s.reload()
+	var node: Node2D = s.new()
+	add_child_autofree(node)
+	get_tree().create_timer(0.05).timeout.connect(func() -> void: node.set("payload", 5))
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "payload", "value": 5, "timeout": 2.0,
+	})
+	assert_true(result["matched"])
+	assert_eq(int(result["value"]), 5)
+
+
+func test_wait_property_missing_property_reason() -> void:
+	## 属性整段缺失：_has_property 的 `in` 快拒路径下 reason 仍是
+	## property_not_found（#109 不改诊断语义）。
+	var node := Node2D.new()
+	add_child_autofree(node)
+	var result: Dictionary = await _api.wait_property_async({
+		"path": str(node.get_path()), "property": "no_such_prop", "value": 1, "timeout": 0.1,
+	})
+	assert_false(result["matched"])
+	assert_eq(result["reason"], "property_not_found")
+	assert_null(result["value"])


### PR DESCRIPTION
Closes #109

## 改动

每帧轮询成本三连降（`wait_property_async`）：

1. **`_wait_compare_raw` / `_encoded_eq_raw`**：与「先 `encode_value` 再 `_wait_compare`」**结果恒等**的结构化直比。容器在 miss 帧不再物化整棵编码树——零分配、首差短路；命中才编码一次做返回 payload。非容器叶子 encode 本就 O(1)，原路不动。
2. **属性存在性 memo**：按节点实例 id 记忆「属性已确认存在」，同实例后续帧裸读（`get` / `get_indexed`），跳过 `_read_property` 里 `get_property_list()` 的逐帧整表分配 + 线性扫。实例 id 不复用 ⇒ 节点被释放/替换时 memo 自动失效回全检。裸读读到 null 一律降级全检（null 无法区分「真 null」与「属性中途消失」），`reason` 诊断精度不降。
3. **`_has_property` 加 `in` 快拒**：实证 `in` 对 Object 是「可取成员」超集（属性/方法/信号/常量全 true）——false ⇒ 必不在 property list，缺属性轮询免逐帧整表分配；true 不充分，仍线性扫确认，**1002 严格性不变**（方法名照旧 1002）。

## 顺手修的存量雷（#96 起就在）

GDScript 层跨类型 `==`（`Array == String`、`bool == int`、`String == NodePath`…）是**运行期脚本错误**：打印错误、中止所在函数、向上抛 Nil——不是静默 false。旧 `_deep_equal` 末行裸 `a == b` 在 expected 与属性类型不符时（agent typo 常态）每帧刷错误日志、还会污染 #103 的 errors 环形缓冲，结果只是靠 Nil→false 的二次错误侥幸正确。引入 `_safe_eq` 类型守卫（合法比较仅：同 typeof / int-float 数值对 / 与 null 比较恒 false）。GUT 套件输出从 **23MB 错误噪声降回 32KB**。

附带行为修正：`get_property_list` 里的 category/group 装饰条目（如 `"Node2D"`，usage=CATEGORY）此前被线性扫误判为属性、读出 null；`in` 快拒后正确报 1002（更可诊断，GUT 已 pin）。

## 等价性怎么保证

- **parity 矩阵**（`test_wait_compare_raw_parity_matrix`）：40 种全类型 corpus × 53 expected × 6 op × 3 tolerance ≈ 38k 组合，逐位断言 raw 直比 ≡ 编码后比较，分歧数必须为 0
- 关键实证（本机 Godot 4.6.2 探针）：**引擎内部深比较是类型严格的**（`{"a":1} == {"a":1.0}` → false，int/float 不互通）——strict 镜像按此实现；Dictionary 内不吃 tolerance、顶层/数组吃 tolerance 的现状语义被显式 pin
- 行为测试：dict 端到端 eq、节点中途换实例（memo 失效）、null→值跃迁（降级全检）、缺属性 reason、跨类型比较干净返回 false（与 Nil 中止可区分）

## 基准（200 键嵌套 Dictionary，1000 次均值，Godot 4.6.2 headless）

| 场景 | 旧 | 新 |
|---|---|---|
| shape-miss（首检短路，常见早期形态） | 7.6ms/帧 | **36µs/帧（≈210×）** |
| 属性读取（memo 裸读 vs 含线性扫全检） | 150µs/次 | **0.11µs/次（≈1300×）** |
| near-miss（200 键全等仅末叶不同，对抗性尾部） | 7.7ms/帧 | 9.6ms/帧（**慢 25%**） |

诚实声明：near-miss 尾部劣化来自 GDScript VM 走查比「GDScript 编码 + C++ 深比较」略贵；现实 miss 平均在半树处短路即赢，且 memo 收益对所有 wait-property 无条件生效。典型标量/sub-path 等待（绝对主流）由 memo 主导，纯赚。

## 测试

- GUT：204/204（含 38k parity 矩阵），输出 23MB → 32KB
- Python：548 passed / 4 skipped，覆盖率 88%（门槛 80%）
- 无 CLI/错误码/信封契约变化 → SKILL.md / README 无需更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)