### PR TITLE
fix(render): screenshot --node 边界补乘 viewport final transform（#137）

### DIFF
--- a/addons/godot_cli_control/bridge/render_api.gd
+++ b/addons/godot_cli_control/bridge/render_api.gd
@@ -30,8 +30,8 @@ func handle_sprite_info(params: Dictionary) -> Dictionary:
 	)
 
 
-## screenshot --node 的边界计算：节点 local rect → 经 canvas/camera 变换的
-## 视口像素坐标 AABB。返回 Rect2，失败返回 error Dictionary（1010）。
+## screenshot --node 的边界计算：节点 local rect → 经 canvas/camera + content
+## scale 变换的物理像素坐标 AABB。返回 Rect2，失败返回 error Dictionary（1010）。
 ## static：只依赖传入节点自身的变换链，便于 GUT 直接单测（无需真渲染）。
 static func compute_node_screen_rect(node: Node) -> Variant:
 	if not (node is CanvasItem):
@@ -51,9 +51,16 @@ static func compute_node_screen_rect(node: Node) -> Variant:
 					% node.get_class(),
 			}
 		}
-	# get_global_transform_with_canvas 含 CanvasLayer / Camera2D 变换，
-	# 结果即视口像素坐标；Transform2D * Rect2 返回旋转后四角的 AABB。
+	# get_global_transform_with_canvas 含 CanvasLayer / Camera2D 变换，结果是画布
+	# （逻辑设计分辨率）坐标；再乘 viewport.get_final_transform()（content scale 的
+	# stretch 缩放 + letterbox 偏移）才与取图侧 get_image() 的物理像素系对齐——
+	# 漏乘时 hiDPI / 拉伸窗口下裁剪整体偏左上且偏小（#137）。平窗（物理 == 逻辑）
+	# 环境 final transform 为 identity，行为不变。Transform2D * Rect2 返回旋转后
+	# 四角的 AABB。
 	var xform: Transform2D = (node as CanvasItem).get_global_transform_with_canvas()
+	var viewport: Viewport = (node as CanvasItem).get_viewport()
+	if viewport != null:
+		xform = viewport.get_final_transform() * xform
 	return xform * (local_rect_or_null as Rect2)
 
 

--- a/addons/godot_cli_control/tests/gut/test_render_api.gd
+++ b/addons/godot_cli_control/tests/gut/test_render_api.gd
@@ -184,6 +184,25 @@ func test_screen_rect_sprite2d_centered_with_scale() -> void:
 	assert_eq(rect as Rect2, Rect2(92, 46, 16, 8))
 
 
+func test_screen_rect_applies_viewport_final_transform() -> void:
+	# content scale（hiDPI / stretch 窗口）回归（#137）：rect 必须落在取图侧
+	# get_image() 的物理像素系。SubViewport size(200,100) + size_2d_override(100,50)
+	# + stretch 构造 final transform = scale 2：Control (10,20,30,40) → (20,40,60,80)。
+	# 漏乘 final transform 时返回画布坐标 (10,20,30,40)，hiDPI 下裁剪整体错位。
+	var viewport := SubViewport.new()
+	viewport.size = Vector2i(200, 100)
+	viewport.size_2d_override = Vector2i(100, 50)
+	viewport.size_2d_override_stretch = true
+	add_child_autofree(viewport)
+	var ctl := Control.new()
+	ctl.position = Vector2(10, 20)
+	ctl.size = Vector2(30, 40)
+	viewport.add_child(ctl)
+	var rect: Variant = RenderApiScript.compute_node_screen_rect(ctl)
+	assert_true(rect is Rect2, "stretch viewport 内 Control 应能算出 Rect2，实际: %s" % [rect])
+	assert_eq(rect as Rect2, Rect2(20, 40, 60, 80))
+
+
 func test_screen_rect_non_canvas_item_returns_1010() -> void:
 	var plain := Node.new()
 	plain.name = "PlainNode"


### PR DESCRIPTION
Fixes #137

## 根因

`screenshot --node` 的边界计算与取图侧坐标系不一致（#101 / PR #130 引入时未考虑 stretch）：

- `compute_node_screen_rect`：`get_global_transform_with_canvas()` → **画布（逻辑设计分辨率）坐标**
- `take_screenshot_async`：`get_viewport().get_texture().get_image()` → **窗口物理像素**
- 两系相差 `viewport.get_final_transform()`（content scale 缩放 + letterbox 偏移）

物理 == 逻辑（平窗、scale=1）时两系重合，所以一直没暴露；hiDPI / stretch 窗口下裁剪整体偏左上且偏小，切出无关画面。

## 修复

`compute_node_screen_rect` 算完 canvas rect 后补乘 `node.get_viewport().get_final_transform()`。identity 环境行为不变（既有 4 个 screen_rect 测试原样通过）。

## 验证

- GUT 新增 `test_screen_rect_applies_viewport_final_transform`：SubViewport `size_2d_override(+stretch)` 构造 scale 2，断言 `(10,20,30,40) → (20,40,60,80)`；TDD 红绿完整（红阶段实测返回画布坐标）
- GUT 全套 205/205；pytest 562 过 / 覆盖率 89%（未动 Python 侧）
- 下游 XGame 实测（Retina 最大化窗口 3584×1934 vs 画布 1920×1080，scale ≈ 1.79）：修复前对 `InventoryScroll` 截图切出无关世界场景；修复后 region 正确换算到物理像素系、裁剪精确命中目标节点（ClaymanTwinkle/XGame#75 的复现场景）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
