### PR TITLE
feat(init): 默认覆盖 addon 目录 + --keep-addon 逃生口

### DIFF
--- a/.claude/skills/godot-cli-control/SKILL.md
+++ b/.claude/skills/godot-cli-control/SKILL.md
@@ -600,7 +600,7 @@ bridge 是 GameClient 的同步包装，方法名一致、无需 await。
 脚本同目录的兄弟模块（from helpers import foo）可正常 import。
 
 $ godot-cli-control init --help
-usage: godot-cli-control init [-h] [--path PATH] [--force]
+usage: godot-cli-control init [-h] [--path PATH] [--force | --keep-addon]
                               [--skills-no-clobber] [--no-gitignore]
                               [--no-skills | --skills-only] [--json] [--text]
                               [--no-json]
@@ -610,7 +610,9 @@ usage: godot-cli-control init [-h] [--path PATH] [--force]
 options:
   -h, --help           show this help message and exit
   --path PATH          目标 Godot 项目根（默认当前目录）
-  --force              覆盖已存在的 addons/godot_cli_control
+  --force              覆盖已存在的 addons/godot_cli_control（现已是默认行为，本 flag 仅为兼容保留）
+  --keep-addon         已存在 addons/godot_cli_control 时跳过插件复制（保留本地版本，不随 CLI
+                       升级刷新；默认会覆盖以同步版本）
   --skills-no-clobber  写 skill 时跳过已存在的 .claude/.codex SKILL.md（默认会覆盖以保证版本与 CLI
                        帮助同步）。与 --no-skills / --skills-only 都兼容。
   --no-gitignore       跳过往项目根 .gitignore 追加 .cli_control/（默认会追加，忽略 daemon

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Both are rendered from the same template and pin the current CLI version + `--he
 godot-cli-control init --skills-only
 ```
 
+Re-running plain `godot-cli-control init` also works and additionally refreshes the bundled `addons/godot_cli_control/` plugin to the new version (pass `--keep-addon` if you've deliberately modified your copy).
+
 If you've hand-edited a `SKILL.md` and want to keep your version:
 
 - `godot-cli-control init --no-skills` — skip skill writes entirely going forward

--- a/docs/superpowers/plans/2026-06-05-init-clobber-addon.md
+++ b/docs/superpowers/plans/2026-06-05-init-clobber-addon.md
@@ -1,0 +1,324 @@
+# init 默认覆盖 addon 目录（clobber_addon）实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `init` 默认覆盖 `addons/godot_cli_control/`（rmtree+copy），新增 `--keep-addon` 逃生口，`--force` 降为兼容 no-op。
+
+**Architecture:** 翻转 `init_cmd.run_init` 的 plugin 复制分支默认值（参数 `force: bool = False` 改名 `clobber_addon: bool = True`，与 `clobber_skills` 对称），CLI 侧 `--force` / `--keep-addon` 进 mutually_exclusive_group，`cmd_init` 以 `clobber_addon=not ns.keep_addon` 接线。文档三处同步 + 仓内渲染版 SKILL.md 重渲染（CI skill-render-drift 门禁）。
+
+**Tech Stack:** Python ≥3.10 / argparse / pytest（venv 在仓库根 `.venv`，Python 3.14）；SKILL.md 重渲染必须 Python 3.12 + COLUMNS=80。
+
+**Spec:** `docs/superpowers/specs/2026-06-05-init-clobber-addon-design.md`（已批准，必读）
+
+**执行约定（来自仓库 CLAUDE.md / 用户全局规则）：**
+- 跑测试一律委托 subagent（`model: "sonnet"`，**禁 run_in_background**），主会话只收精简结论
+- 工作分支：`feat/init-clobber-addon`（已存在，spec commit 在其上）
+- 测试命令统一在仓库根执行；e2e 需要 `GODOT_BIN=$HOME/.local/bin/godot`
+
+---
+
+### Task 1: run_init 行为翻转 + CLI 参数面
+
+**Files:**
+- Modify: `python/godot_cli_control/init_cmd.py`（签名 ~L48-58、docstring ~L59-77、plugin 分支 ~L126-140）
+- Modify: `python/godot_cli_control/cli.py`（`cmd_init` L1801、init parser L2239-2243）
+- Test: `python/tests/test_init.py`、`python/tests/test_cli.py`
+
+- [ ] **Step 1: 写失败测试（API 层，test_init.py，加在 `test_run_init_idempotent` 之后）**
+
+```python
+def test_run_init_overwrites_existing_addon_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """默认 clobber_addon=True：已存在的 addon 整目录刷新，旧文件被清掉。"""
+    monkeypatch.delenv("GODOT_BIN", raising=False)
+    monkeypatch.setattr(
+        "godot_cli_control.init_cmd.find_godot_binary", lambda: None
+    )
+    project = _minimal_project(tmp_path)
+    assert run_init(project) == 0
+
+    plugin_dst = project / "addons" / "godot_cli_control"
+    marker = plugin_dst / "user_local_hack.gd"
+    marker.write_text("# 用户本地改动\n")
+
+    result: dict = {}
+    assert run_init(project, result=result) == 0
+    assert not marker.exists(), "默认应 rmtree+copy，旧文件要被清掉"
+    assert (plugin_dst / "plugin.cfg").is_file()
+    assert result["plugin_copied"] is True
+    assert result["plugin_overwritten"] is True
+
+
+def test_run_init_keep_addon_preserves_existing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """clobber_addon=False（CLI --keep-addon）：已存在 addon 原样保留。"""
+    monkeypatch.delenv("GODOT_BIN", raising=False)
+    monkeypatch.setattr(
+        "godot_cli_control.init_cmd.find_godot_binary", lambda: None
+    )
+    project = _minimal_project(tmp_path)
+    assert run_init(project) == 0
+
+    plugin_dst = project / "addons" / "godot_cli_control"
+    marker = plugin_dst / "user_local_hack.gd"
+    marker.write_text("# 用户本地改动\n")
+
+    result: dict = {}
+    assert run_init(project, clobber_addon=False, result=result) == 0
+    assert marker.exists(), "--keep-addon 必须保留本地文件"
+    assert result["plugin_copied"] is False
+    assert result["plugin_overwritten"] is False
+```
+
+- [ ] **Step 2: 写失败测试（CLI 层，test_cli.py，加在 `test_init_subcommand_rejects_both_flags` 之后，模仿其写法）**
+
+```python
+def test_init_subcommand_accepts_keep_addon_flag() -> None:
+    from godot_cli_control.cli import build_parser
+
+    ns = build_parser().parse_args(["init", "--keep-addon"])
+    assert ns.keep_addon is True
+    assert ns.force is False
+
+
+def test_init_subcommand_force_still_accepted_as_noop() -> None:
+    """--force 降为兼容 no-op：必须仍被 argparse 接受。"""
+    from godot_cli_control.cli import build_parser
+
+    ns = build_parser().parse_args(["init", "--force"])
+    assert ns.force is True
+    assert ns.keep_addon is False
+
+
+def test_init_subcommand_rejects_force_with_keep_addon() -> None:
+    """--force 与 --keep-addon 互斥（mutually_exclusive_group）。"""
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["init", "--force", "--keep-addon"])
+
+
+def test_cmd_init_wires_keep_addon_to_clobber_addon(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """cmd_init 必须把 --keep-addon 翻译成 clobber_addon=False。"""
+    import argparse
+
+    from godot_cli_control.cli import OUTPUT_JSON, cmd_init
+
+    captured: dict = {}
+
+    def fake_run_init(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("godot_cli_control.init_cmd.run_init", fake_run_init)
+    ns = argparse.Namespace(
+        path=None,
+        force=False,
+        keep_addon=True,
+        no_skills=False,
+        skills_only=False,
+        skills_no_clobber=False,
+        no_gitignore=False,
+        output_format=OUTPUT_JSON,
+    )
+    assert cmd_init(ns) == 0
+    capsys.readouterr()
+    assert captured["clobber_addon"] is False
+    assert "force" not in captured
+```
+
+注意：`cmd_init` 是 `from .init_cmd import ... run_init` 的函数内 import，monkeypatch 目标必须是 `godot_cli_control.init_cmd.run_init`。
+
+- [ ] **Step 3: 跑新测试确认失败**
+
+Run（subagent）: `cd /Users/kesar/Projects/godot-cli-control && .venv/bin/python -m pytest python/tests/test_init.py python/tests/test_cli.py -q -k "overwrites_existing_addon or keep_addon or force_still"`
+Expected: FAIL —— `run_init` 无 `clobber_addon` 参数（TypeError）、parser 无 `--keep-addon`（SystemExit/AttributeError）。
+
+- [ ] **Step 4: 改 `init_cmd.py`**
+
+签名（L48-58）：`force: bool = False` → `clobber_addon: bool = True`：
+
+```python
+def run_init(
+    project_root: Path,
+    clobber_addon: bool = True,
+    write_skills: bool = True,
+    skills_only: bool = False,
+    clobber_skills: bool = True,
+    write_gitignore: bool = True,
+    *,
+    output_format: str = "text",
+    result: dict[str, Any] | None = None,
+) -> int:
+```
+
+docstring 在 `skills_only=True` 段之前补一段（原文没有 force 的说明，新增即可）：
+
+```
+    ``clobber_addon=False``（CLI ``--keep-addon``）：已存在
+    ``addons/godot_cli_control/`` 时跳过插件复制，保留用户本地版本。
+    默认 True：每次 init 都 rmtree+copy 刷新 addon，保证与当前 CLI 版本
+    同步 —— 与 ``clobber_skills`` 默认覆盖同源的设计理由（CLI 升级后
+    GDScript 侧必须跟上，否则两侧协议错位）。
+```
+
+plugin 分支（L128-135）：
+
+```python
+        if plugin_dst.exists():
+            if clobber_addon:
+                shutil.rmtree(plugin_dst)
+                _copy_plugin(plugin_src, plugin_dst)
+                _say(f"覆盖：{plugin_dst}")
+                _record(plugin_copied=True, plugin_overwritten=True)
+            else:
+                _say(f"已存在：{plugin_dst}（--keep-addon 保留，未更新）")
+```
+
+模块 docstring（L1-15）第 2 条「复制插件物料到 ``addons/godot_cli_control/``」改为「复制插件物料到 ``addons/godot_cli_control/``（已存在则默认整目录刷新，``--keep-addon`` 跳过）」。
+
+- [ ] **Step 5: 改 `cli.py`**
+
+`cmd_init`（L1801）：`force=ns.force,` → `clobber_addon=not ns.keep_addon,`
+（mutex 保证 `--force` 与 `--keep-addon` 不并存；单传 `--force` 时 `keep_addon=False` → 覆盖，与其意图一致，故 `ns.force` 无需再读。）
+
+init parser（L2239-2243 的 `--force` 定义处）改成 mutex group：
+
+```python
+    addon_group = init_p.add_mutually_exclusive_group()
+    addon_group.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "覆盖已存在的 addons/godot_cli_control"
+            "（现已是默认行为，本 flag 仅为兼容保留）"
+        ),
+    )
+    addon_group.add_argument(
+        "--keep-addon",
+        action="store_true",
+        help=(
+            "已存在 addons/godot_cli_control 时跳过插件复制"
+            "（保留本地版本，不随 CLI 升级刷新；默认会覆盖以同步版本）"
+        ),
+    )
+```
+
+- [ ] **Step 6: 更新存量测试**
+
+- 四处 `argparse.Namespace(...)`（以 `force=False,` 为锚）：`python/tests/test_init.py` 约 L427、L459、L645 + `python/tests/test_cli.py` 约 L723（`test_cmd_init_catches_unexpected_exception_into_envelope` 内）。每处在 `force=False,` 后加一行 `keep_addon=False,`（保留 `force` 字段——真 parser 的 namespace 两个属性都有，测试镜像之）。漏掉任何一处会在 Step 7 红：`AttributeError: Namespace object has no attribute 'keep_addon'`。
+- `test_run_init_idempotent`（L179-193）：docstring 改为「重复跑 init 不能破坏 project.godot 或抛错（addon 会被默认刷新，project.godot patch 仍幂等）」；L190 注释「# 第二次：应该 noop」改为「# 第二次：addon 整目录刷新（默认 clobber），project.godot 不得重复 patch」。
+- 如有其它 `run_init(..., force=...)` 关键字调用（grep 确认），改为 `clobber_addon=`。
+
+- [ ] **Step 7: 跑相关测试确认全绿**
+
+Run（subagent）: `cd /Users/kesar/Projects/godot-cli-control && .venv/bin/python -m pytest python/tests/test_init.py python/tests/test_cli.py -q`
+Expected: 全 PASS。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add python/godot_cli_control/init_cmd.py python/godot_cli_control/cli.py python/tests/test_init.py python/tests/test_cli.py
+git commit -m "feat(init): 默认覆盖 addons/godot_cli_control，--keep-addon 逃生口
+
+force→clobber_addon（默认 True，与 clobber_skills 对称）；--force 降为
+兼容 no-op，与 --keep-addon 互斥。理由与 SKILL.md 默认 clobber 同源：
+CLI 升级后重跑 init 必须让 GDScript 侧跟上，否则协议错位。"
+```
+
+---
+
+### Task 2: 文档同步 + 仓内 SKILL.md 重渲染
+
+**Files:**
+- Modify: `python/README.md:28`、`python/README.md:99`
+- Modify: `README.md`（Agent integration 节，~L193-197）
+- Regenerate: `.claude/skills/godot-cli-control/SKILL.md`（CI skill-render-drift 门禁）
+
+- [ ] **Step 1: 改 `python/README.md`**
+
+L28 整行替换为：
+
+```markdown
+Re-running `init` refreshes both `addons/godot_cli_control/` and the SKILL.md files to match the installed CLI version (the plugin directory is wiped and re-copied; `project.godot` patching stays idempotent). Pass `--keep-addon` to keep an existing `addons/godot_cli_control/` untouched.
+```
+
+L99：`godot-cli-control init [--path DIR] [--force]` → `godot-cli-control init [--path DIR] [--keep-addon]`
+
+- [ ] **Step 2: 改顶层 `README.md`**
+
+L196-197 的 `init --skills-only` 代码块之后、L199「If you've hand-edited」之前，插入一段：
+
+```markdown
+Re-running plain `godot-cli-control init` also works and additionally refreshes the bundled `addons/godot_cli_control/` plugin to the new version (pass `--keep-addon` if you've deliberately modified your copy).
+```
+
+- [ ] **Step 3: 重渲染仓内 SKILL.md（必须 Python 3.12 + COLUMNS=80，否则 CI skill-render-drift 假红）**
+
+一次性 3.12 venv（已存在则跳过创建）：
+
+```bash
+[ -x /tmp/sk312/bin/python ] || (python3.12 -m venv /tmp/sk312 && /tmp/sk312/bin/pip install -q 'websockets>=14,<16')
+cd /Users/kesar/Projects/godot-cli-control
+COLUMNS=80 PYTHONPATH=python /tmp/sk312/bin/python -c "from godot_cli_control import cli; from godot_cli_control.skills_install import render_skill; from godot_cli_control._version import version; open('.claude/skills/godot-cli-control/SKILL.md','w').write(render_skill(version, cli.format_full_help()))"
+```
+
+（此命令已在本机验证可跑通；系统 python3.12 缺 websockets，必须走 /tmp/sk312。）
+
+- [ ] **Step 4: 检查重渲染 diff 只含预期变化**
+
+Run: `git diff --stat .claude/skills/ && git diff .claude/skills/ | head -80`
+Expected: 仅 init 小节 help 文本（`--force` 措辞、新增 `--keep-addon`、usage 行 `[--force | --keep-addon]`）+ 末行版本号变化。出现大面积重排 = COLUMNS 或 Python 版本不对，回 Step 3。
+
+- [ ] **Step 5: 渲染健康检查 + skills install 测试**
+
+Run（subagent）: `cd /Users/kesar/Projects/godot-cli-control && .venv/bin/python -c "from godot_cli_control import cli; print(len(cli.format_full_help()))" && .venv/bin/python -m pytest python/tests/test_skills_install.py -q`
+Expected: 打印长度无异常；test_skills_install 全 PASS。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/README.md README.md .claude/skills/godot-cli-control/SKILL.md
+git commit -m "docs(init): README 同步 init 覆盖语义 + 重渲染仓内 SKILL.md"
+```
+
+---
+
+### Task 3: 全量验证 + PR
+
+- [ ] **Step 1: 全量测试 + 覆盖率 + lint（subagent，禁 run_in_background）**
+
+```bash
+cd /Users/kesar/Projects/godot-cli-control
+GODOT_BIN=$HOME/.local/bin/godot .venv/bin/coverage run -m pytest python/tests/ -q
+.venv/bin/coverage report | tail -5
+.venv/bin/ruff check .
+```
+
+Expected: pytest 全 PASS（e2e 必真跑，GODOT_BIN 已给，「缺 GODOT_BIN」不是合法跳过理由）；coverage ≥ 80%（fail_under 门槛）；ruff 0 错。
+
+- [ ] **Step 2: 提交计划文档（若有未提交改动）并推送开 PR**
+
+```bash
+git push -u origin feat/init-clobber-addon
+```
+
+gh 操作需绕本地代理（`env -u http_proxy -u https_proxy -u all_proxy ...` + 禁沙箱）：
+
+```bash
+gh pr create --title "feat(init): 默认覆盖 addon 目录 + --keep-addon 逃生口" --body "<按 spec 摘要，含 spec/plan 链接>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+gh pr merge --auto --squash
+```
+
+合并挂上后用 `gh pr view --json autoMergeRequest` 自检非 null（required check = ci-ok）。
+
+- [ ] **Step 3: 收尾**
+
+- 等 CI 绿自动合并后，按仓库惯例在 main 上更新 `CLAUDE.md`「已知遗留 issue」段（注明本次 land）
+- 盘点遗留问题，按全局规则开 GitHub issues（如无遗留则明说）

--- a/docs/superpowers/specs/2026-06-05-init-clobber-addon-design.md
+++ b/docs/superpowers/specs/2026-06-05-init-clobber-addon-design.md
@@ -1,0 +1,96 @@
+# init 默认覆盖 addon 目录设计：clobber_addon
+
+日期：2026-06-05
+状态：已批准（brainstorming 确认）
+
+## 问题
+
+`init` 对 `addons/godot_cli_control/` 的现行为是「已存在则跳过，`--force` 才覆盖」
+（`init_cmd.py` `run_init` 的 plugin 复制分支）。这在 CLI 升级场景是个坑：
+
+1. `pip install -U godot-cli-control` 后重跑 `init`，不带 `--force` 会留下旧版
+   addon —— Python 侧与 GDScript 侧协议错位，错误还不在 init 时报，而是延迟到
+   RPC 行为不对时才暴露
+2. 与 SKILL.md 的默认行为不一致：SKILL.md 默认 clobber（spec §4，理由正是
+   「跟随版本与 CLI 帮助自动同步」），同一个同步理由对 addon 只会更强
+3. 项目哲学本就不鼓励用户改 addon 目录（定制走 `method_blacklist_extra`
+   ProjectSettings 增量路径），「保护用户对 addon 的改动」保护的是反模式
+
+## 目标
+
+1. `init` 默认覆盖已存在的 `addons/godot_cli_control/`（rmtree + copytree，
+   与现 `--force` 路径同实现）
+2. 保留逃生口：新增 `--keep-addon`，已存在则跳过插件复制（真改过 addon 的人用）
+3. `--force` 保留为兼容 no-op，旧脚本不破
+
+## 已决策的设计选择
+
+| 决策点 | 选择 | 备注 |
+|---|---|---|
+| 默认行为 | 覆盖（rmtree+copy） | 与 SKILL.md clobber 同源的版本同步理由 |
+| `--force` 处置 | 保留为 no-op | help 注明「现已是默认行为」；删掉会让旧脚本 exit 64 |
+| 逃生口命名 | `--keep-addon` | 「保留」语义直白；不复用 `--skills-no-clobber` 的 no-clobber 命名是因为 keep 更短且 addon 只有一个目标（skills 有两条路径才需要 clobber/补缺语义） |
+| `--force` × `--keep-addon` | mutually_exclusive_group | 同时传走 argparse 用法错既有路径（exit 64 / `-1003`） |
+| `--skills-only` × `--keep-addon` | 接受并忽略 | 与今天 `--force` × `--skills-only` 同等对待；插件复制本就被跳过 |
+| `run_init` 参数 | `force: bool = False` 改名 `clobber_addon: bool = True` | 与 `clobber_skills` 对称；调用方仅 `cli.cmd_init` 与测试，无对外 API 承诺 |
+
+## 组件设计
+
+### 1. CLI（`cli.py`）
+
+- `--force`：保留 `store_true`，help 改为「覆盖已存在的 addons/godot_cli_control
+  （现已是默认行为，本 flag 仅为兼容保留）」
+- 新增 `--keep-addon`：`store_true`，help 说明「已存在 addons/godot_cli_control
+  时跳过插件复制（保留本地版本，不随 CLI 升级刷新）」
+- 二者放进 `add_mutually_exclusive_group()`
+- `cmd_init`：`clobber_addon=not ns.keep_addon` 传给 `run_init`；不再有任何
+  `if ns.force` 分支（单传 `--force` 时 `keep_addon=False` → 覆盖，行为本就
+  与其意图一致；mutex 保证两 flag 不并存）
+
+### 2. `init_cmd.run_init`
+
+- 签名：`force: bool = False` → `clobber_addon: bool = True`
+- plugin 复制分支翻转：
+  - `clobber_addon=True`（默认）且已存在 → rmtree + copy，
+    `_say(f"覆盖：{plugin_dst}")`，`_record(plugin_copied=True, plugin_overwritten=True)`
+  - `clobber_addon=False` 且已存在 → 跳过，
+    `_say(f"已存在：{plugin_dst}（--keep-addon 保留，未更新）")`
+  - 不存在 → 复制（不变；`plugin_overwritten` 保持 False，与现行为一致）
+- JSON 字段 `plugin_copied` / `plugin_overwritten` 名称与语义不变
+
+### 3. 不动的部分
+
+- SKILL.md 写入逻辑（`clobber_skills` / `--skills-no-clobber`）原样
+- project.godot patch / godot_bin 检测 / .gitignore 维护原样
+- `skills_install.py` 不改（其 docstring 里「`force=True` 是 init 的默认」
+  讲的是 skills 路径，本就成立）
+
+## 测试策略
+
+| 场景 | 断言 |
+|---|---|
+| 已存在 addon + 默认 init | 旧文件（塞个 marker 文件进 addon 目录）被清掉，新物料落位；`plugin_overwritten=True` |
+| `--keep-addon` + 已存在 | marker 文件原样保留；`plugin_copied=False` |
+| `--force` 仍被接受 | 行为与默认一致，不报错 |
+| `--force --keep-addon` | argparse 用法错 → exit 64 |
+| 存量测试 | 3 处 `argparse.Namespace(force=False, ...)` 补 `keep_addon=False`（`force` 字段可留可删，`cmd_init` 不再读取） |
+| `run_init` API 级 | 直接调用处的 `force=` 关键字改 `clobber_addon=` |
+
+## 文档同步（契约 7）
+
+- argparse help 变 → `{{cli_help}}` 注入自动跟随；仓内 `.claude/skills` 渲染
+  副本必须用 `skills_install.render_skill` 重渲染（COLUMNS=80 + Python 3.12，
+  过 CI skill-render-drift）
+- `python/README.md:28` 硬写了旧语义（"idempotent … Pass `--force` to
+  overwrite"）→ 改为「重跑 init 会刷新 addon 与 SKILL.md 到当前 CLI 版本；
+  `--keep-addon` 保留本地 addon」；`:99` 的 usage 行同步
+- 顶层 `README.md` Agent integration 节的升级建议（"refresh with
+  `init --skills-only`"）补一句：重跑完整 `init` 可同时刷新 addon
+- SKILL.md 模板 prose 与 addon README 未硬写 `--force` 语义，不用动
+
+## 不做的事（YAGNI）
+
+- 不做「比较版本号 / 内容 hash，只在不同时覆盖」—— rmtree+copy 本就廉价幂等，
+  加判断只引入新失败面
+- 不做覆盖前自动备份 —— addon 目录在用户 git 仓里，git 即备份
+- 不做 `--keep-addon` 下的版本错位检测告警（真需要再说）

--- a/python/README.md
+++ b/python/README.md
@@ -25,7 +25,7 @@ godot-cli-control tree 3
 godot-cli-control daemon stop
 ```
 
-`init` is idempotent — running it twice on the same project does nothing the second time. Pass `--force` to overwrite an existing `addons/godot_cli_control/`.
+Re-running `init` refreshes both `addons/godot_cli_control/` and the SKILL.md files to match the installed CLI version (the plugin directory is wiped and re-copied; `project.godot` patching stays idempotent). Pass `--keep-addon` to keep an existing `addons/godot_cli_control/` untouched.
 
 `init` also writes `.claude/skills/godot-cli-control/SKILL.md` and `.codex/skills/godot-cli-control/SKILL.md` so AI agents working in your Godot project can pick up this CLI surface automatically. Use `--no-skills` to skip, or `--skills-only` to refresh just those files after a CLI upgrade. See the [top-level README](../README.md#agent-integration) for details.
 
@@ -96,7 +96,7 @@ The CLI is the canonical surface — every `GameClient` method has a one-line eq
 
 ```bash
 # Lifecycle
-godot-cli-control init [--path DIR] [--force]
+godot-cli-control init [--path DIR] [--keep-addon]
 godot-cli-control daemon start [--headless | --gui] [--port N --idle-timeout 30m]
 godot-cli-control daemon start --record --movie-path X [--fps N]   # 录制需真实渲染器，不能与 --headless 同用
 godot-cli-control daemon stop [--all | --project PATH]

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1798,7 +1798,7 @@ def cmd_init(ns: argparse.Namespace) -> int:
             # 保留 .resolve()：run_init 内部用 relative_to(project_root) 打印
             # skill 路径，相对路径会让 relative_to 在 cwd 不寻常时抛 ValueError。
             project_root=(Path(ns.path).resolve() if ns.path else Path.cwd()),
-            force=ns.force,
+            clobber_addon=not ns.keep_addon,
             write_skills=not ns.no_skills,
             skills_only=ns.skills_only,
             clobber_skills=not ns.skills_no_clobber,
@@ -2236,10 +2236,22 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="目标 Godot 项目根（默认当前目录）",
     )
-    init_p.add_argument(
+    addon_group = init_p.add_mutually_exclusive_group()
+    addon_group.add_argument(
         "--force",
         action="store_true",
-        help="覆盖已存在的 addons/godot_cli_control",
+        help=(
+            "覆盖已存在的 addons/godot_cli_control"
+            "（现已是默认行为，本 flag 仅为兼容保留）"
+        ),
+    )
+    addon_group.add_argument(
+        "--keep-addon",
+        action="store_true",
+        help=(
+            "已存在 addons/godot_cli_control 时跳过插件复制"
+            "（保留本地版本，不随 CLI 升级刷新；默认会覆盖以同步版本）"
+        ),
     )
     init_p.add_argument(
         "--skills-no-clobber",

--- a/python/godot_cli_control/init_cmd.py
+++ b/python/godot_cli_control/init_cmd.py
@@ -3,7 +3,7 @@
 在目标 Godot 项目根执行后：
 
 1. 校验 ``project.godot`` 存在
-2. 复制插件物料到 ``addons/godot_cli_control/``
+2. 复制插件物料到 ``addons/godot_cli_control/``（已存在则默认整目录刷新，``--keep-addon`` 跳过）
 3. patch ``project.godot``：注入 ``[autoload]`` 与 ``[editor_plugins]`` 两节，
    绕过 Godot Editor GUI 启用步骤
 4. 自动检测 Godot 二进制，写入 ``.cli_control/godot_bin``，daemon 启动时
@@ -47,7 +47,7 @@ INIT_RESULT_ERROR_KEY = "__init_error_message__"
 
 def run_init(
     project_root: Path,
-    force: bool = False,
+    clobber_addon: bool = True,
     write_skills: bool = True,
     skills_only: bool = False,
     clobber_skills: bool = True,
@@ -57,6 +57,12 @@ def run_init(
     result: dict[str, Any] | None = None,
 ) -> int:
     """实施接入流程。返回进程 exit code。
+
+    ``clobber_addon=False``（CLI ``--keep-addon``）：已存在
+    ``addons/godot_cli_control/`` 时跳过插件复制，保留用户本地版本。
+    默认 True：每次 init 都 rmtree+copy 刷新 addon，保证与当前 CLI 版本
+    同步 —— 与 ``clobber_skills`` 默认覆盖同源的设计理由（CLI 升级后
+    GDScript 侧必须跟上，否则两侧协议错位）。
 
     ``skills_only=True``：跳过 1-4 步（插件复制 / project.godot patch /
     godot_bin 检测），只写 SKILL.md —— 用于 CLI 升级后单独刷新 skill。
@@ -126,13 +132,13 @@ def run_init(
         addons_dir = project_root / ADDONS_DIRNAME
         plugin_dst = addons_dir / PLUGIN_DIR_NAME
         if plugin_dst.exists():
-            if force:
+            if clobber_addon:
                 shutil.rmtree(plugin_dst)
                 _copy_plugin(plugin_src, plugin_dst)
                 _say(f"覆盖：{plugin_dst}")
                 _record(plugin_copied=True, plugin_overwritten=True)
             else:
-                _say(f"已存在：{plugin_dst}（用 --force 覆盖）")
+                _say(f"已存在：{plugin_dst}（--keep-addon 保留，未更新）")
         else:
             addons_dir.mkdir(parents=True, exist_ok=True)
             _copy_plugin(plugin_src, plugin_dst)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -184,6 +184,72 @@ def test_init_subcommand_rejects_both_flags() -> None:
         build_parser().parse_args(["init", "--no-skills", "--skills-only"])
 
 
+def test_init_subcommand_accepts_keep_addon_flag() -> None:
+    """--keep-addon：已存在 addon 时跳过插件复制的逃生口。"""
+    from godot_cli_control.cli import build_parser
+
+    ns = build_parser().parse_args(["init", "--keep-addon"])
+    assert ns.keep_addon is True
+    assert ns.force is False
+
+
+def test_init_subcommand_force_still_accepted_as_noop() -> None:
+    """--force 降为兼容 no-op：必须仍被 argparse 接受。"""
+    from godot_cli_control.cli import build_parser
+
+    ns = build_parser().parse_args(["init", "--force"])
+    assert ns.force is True
+    assert ns.keep_addon is False
+
+
+def test_init_subcommand_rejects_force_with_keep_addon() -> None:
+    """--force 与 --keep-addon 互斥（mutually_exclusive_group）。"""
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["init", "--force", "--keep-addon"])
+
+
+@pytest.mark.parametrize(
+    ("keep_addon", "expected_clobber"),
+    [(True, False), (False, True)],
+    ids=["keep-addon", "default-clobber"],
+)
+def test_cmd_init_wires_keep_addon_to_clobber_addon(
+    keep_addon: bool,
+    expected_clobber: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """cmd_init 的接线两个方向都钉死：--keep-addon → clobber_addon=False，
+    默认（keep_addon=False）→ clobber_addon=True（本次行为翻转的主线）。"""
+    import argparse
+
+    from godot_cli_control.cli import OUTPUT_JSON, cmd_init
+
+    captured: dict = {}
+
+    def fake_run_init(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("godot_cli_control.init_cmd.run_init", fake_run_init)
+    ns = argparse.Namespace(
+        path=None,
+        force=False,
+        keep_addon=keep_addon,
+        no_skills=False,
+        skills_only=False,
+        skills_no_clobber=False,
+        no_gitignore=False,
+        output_format=OUTPUT_JSON,
+    )
+    assert cmd_init(ns) == 0
+    capsys.readouterr()
+    assert captured["clobber_addon"] is expected_clobber
+    assert "force" not in captured
+
+
 def test_version_flag_prints_version(capsys: pytest.CaptureFixture[str]) -> None:
     """``-V`` / ``--version`` 必须打印版本并 exit 0。SKILL.md 渲染依赖该版本号
     保持可用，回归保护。"""
@@ -721,6 +787,7 @@ def test_cmd_init_catches_unexpected_exception_into_envelope(
     ns = argparse.Namespace(
         path=str(tmp_path),
         force=False,
+        keep_addon=False,
         no_skills=False,
         skills_only=False,
         skills_no_clobber=False,

--- a/python/tests/test_init.py
+++ b/python/tests/test_init.py
@@ -177,7 +177,7 @@ def test_run_init_creates_addons_and_patches_project_godot(
 
 
 def test_run_init_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """重复跑 init 不能破坏 project.godot 或抛错。"""
+    """重复跑 init 不能破坏 project.godot 或抛错（addon 会被默认刷新，project.godot patch 仍幂等）。"""
     monkeypatch.delenv("GODOT_BIN", raising=False)
     monkeypatch.setattr(
         "godot_cli_control.init_cmd.find_godot_binary", lambda: None
@@ -187,10 +187,55 @@ def test_run_init_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert run_init(project) == 0
     pg_after_first = (project / "project.godot").read_text()
 
-    # 第二次：应该 noop
+    # 第二次：addon 整目录刷新（默认 clobber），project.godot 不得重复 patch
     assert run_init(project) == 0
     pg_after_second = (project / "project.godot").read_text()
     assert pg_after_first == pg_after_second
+
+
+def test_run_init_overwrites_existing_addon_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """默认 clobber_addon=True：已存在的 addon 整目录刷新，旧文件被清掉。"""
+    monkeypatch.delenv("GODOT_BIN", raising=False)
+    monkeypatch.setattr(
+        "godot_cli_control.init_cmd.find_godot_binary", lambda: None
+    )
+    project = _minimal_project(tmp_path)
+    assert run_init(project) == 0
+
+    plugin_dst = project / "addons" / "godot_cli_control"
+    marker = plugin_dst / "user_local_hack.gd"
+    marker.write_text("# 用户本地改动\n")
+
+    result: dict = {}
+    assert run_init(project, result=result) == 0
+    assert not marker.exists(), "默认应 rmtree+copy，旧文件要被清掉"
+    assert (plugin_dst / "plugin.cfg").is_file()
+    assert result["plugin_copied"] is True
+    assert result["plugin_overwritten"] is True
+
+
+def test_run_init_keep_addon_preserves_existing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """clobber_addon=False（CLI --keep-addon）：已存在 addon 原样保留。"""
+    monkeypatch.delenv("GODOT_BIN", raising=False)
+    monkeypatch.setattr(
+        "godot_cli_control.init_cmd.find_godot_binary", lambda: None
+    )
+    project = _minimal_project(tmp_path)
+    assert run_init(project) == 0
+
+    plugin_dst = project / "addons" / "godot_cli_control"
+    marker = plugin_dst / "user_local_hack.gd"
+    marker.write_text("# 用户本地改动\n")
+
+    result: dict = {}
+    assert run_init(project, clobber_addon=False, result=result) == 0
+    assert marker.exists(), "--keep-addon 必须保留本地文件"
+    assert result["plugin_copied"] is False
+    assert result["plugin_overwritten"] is False
 
 
 def test_run_init_writes_godot_bin_when_detected(
@@ -425,6 +470,7 @@ def test_cmd_init_emits_success_envelope_in_json_mode(
     ns = argparse.Namespace(
         path=str(proj),
         force=False,
+        keep_addon=False,
         no_skills=False,
         skills_only=False,
         skills_no_clobber=False,
@@ -457,6 +503,7 @@ def test_cmd_init_emits_error_envelope_on_non_godot_dir(
     ns = argparse.Namespace(
         path=str(tmp_path),
         force=False,
+        keep_addon=False,
         no_skills=False,
         skills_only=False,
         skills_no_clobber=False,
@@ -643,6 +690,7 @@ def test_cmd_init_no_gitignore_flag_skips(
     ns = argparse.Namespace(
         path=str(proj),
         force=False,
+        keep_addon=False,
         no_skills=False,
         skills_only=False,
         skills_no_clobber=False,


### PR DESCRIPTION
## 变更

`init` 对 `addons/godot_cli_control/` 的行为从「已存在则跳过、`--force` 才覆盖」翻转为**默认覆盖**（rmtree+copy）：

- `run_init` 参数 `force: bool = False` → `clobber_addon: bool = True`（与 `clobber_skills` 对称）
- 新增 `--keep-addon` 逃生口：已存在则跳过插件复制（真改过 addon 的人用）
- `--force` 保留为兼容 no-op，与 `--keep-addon` 互斥（并存 → exit 64 / `-1003` 既有用法错路径）

## 为什么

CLI 升级后重跑 `init` 不带 `--force` 会留下旧版 addon——Python 侧与 GDScript 侧协议错位，且错误延迟到 RPC 行为不对时才暴露。这与 SKILL.md 默认 clobber 是同一个同步理由（spec §4）；项目哲学本就引导定制走 `method_blacklist_extra` 增量路径而非改 addon 目录。

> ⚠️ 行为变化提示：plain `init` 重跑现在会**静默重建** addon 目录。手改过 addon 的用户需改用 `--keep-addon`（git 即备份；两个 README 已标注）。

## 配套

- 测试：6 新增（marker 文件真覆盖/真保留、flag 解析、mutex、接线 parametrize 双向）+ 4 处存量 Namespace 更新
- 文档：`python/README.md` 旧 idempotent/`--force` 语义改写、顶层 README Agent integration 补充、仓内 `.claude/skills` SKILL.md 重渲染（Python 3.12 + COLUMNS=80，过 skill-render-drift）
- spec / plan 文档随分支入库（`docs/superpowers/`）

## 验证

- 555 passed / 4 平台门控 skip（e2e 真跑，GODOT_BIN 本机）
- coverage 88%（门槛 80）
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)