### PR TITLE
docs(readme): 追平 PyPI description / 顶层 README 与当前 CLI 命令面

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,14 @@ Godot ships great tools for *playing* a scene, but very little for *programmatic
 
 One install, one daemon, one consistent API across your editor, your tests, your CI, and your agents.
 
-## Recent changes
-
-**BREAKING (unreleased):** `get` now returns compound Variants (Vector2, Color, etc.) as a structured object `{"value": [x, y], "type": "Vector2"}` instead of the old `"(x, y)"` string. The `value` array is the same layout `set` accepts, so round-trips work directly. Also new: `get <path> <prop1> <prop2>` reads multiple properties atomically in one frame (`get_properties` RPC, #100).
-
 ## Highlights
 
 | | |
 |---|---|
 | **One-shot onboarding** | `godot-cli-control init` copies the addon, patches `project.godot`, autodetects the Godot binary, and writes AI-agent skill files. Idempotent. |
-| **Shell is canonical**  | 21+ subcommands cover the full RPC surface; output is single-line JSON envelope by default (`--text` for legacy strings). `GameClient` (async) / `GameBridge` (sync) are still there when you need to keep one connection across many steps. |
-| **pytest fixtures**     | Auto-loaded `godot_daemon` (session) + `bridge` (function) fixtures. Held inputs released between cases. |
+| **Shell is canonical**  | 30+ subcommands cover the full RPC surface; output is single-line JSON envelope by default (`--text` for legacy strings). `GameClient` (async) / `GameBridge` (sync) are still there when you need to keep one connection across many steps. |
+| **pytest fixtures**     | Auto-loaded `godot_daemon` (session) + `bridge` (function) fixtures, plus opt-in `fresh_scene` (per-test scene reload) and `no_push_errors` (fail on silent `push_error`). Held inputs / pause / time-scale restored between cases; failures auto-screenshot. |
+| **Deterministic waits** | `wait-prop` / `wait-signal` / `wait-frames` / `pause` + `step-frames` / `time-scale` — assert on real engine state instead of sleeping and hoping. |
 | **AI-agent ready**      | `init` ships `.claude/skills/.../SKILL.md` and `.codex/skills/.../SKILL.md` pinned to your installed CLI version. Includes exit-code semantics, error code reference, and JSON envelope contract. |
 | **Headless or GUI**     | Runs under `--headless` for CI, or with a real window for visual debugging. |
 | **Cross-platform**      | Linux, macOS, and native Windows (no WSL). |
@@ -159,12 +156,15 @@ Every RPC has both a CLI subcommand and a `GameClient` method — pick whichever
 
 | Category | CLI | GameClient |
 |---|---|---|
-| Scene tree | `tree`, `children`, `exists`, `wait-node` | `get_scene_tree`, `get_children`, `node_exists`, `wait_for_node` |
-| Inspection | `get`, `text`, `visible` | `get_property`, `get_text`, `is_visible` |
+| Scene tree | `tree`, `children`, `exists` | `get_scene_tree`, `get_children`, `node_exists` |
+| Inspection | `get` (multi-prop = atomic same-frame read), `text`, `visible`, `sprite-info` | `get_property`, `get_properties`, `get_text`, `is_visible`, `sprite_info` |
 | Mutation   | `set`, `call`, `click` | `set_property`, `call_method`, `click` |
 | Input      | `press`, `release`, `tap`, `hold`, `combo`, `combo-cancel`, `release-all`, `pressed`, `actions` | `action_press`, `action_release`, `action_tap`, `hold`, `combo`, `combo_cancel`, `release_all`, `get_pressed`, `list_input_actions` |
-| Render     | `screenshot` (path required) | `screenshot` |
-| Timing     | `wait-time` | `wait_game_time` |
+| Waiting    | `wait-node`, `wait-prop`, `wait-signal`, `wait-frames`, `wait-time` | `wait_for_node`, `wait_property`, `wait_signal`, `wait_frames`, `wait_game_time` |
+| Scene isolation | `scene-reload`, `scene-change` | `scene_reload`, `scene_change` |
+| Time control | `time-scale`, `pause`, `unpause`, `step-frames` | `time_scale`, `pause`, `unpause`, `step_frames` |
+| Render     | `screenshot` (path required, `--node` crops to a node's screen rect) | `screenshot` |
+| Diagnostics | `errors` (structured `push_error` log, Godot 4.5+), `daemon logs` | `errors` |
 
 Full RPC reference (signatures, error codes, blacklist): [plugin README](addons/godot_cli_control/README.md#rpc-reference). Output contract & exit codes: see the AI Quickstart in any project's `.claude/skills/godot-cli-control/SKILL.md`.
 
@@ -213,11 +213,14 @@ If you don't want `init`, copy the plugin manually and enable it from the editor
 
 ## Recent changes
 
-- **Default daemon port is now OS-assigned (was 9877).** The actual port is written to `.cli_control/port`; CLI subcommands and `GameClient()` (no port arg) auto-discover it. External scripts that hardcoded `127.0.0.1:9877` should either read `.cli_control/port` or pass `--port 9877` explicitly to `daemon start`.
-- **New: `godot-cli-control daemon ls`** — list daemons across all projects.
-- **New: `godot-cli-control daemon stop --all`** / **`--project <path>`** — batch / cross-project stop.
-- **New: `godot-cli-control daemon start --idle-timeout 30m`** — opt-in: auto-shutdown the Godot process after N minutes of no RPC activity. Default off. A project-level default can live in `.cli_control/config.json` (`{"idle_timeout": "30m"}`); an explicit flag always wins.
-- **New: `GODOT_CLI_LONG_OP_TIMEOUT=<seconds>`** — raise the 600s client-side ceiling on long operations (e.g. recordings longer than 10 minutes). Non-positive / non-numeric values are ignored.
+- **Wait primitives:** `wait-prop` (poll a property until it matches, with `--op` / `--tolerance`), `wait-signal` (arm before triggering), `wait-frames` (deterministic frame advance) — replace sleep-and-hope polling.
+- **Scene isolation:** `scene-reload` / `scene-change` block until the new scene is ready; the pytest `fresh_scene` fixture gives each test a pristine scene.
+- **Time control:** `time-scale` (read/write `Engine.time_scale`), `pause` / `unpause`, and `step-frames` for deterministic stepping while paused.
+- **Visual-state assertions:** `sprite-info` aggregates a sprite's render state (effective atlas region, frame, flips, modulate) in one call; `screenshot --node` crops to a node's screen rect for pixel-level asserts.
+- **Diagnostics:** `errors` queries structured `push_error` / `push_warning` logs with a cursor (Godot 4.5+); `daemon logs --tail N` reads the daemon log even post-mortem; pytest gains `no_push_errors` (fail on silent errors) and automatic failure screenshots.
+- **BREAKING (0.2.x):** `get` returns compound Variants (Vector2, Color, …) as `{"value": [x, y], "type": "Vector2"}` instead of the old `"(x, y)"` string — the `value` layout round-trips into `set`. `get <path> <prop1> <prop2>` reads multiple properties atomically in one frame.
+
+Full history: [`CHANGELOG`](addons/godot_cli_control/CHANGELOG.md).
 
 ## Status
 

--- a/python/README.md
+++ b/python/README.md
@@ -80,7 +80,10 @@ def test_jump(godot_daemon, bridge):
 ```
 
 - `godot_daemon` (session-scoped) starts headless Godot once and stops it after all tests; if a daemon is already running it's reused (and not stopped at teardown — keeps your IDE workflow alive).
-- `bridge` (function-scoped) gives a fresh `GameBridge`; on teardown it calls `release_all()` so a `hold` left behind by one case can't bleed into the next, then closes the connection.
+- `bridge` (function-scoped) gives a fresh `GameBridge`; on teardown it best-effort restores global engine state — `unpause()`, `time_scale` back to its setup-time snapshot, `release_all()` — so a `hold`/`pause`/speed-up left behind by one case can't bleed into the next, then closes the connection.
+- `fresh_scene` (function-scoped, opt-in) calls `scene_reload()` at setup so the case starts on a pristine scene. Node references cached before the reload are invalid afterwards.
+- `no_push_errors` (function-scoped, opt-in) records an `errors` marker at setup and fails the case if any new `push_error` was emitted during it (warnings don't fail). Requires Godot 4.5+ (Logger API) — older engines raise `RpcError` 1012 at setup, loudly.
+- On a test failure (non-headless daemon only) a best-effort screenshot is saved to `.cli_control/failures/<nodeid>.png` and the path is attached to the pytest report.
 
 CLI options:
 
@@ -88,6 +91,7 @@ CLI options:
 --godot-cli-port=N           # GameBridge port (default: read from .cli_control/port)
 --godot-cli-no-headless      # open a real Godot window
 --godot-cli-project-root=DIR # default: pytest rootdir
+--godot-cli-time-scale=X     # Engine.time_scale applied at daemon startup (e.g. 5 to speed up the suite)
 ```
 
 ## CLI
@@ -102,17 +106,20 @@ godot-cli-control daemon start --record --movie-path X [--fps N]   # 录制需�
 godot-cli-control daemon stop [--all | --project PATH]
 godot-cli-control daemon status
 godot-cli-control daemon ls                  # list running daemons across all projects
+godot-cli-control daemon logs [--tail N]     # last N lines of .cli_control/godot.log (works post-mortem)
 godot-cli-control run <script.py> [--headless ...]
 
 # Read
 godot-cli-control tree [depth]
-godot-cli-control get      <node_path> <prop>
+godot-cli-control get      <node_path> <prop> [prop2 ...]   # multi-prop = atomic same-frame read
 godot-cli-control text     <node_path>
 godot-cli-control exists   <node_path>      # exit 0=true, 1=false, 2=infra
 godot-cli-control visible  <node_path>      # exit 0=true, 1=false, 2=infra
 godot-cli-control children <node_path> [type-filter]
 godot-cli-control pressed
 godot-cli-control actions [--all]
+godot-cli-control sprite-info <node_path>   # Sprite2D/AnimatedSprite2D/TextureRect render state in one call
+godot-cli-control errors [--since MARKER] [--limit N]   # structured push_error/push_warning log (Godot 4.5+)
 
 # Write / call
 godot-cli-control set   <node_path> <prop>   <json-value>
@@ -127,21 +134,33 @@ godot-cli-control combo --steps-json '[...]'   # or `combo file.json` / `combo -
 godot-cli-control combo-cancel
 godot-cli-control release-all
 
-# Wait
-godot-cli-control wait-node <node_path> [timeout]   # exit 0=found, 1=timeout
-godot-cli-control wait-time <seconds>
+# Wait (exit 0=hit, 1=timeout)
+godot-cli-control wait-node   <node_path> [timeout]
+godot-cli-control wait-prop   <node_path> <prop> <value> [--op gt|lt|ge|le|ne] [--timeout S] [--tolerance T]
+godot-cli-control wait-signal <node_path> <signal> [timeout]   # arm BEFORE triggering the action
+godot-cli-control wait-frames <n> [--physics]
+godot-cli-control wait-time <seconds>        # game time — scales with time-scale
+
+# Scene isolation
+godot-cli-control scene-reload [--timeout S]            # reload current scene, block until ready
+godot-cli-control scene-change <res://path.tscn>        # switch scene, block until ready
+
+# Time control
+godot-cli-control time-scale [value]         # read (no arg) or set Engine.time_scale, (0, 100]
+godot-cli-control pause | unpause
+godot-cli-control step-frames <n> [--physics]   # deterministic stepping while paused
 
 # Render (path is required as of 0.2.0)
-godot-cli-control screenshot <output.png>
+godot-cli-control screenshot <output.png> [--node <node_path>]   # --node crops to that node's screen rect
 ```
 
 ### Output contract
 
 - success: `{"ok": true, "result": <data>}` on stdout, exit 0
-- error:   `{"ok": false, "error": {"code": N, "message": "..."}}` on stdout, exit 1 (RPC) or 2 (connection / usage)
+- error:   `{"ok": false, "error": {"code": N, "message": "..."}}` on stdout, exit 1 (RPC), 2 (connection / infra), or 64 (usage)
 - `--text` / `--no-json` switches back to the legacy human-readable strings; errors then go to stderr.
 
-`exists` / `visible` / `wait-node` propagate their boolean result to the exit code, so shell `if` works:
+`exists` / `visible` and the `wait-*` commands propagate their boolean / hit-or-timeout result to the exit code, so shell `if` works:
 
 ```bash
 if godot-cli-control exists /root/Main/Boss; then


### PR DESCRIPTION
## 背景

用户发现 PyPI 的 Project description 陈旧。排查结论：发布机制正常（PyPI 0.2.17 description 与 `python/README.md` 逐字节一致，由 `pyproject.toml` 的 `readme=` 注入），**陈旧的是 README 内容本身**——停留在 #133 之前，34 个子命令里 11 个没出现在 PyPI 页面上。

## 变更

### `python/README.md`（PyPI description 源）
- CLI 命令表补齐：`wait-prop` / `wait-signal` / `wait-frames`（#96/#97）、`scene-reload` / `scene-change`（#98）、`time-scale` / `pause` / `unpause` / `step-frames`（#102）、`sprite-info` + `screenshot --node`（#101）、`errors` + `daemon logs`（#103）、`get` 多属性原子读（#100）
- pytest 段补 `fresh_scene` / `no_push_errors` fixture、`bridge` teardown 还原 pause/time_scale（#124）、失败自动截图、`--godot-cli-time-scale` 选项
- Output contract 退出码修正：usage 错 2 → 64（#111 后的现状）

### `README.md`（GitHub 首页）
- 删除重复且标着 "BREAKING (unreleased)" 的第一个 Recent changes 段（该变更早已发版）
- 底部 Recent changes 刷新为 #96–#103 批次
- Highlights：21+ → 30+ subcommands，pytest 行补新 fixture，新增 Deterministic waits 行
- API at a glance 表新增 Waiting / Scene isolation / Time control / Diagnostics 四类

## 影响

纯文档变更，无代码改动。PyPI 页面在下次发版时自动追平。

🤖 Generated with [Claude Code](https://claude.com/claude-code)