### PR TITLE
feat: 同项目多实例 CLI 控制（命名实例）

### DIFF
--- a/.claude/skills/godot-cli-control/SKILL.md
+++ b/.claude/skills/godot-cli-control/SKILL.md
@@ -26,12 +26,19 @@ Pipe straight into `jq` or `json.loads`. Add `--text` (or `--no-json`) to switch
 # One-time per Godot project (already done if you're reading this file):
 godot-cli-control init
 
-# Per session:
+# Per session (single instance):
 godot-cli-control daemon start --headless         # boots Godot in the background
 godot-cli-control daemon status                   # exit 0 = running, 1 = stopped
 godot-cli-control tree 2 | jq .result             # confirm RPC works
 # ... your work ...
 godot-cli-control daemon stop
+
+# Per session (multiple instances, e.g. server + client):
+godot-cli-control daemon start --name server --headless
+godot-cli-control daemon start --name client1 --headless
+godot-cli-control --instance server tree 2 | jq .result
+godot-cli-control --instance client1 click /root/Game/JoinButton
+godot-cli-control daemon stop --all --project .
 ```
 
 > As of this version, `daemon start` autodetects headless mode by checking `stdout.isatty()`. Pipes, CI, and agent shell-outs run headless by default; an interactive terminal still gets a window. The explicit flags below are only needed to override: `--headless` forces headless even in a TTY; `--gui` forces a window even when stdout is piped.
@@ -59,22 +66,76 @@ fi
 ## Daemon management
 
 ```bash
-godot-cli-control daemon start             # boot daemon for cwd project
-godot-cli-control daemon start --time-scale 5  # start at 5× game speed (applies Engine.time_scale from frame 0)
-godot-cli-control daemon status            # exit 0 = running, 1 = stopped
-godot-cli-control daemon stop              # stop cwd-project daemon (rc 0; rc 2 = ffmpeg transcode failed)
+godot-cli-control daemon start                           # boot daemon for cwd project (instance "default")
+godot-cli-control daemon start --name server             # boot a named instance
+godot-cli-control daemon start --name client1 --port 0   # second instance on an OS-assigned port
+godot-cli-control daemon start --time-scale 5            # start at 5× game speed
+godot-cli-control daemon status                          # exit 0 = running, 1 = stopped
+godot-cli-control daemon status --name server            # status for a specific instance
+godot-cli-control daemon stop                            # stop cwd-project daemon (auto-selects if 1 running)
+godot-cli-control daemon stop --name server              # stop a named instance
 godot-cli-control daemon stop --project /path/to/other/godot/project
-godot-cli-control daemon stop --all        # stop every registered daemon; exit 3 if any failed
-godot-cli-control daemon ls                # list all running daemons (cross-project, walks the registry)
-godot-cli-control daemon logs --tail 50    # last N lines of godot.log (works after the daemon died, too)
+godot-cli-control daemon stop --all                      # stop every registered daemon; exit 3 if any failed
+godot-cli-control daemon stop --all --project /path/to/project  # stop all instances of one project
+godot-cli-control daemon ls                              # list all running daemons (cross-project, with instance column)
+godot-cli-control daemon logs --tail 50                  # last N lines of godot.log (works after the daemon died, too)
+godot-cli-control daemon logs --name server --tail 50    # logs for a specific instance
 ```
 
-- **`daemon status` payload when running**: `{"state": "running", "pid": N, "port": M}`.
-- **`daemon status` payload when stopped**: `{"state": "stopped"}`. If the previous launch wrote `.cli_control/godot.log` or recorded an exit code, the envelope also includes `"last_log": "<path>"` and/or `"last_exit_code": <int>` — use these to diagnose why the daemon died without manually grepping under `.cli_control/`.
-- **`daemon ls` payload**: `{"daemons": [{"project_root", "pid", "port", "started_at", "godot_bin", "log_path"}, ...]}`. Dead records (PID gone) are auto-pruned on each call, so this is the canonical list of *actually-alive* daemons across all projects on the machine.
-- **`daemon stop --all` payload**: `{"stopped": [{"project_root","pid","port","rc"[, "error"]}, ...], "rc": 0|3}`. Each entry's `rc` is the per-project stop result; the top-level `rc` is the aggregate exit code.
-- **`daemon logs [--tail N]` payload**: `{"path": "<godot.log>", "lines": [...], "returned": N}` (default 50, max 1000). Reads the file client-side — **no RPC**, so it works post-mortem after the daemon crashed or stopped (the companion to `daemon status`'s `last_log` hint: status tells you where the log is, `logs` hands you the tail directly). No log file yet → `-1006`, exit 2.
+- **`daemon status` payload when running**: `{"state": "running", "pid": N, "port": M, "instance": "<name>"}`.
+- **`daemon status` payload when stopped**: `{"state": "stopped"}`. If the previous launch wrote `.cli_control/instances/<name>/godot.log` or recorded an exit code, the envelope also includes `"last_log": "<path>"` and/or `"last_exit_code": <int>` — use these to diagnose why the daemon died without manually grepping under `.cli_control/`.
+- **`daemon ls` payload**: `{"daemons": [{"project_root", "pid", "port", "instance", "started_at", "godot_bin", "log_path"}, ...]}`. Dead records (PID gone) are auto-pruned on each call, so this is the canonical list of *actually-alive* daemons across all projects on the machine. Text output columns: `pid\tport\tinstance\tproject_root\tstarted_at`.
+- **`daemon stop --all` payload**: `{"stopped": [{"project_root","pid","port","instance","rc"[, "error"]}, ...], "rc": 0|3}`. Each entry's `rc` is the per-instance stop result; the top-level `rc` is the aggregate exit code.
+- **`daemon logs [--tail N]` payload**: `{"path": "<godot.log>", "lines": [...], "returned": N, "instance": "<name>"}` (default 50, max 1000). Reads the file client-side — **no RPC**, so it works post-mortem after the daemon crashed or stopped (the companion to `daemon status`'s `last_log` hint: status tells you where the log is, `logs` hands you the tail directly). No log file yet → `-1006`, exit 2.
 - **`daemon start --time-scale N`**: sets `Engine.time_scale = N` (range `(0, 100]`) from the very first frame of the Godot process. Useful to run an entire test suite at e.g. 5× speed. **Asymmetry**: `run <script>` mode does not support `--time-scale` as a startup flag — inside the script call `bridge.time_scale(5)` on the first line instead; or use `daemon start --time-scale 5` beforehand and connect the script to the already-running daemon.
+
+## Multi-instance (multiple daemons for one project)
+
+You can run more than one Godot instance per project — for example a "server" and a "client" connected to the same game.
+
+**Starting two instances:**
+
+```bash
+godot-cli-control daemon start --name server
+godot-cli-control daemon start --name client1
+```
+
+**Sending RPC to a specific instance** — use the top-level `--instance` flag (or `--name` inside `daemon` subcommands):
+
+```bash
+godot-cli-control --instance server click /root/Game/StartButton
+godot-cli-control --instance client1 get /root/Player position
+godot-cli-control --instance server daemon stop   # or: daemon stop --name server
+```
+
+**Stopping both:**
+
+```bash
+godot-cli-control daemon stop --name server
+godot-cli-control daemon stop --name client1
+# or in one shot:
+godot-cli-control daemon stop --all --project /path/to/project
+```
+
+**Target-selection semantics (same for all subcommands):**
+
+| Running instances | No `--instance` / `--name` | Explicit `--instance nope` |
+|---|---|---|
+| 0 | connects to "default" (legacy fallback) | error -1003, exit 64 |
+| 1 | auto-selects the single instance | error -1003, exit 64 |
+| ≥ 2 | **error -1003, exit 64** — lists names in message | error -1003, exit 64 |
+
+When ≥ 2 instances are running and you omit `--instance`, the error JSON is:
+
+```json
+{"ok": false, "error": {"code": -1003, "message": "multiple instances running: client1, server — pass --instance <name>"}}
+```
+
+— read the `message`, pick a name from the list, and re-run with `--instance <name>`.
+
+`--instance` (top-level) and `--name` (daemon subcommands) are equivalent; passing both with the same value is allowed, different values → -1003 conflict error. `--instance` and `--port` are mutually exclusive (both select which daemon to talk to).
+
+**Upgrade-period note**: if you have a legacy daemon started with an older version of the CLI (its pid/port files sit directly under `.cli_control/` instead of `.cli_control/instances/<name>/`), `daemon ls` may temporarily show two lines for the same project. Stop the legacy daemon and the extra line disappears — no manual file migration needed.
 
 ## JSON envelope examples
 
@@ -351,78 +412,84 @@ Key constraints:
 <!-- BEGIN cli_help (auto-generated by godot-cli-control init) -->
 ```
 $ godot-cli-control --help
-usage: godot-cli-control [-h] [-V] [--port PORT] [--json] [--text] [--no-json]
+usage: godot-cli-control [-h] [-V] [--port PORT | --instance INSTANCE]
+                         [--json] [--text] [--no-json]
                          <command> ...
 
 Godot CLI Control —— 通过命令行远程驱动 Godot 项目
 
 positional arguments:
   <command>
-    daemon        管理 Godot daemon 进程
-    run           启动 daemon → 跑脚本 → 停 daemon
-    init          在 Godot 项目根一键接入插件
-    click         对 Control/Button 节点触发点击。
-    screenshot    截屏并写 PNG 文件。**路径必填**（旧版本可省、把 base64 喷到 stdout —— 已删，避免撑爆 AI
-                  上下文）。
-    sprite-info   渲染态聚合查询（issue #101）：Sprite2D / AnimatedSprite2D /
-                  TextureRect 的 texture、实际图集区域（effective_region /
-                  frame_texture）、翻转、帧号、modulate、visible 一次拿齐。纯属性读，headless
-                  可用。非 sprite 类节点 → 1010。
-    errors        结构化查询运行期捕获的 push_error / push_warning（issue #103）。返回
-                  {errors, marker, dropped, truncated}；--since 传上次 marker
-                  只看新增（「本用例期间应零 push_error」断言的原语），--limit 0 纯拿基线。需 Godot
-                  4.5+（Logger API），老引擎报 1012。
-    tree          dump 当前场景树为 JSON。
-    press         按下输入动作（持续按住，需配 release 释放）。
-    release       释放之前 press 按下的输入动作。
-    tap           短按动作（press → 等待 → release）。默认异步立即返回；加 --wait 阻塞到时长结束。
-    hold          按住动作指定时长（秒），到点自动释放。默认命令立即返回（动作在游戏里持续该时长）；要读动作完成后的状态请加
-                  --wait（或命令后先 wait-time <时长>）。
-    combo         依次执行一段输入动作。三种喂法：位置 ``<file.json>`` / 位置 ``-`` (stdin) /
-                  ``--steps-json '[...]'``。
-    release-all   释放所有当前持有的输入动作。
-    get           读节点属性（1 个或多个；多个时服务端同帧原子读，issue #100）。复合类型（Vector2 等）返回与 set
-                  同 schema 的数组 + type 字段，可直接回灌 set（issue #99）。支持 sub-
-                  path：position:x。
-    set           写节点属性。value 优先按 JSON 解析（数字/数组/对象），失败退回字符串。加 --text-value 强制把
-                  value 当字符串，避开 null/true/false/数字 footgun。
-    call          调节点方法。每个参数同 set：先 JSON 解析，失败退回字符串。返回值原样（同 ``get`` 渲染规则）。
-    text          读 Label / Button 的 text（get_text 的便捷形式）。
-    exists        节点是否存在。退出码：0=true, 1=false, 2=连接/超时错误。shell ``if godot-cli-
-                  control exists /root/Foo; then …`` 可用。
-    visible       节点是否可见。退出码同 exists：0=true, 1=false, 2=infra error。
-    children      列出节点的直接子节点（一层）。
-    wait-node     轮询直到节点出现（或 timeout）。退出码：0=found, 1=timeout, 2=infra error。
-    wait-time     按 game time 等待 N 秒（在 --write-movie 模式下与录像帧对齐）。
-    wait-prop     逐帧轮询直到属性满足条件（或 timeout）。退出码：0=命中, 1=超时, 2=infra error。超时返回
-                  reason（timeout/node_not_found/property_not_found）+
-                  最后读到的值，便于诊断 typo。
-    wait-signal   等信号发射（或 timeout），命中带回编码后的信号参数。退出码：0=命中, 1=超时, 2=infra
-                  error。注意：必须先挂等待再触发动作（见 SKILL.md pitfall）。
-    wait-frames   等 N 个 process 帧（--physics 等物理帧）。确定性帧推进，替代短 sleep。
-    scene-reload  重载当前场景并阻塞到新场景 ready（per-test 隔离原语）。失败（无 current scene / 超时）报
-                  1008，exit 1。注意：返回后此前缓存的所有节点路径/引用全部失效。
-    scene-change  切换到指定场景并阻塞到新场景 ready。路径不存在/加载失败/超时 报 1008，exit 1。
-    time-scale    读 / 写 Engine.time_scale（无参 = 读）。wait-time 按 game time
-                  计，倍速后语义不变、墙钟变快。合法域 (0, 100]。注意：--record 下仍生效，录出的是加速画面。
-    pause         暂停 SceneTree（get_tree().paused = true）。幂等；返回 {"paused":
-                  true}。
-    unpause       恢复 SceneTree（paused = false）。幂等；返回 {"paused": false}。
-    step-frames   paused 状态下确定性推进 N 帧再停（物理断言银弹：推 N 个物理帧后状态必然确定）。必须先 pause，否则报
-                  1009，exit 1。
-    pressed       列出当前模拟器持有的输入动作（press + held 去重合并）。
-    combo-cancel  取消正在运行的 combo（不影响 press/hold）。
-    actions       列出运行项目的 InputMap 动作。默认过滤 ui_* 内置；加 ``--all`` 看全。
+    daemon             管理 Godot daemon 进程
+    run                启动 daemon → 跑脚本 → 停 daemon
+    init               在 Godot 项目根一键接入插件
+    click              对 Control/Button 节点触发点击。
+    screenshot         截屏并写 PNG 文件。**路径必填**（旧版本可省、把 base64 喷到 stdout ——
+                       已删，避免撑爆 AI 上下文）。
+    sprite-info        渲染态聚合查询（issue #101）：Sprite2D / AnimatedSprite2D /
+                       TextureRect 的 texture、实际图集区域（effective_region /
+                       frame_texture）、翻转、帧号、modulate、visible
+                       一次拿齐。纯属性读，headless 可用。非 sprite 类节点 → 1010。
+    errors             结构化查询运行期捕获的 push_error / push_warning（issue #103）。返回
+                       {errors, marker, dropped, truncated}；--since 传上次 marker
+                       只看新增（「本用例期间应零 push_error」断言的原语），--limit 0 纯拿基线。需 Godot
+                       4.5+（Logger API），老引擎报 1012。
+    tree               dump 当前场景树为 JSON。
+    press              按下输入动作（持续按住，需配 release 释放）。
+    release            释放之前 press 按下的输入动作。
+    tap                短按动作（press → 等待 → release）。默认异步立即返回；加 --wait 阻塞到时长结束。
+    hold               按住动作指定时长（秒），到点自动释放。默认命令立即返回（动作在游戏里持续该时长）；要读动作完成后的状态请加
+                       --wait（或命令后先 wait-time <时长>）。
+    combo              依次执行一段输入动作。三种喂法：位置 ``<file.json>`` / 位置 ``-`` (stdin) /
+                       ``--steps-json '[...]'``。
+    release-all        释放所有当前持有的输入动作。
+    get                读节点属性（1 个或多个；多个时服务端同帧原子读，issue #100）。复合类型（Vector2 等）返回与
+                       set 同 schema 的数组 + type 字段，可直接回灌 set（issue #99）。支持 sub-
+                       path：position:x。
+    set                写节点属性。value 优先按 JSON 解析（数字/数组/对象），失败退回字符串。加 --text-
+                       value 强制把 value 当字符串，避开 null/true/false/数字 footgun。
+    call               调节点方法。每个参数同 set：先 JSON 解析，失败退回字符串。返回值原样（同 ``get``
+                       渲染规则）。
+    text               读 Label / Button 的 text（get_text 的便捷形式）。
+    exists             节点是否存在。退出码：0=true, 1=false, 2=连接/超时错误。shell ``if godot-
+                       cli-control exists /root/Foo; then …`` 可用。
+    visible            节点是否可见。退出码同 exists：0=true, 1=false, 2=infra error。
+    children           列出节点的直接子节点（一层）。
+    wait-node          轮询直到节点出现（或 timeout）。退出码：0=found, 1=timeout, 2=infra
+                       error。
+    wait-time          按 game time 等待 N 秒（在 --write-movie 模式下与录像帧对齐）。
+    wait-prop          逐帧轮询直到属性满足条件（或 timeout）。退出码：0=命中, 1=超时, 2=infra
+                       error。超时返回
+                       reason（timeout/node_not_found/property_not_found）+
+                       最后读到的值，便于诊断 typo。
+    wait-signal        等信号发射（或 timeout），命中带回编码后的信号参数。退出码：0=命中, 1=超时, 2=infra
+                       error。注意：必须先挂等待再触发动作（见 SKILL.md pitfall）。
+    wait-frames        等 N 个 process 帧（--physics 等物理帧）。确定性帧推进，替代短 sleep。
+    scene-reload       重载当前场景并阻塞到新场景 ready（per-test 隔离原语）。失败（无 current scene /
+                       超时）报 1008，exit 1。注意：返回后此前缓存的所有节点路径/引用全部失效。
+    scene-change       切换到指定场景并阻塞到新场景 ready。路径不存在/加载失败/超时 报 1008，exit 1。
+    time-scale         读 / 写 Engine.time_scale（无参 = 读）。wait-time 按 game time
+                       计，倍速后语义不变、墙钟变快。合法域 (0, 100]。注意：--record 下仍生效，录出的是加速画面。
+    pause              暂停 SceneTree（get_tree().paused = true）。幂等；返回 {"paused":
+                       true}。
+    unpause            恢复 SceneTree（paused = false）。幂等；返回 {"paused": false}。
+    step-frames        paused 状态下确定性推进 N 帧再停（物理断言银弹：推 N 个物理帧后状态必然确定）。必须先
+                       pause，否则报 1009，exit 1。
+    pressed            列出当前模拟器持有的输入动作（press + held 去重合并）。
+    combo-cancel       取消正在运行的 combo（不影响 press/hold）。
+    actions            列出运行项目的 InputMap 动作。默认过滤 ui_* 内置；加 ``--all`` 看全。
 
 options:
-  -h, --help      show this help message and exit
-  -V, --version   show program's version number and exit
-  --port PORT     RPC 子命令连接的 GameBridge 端口（默认从 .cli_control/port 读取，否则
-                  9877）。注意：仅作用于 RPC 子命令，daemon start / run 启动 daemon 时请用其各自的
-                  --port。
-  --json          输出 JSON 信封（默认）
-  --text          输出旧的人类可读字符串（不再加信封；errors 走 stderr）
-  --no-json       --text 别名
+  -h, --help           show this help message and exit
+  -V, --version        show program's version number and exit
+  --port PORT          RPC 子命令连接的 GameBridge 端口（默认从 .cli_control/port 读取，否则
+                       9877）。注意：仅作用于 RPC 子命令，daemon start / run 启动 daemon
+                       时请用其各自的 --port。
+  --instance INSTANCE  目标实例名；RPC 与 run/daemon 子命令通用（daemon 子命令的 --name
+                       是等价写法）。多实例并行时必传；与 --port 互斥。
+  --json               输出 JSON 信封（默认）
+  --text               输出旧的人类可读字符串（不再加信封；errors 走 stderr）
+  --no-json            --text 别名
 
 命令分组：
 
@@ -477,8 +544,8 @@ usage: godot-cli-control daemon start [-h] [--record]
                                       [--headless | --gui] [--fps FPS]
                                       [--port PORT]
                                       [--idle-timeout IDLE_TIMEOUT]
-                                      [--time-scale TIME_SCALE] [--json]
-                                      [--text] [--no-json]
+                                      [--name NAME] [--time-scale TIME_SCALE]
+                                      [--json] [--text] [--no-json]
 
 启动 Godot daemon 并写入 .cli_control/{godot.pid,port}。
 
@@ -497,6 +564,7 @@ options:
                         空闲超时（如 30m / 2h / 90s / 0=关闭，默认关）。开启后 Godot 端 Timer 自动
                         quit。不传时回退读 .cli_control/config.json 的
                         idle_timeout（issue #44），省得每次手敲。
+  --name NAME           实例名（默认 default；多实例并行时用于选靶，等价顶层 --instance；两者同时传值须一致）
   --time-scale TIME_SCALE
                         启动即设 Engine.time_scale（>0 且 <=100），整套 e2e 提速用
   --json                输出 JSON 信封（默认）
@@ -504,50 +572,60 @@ options:
   --no-json             --text 别名
 
 $ godot-cli-control daemon stop --help
-usage: godot-cli-control daemon stop [-h] [--all | --project PROJECT] [--json]
-                                     [--text] [--no-json]
+usage: godot-cli-control daemon stop [-h] [--all] [--project PROJECT]
+                                     [--name NAME] [--json] [--text]
+                                     [--no-json]
 
-停止 daemon。无 flag 时停 cwd 项目；--all 停所有注册的 daemon；--project <path> 停指定项目。
+停止 daemon。无 flag 时停 cwd 项目（自动选靶：若 cwd 有多实例须加 --name）；--all 停所有注册的
+daemon；--project <path> 停指定项目；--name <inst> 选靶指定实例（与 --all 互斥）。
 
 options:
   -h, --help         show this help message and exit
-  --all              停止注册表中所有运行中的 daemon
+  --all              停止注册的所有 daemon（配合 --project 可限定项目）
   --project PROJECT  停止指定项目根的 daemon（绝对/相对路径均可）
+  --name NAME        实例名（默认 default；多实例并行时用于选靶，等价顶层 --instance；两者同时传值须一致）
   --json             输出 JSON 信封（默认）
   --text             输出旧的人类可读字符串（不再加信封；errors 走 stderr）
   --no-json          --text 别名
 
 $ godot-cli-control daemon status --help
-usage: godot-cli-control daemon status [-h] [--json] [--text] [--no-json]
+usage: godot-cli-control daemon status [-h] [--name NAME] [--json] [--text]
+                                       [--no-json]
 
-打印 daemon 状态到 stdout 并以 exit code 表示：0 = 运行中（输出 running pid=<pid>
-port=<port>），1 = 未运行（输出 stopped）。默认输出 JSON 信封；加 --text 切回旧的字符串格式。
+打印 daemon 状态到 stdout 并以 exit code 表示：0 = 运行中（输出 running pid=<pid> port=<port>
+instance=<name>），1 = 未运行（输出 stopped）。多实例时用 --name 选靶；若只有一个实例在跑则自动选中。默认输出 JSON
+信封；加 --text 切回旧的字符串格式。
 
 options:
-  -h, --help  show this help message and exit
-  --json      输出 JSON 信封（默认）
-  --text      输出旧的人类可读字符串（不再加信封；errors 走 stderr）
-  --no-json   --text 别名
+  -h, --help   show this help message and exit
+  --name NAME  实例名（默认 default；多实例并行时用于选靶，等价顶层 --instance；两者同时传值须一致）
+  --json       输出 JSON 信封（默认）
+  --text       输出旧的人类可读字符串（不再加信封；errors 走 stderr）
+  --no-json    --text 别名
 
 $ godot-cli-control daemon logs --help
-usage: godot-cli-control daemon logs [-h] [--tail N] [--json] [--text]
-                                     [--no-json]
+usage: godot-cli-control daemon logs [-h] [--tail N] [--name NAME] [--json]
+                                     [--text] [--no-json]
 
 直接输出 .cli_control/godot.log 的最后 N 行（JSON 信封包裹），免去先 daemon status 拿路径再
-tail。纯客户端读文件：daemon 已退出时同样可用（post-mortem 排查启动失败/崩溃）。无日志文件 → -1006，exit 2。
+tail。纯客户端读文件：daemon 已退出时同样可用（post-mortem 排查启动失败/崩溃）。多实例时用 --name 选靶。无日志文件 →
+-1006，exit 2。
 
 options:
-  -h, --help  show this help message and exit
-  --tail N    返回最后 N 行（1..1000，默认 50）
-  --json      输出 JSON 信封（默认）
-  --text      输出旧的人类可读字符串（不再加信封；errors 走 stderr）
-  --no-json   --text 别名
+  -h, --help   show this help message and exit
+  --tail N     返回最后 N 行（1..1000，默认 50）
+  --name NAME  实例名（默认 default；多实例并行时用于选靶，等价顶层 --instance；两者同时传值须一致）
+  --json       输出 JSON 信封（默认）
+  --text       输出旧的人类可读字符串（不再加信封；errors 走 stderr）
+  --no-json    --text 别名
 
 $ godot-cli-control daemon ls --help
 usage: godot-cli-control daemon ls [-h] [--json] [--text] [--no-json]
 
 扫描全局注册表（POSIX ~/.local/state/godot-cli-control/daemons/；Windows
-%LOCALAPPDATA%\godot-cli-control\daemons\），列出所有探活通过的 daemon。死记录会被自动清理。
+%LOCALAPPDATA%\godot-cli-control\daemons\），列出所有探活通过的
+daemon。死记录会被自动清理。JSON：{"daemons": [{"pid", "port", "instance", "project_root",
+...}]}；Text：每行 pid\tport\tinstance\tproject_root\tstarted_at。
 
 options:
   -h, --help  show this help message and exit
@@ -558,8 +636,8 @@ options:
 $ godot-cli-control run --help
 usage: godot-cli-control run [-h] [--record] [--movie-path MOVIE_PATH]
                              [--headless | --gui] [--fps FPS] [--port PORT]
-                             [--idle-timeout IDLE_TIMEOUT] [--no-gui-auto]
-                             [--json] [--text] [--no-json]
+                             [--idle-timeout IDLE_TIMEOUT] [--name NAME]
+                             [--no-gui-auto] [--json] [--text] [--no-json]
                              script
 
 若 daemon 未运行则先启动，加载用户脚本调用其 run(bridge) 函数，脚本结束后停掉刚启动的 daemon（已在跑的 daemon 保持原状）。脚本里抛任何异常都会以 exit code 1 退出并打印 traceback。
@@ -582,6 +660,7 @@ options:
                         空闲超时（如 30m / 2h / 90s / 0=关闭，默认关）。开启后 Godot 端 Timer 自动
                         quit。不传时回退读 .cli_control/config.json 的
                         idle_timeout（issue #44），省得每次手敲。
+  --name NAME           实例名（默认 default；多实例并行时用于选靶，等价顶层 --instance；两者同时传值须一致）
   --no-gui-auto         禁用脚本静态检测自动 GUI。默认含 screenshot 调用的脚本在非 TTY （subagent /
                         pipe / CI）下也强制开窗 —— headless dummy renderer 拿不到
                         viewport texture，截图会 1006 fail。
@@ -1243,7 +1322,7 @@ options:
 
 ## Python `GameClient` API
 
-`from godot_cli_control.client import GameClient` — async WebSocket client; use as `async with GameClient() as client:`. **With no `port` argument it auto-discovers from `.cli_control/port`** (the same file the daemon writes and the CLI reads), falling back to `9877` if absent — so a no-arg `GameClient()` connects to a running daemon out of the box. Pass `GameClient(port=N)` only to override. (`GameBridge()` in `run` scripts auto-discovers identically.) **Every method below has a 1-line CLI equivalent above; only reach for Python when you need to keep a client open across many steps without the connection-per-call overhead.**
+`from godot_cli_control.client import GameClient` — async WebSocket client; use as `async with GameClient() as client:`. **With no `port` argument it auto-discovers from `.cli_control/instances/<name>/port`** (the same file the daemon writes and the CLI reads), falling back to `9877` if absent — so a no-arg `GameClient()` connects to a running daemon out of the box. Pass `GameClient(port=N)` to override with an explicit port, or `GameClient(instance="server")` to target a named instance (when `port=None`, `instance` takes effect; explicit `port` wins). (`GameBridge(instance="server")` in `run` scripts works identically.) **Every method below has a 1-line CLI equivalent above; only reach for Python when you need to keep a client open across many steps without the connection-per-call overhead.**
 
 Errors raise `RpcError(code, message)` (a `RuntimeError` subclass) that preserves the server's error code — useful for retrying `1004 "combo in progress"`.
 
@@ -1353,6 +1432,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 
 ## Common pitfalls
 
+- **Multiple instances running and you forgot `--instance`** — exit 64 / code `-1003`, message lists all running instance names: `"multiple instances running: client1, server — pass --instance <name>"`. Read the message, pick the name you want, and re-run with `godot-cli-control --instance <name> <subcommand>`. The same applies to `daemon` subcommands (use `--name <instance>` instead of `--instance`).
 - **`{"ok": false, "error": {"code": -1001, ...}}` on every RPC** — daemon isn't running. Run `godot-cli-control daemon status` to confirm, then `daemon start`.
 - **Node paths must be absolute** — start with `/root/...`. Relative paths return `node not found`.
 - **`InvalidMessage` / `did not receive a valid HTTP response`** — `all_proxy` / `http_proxy` env var is hijacking localhost. The client sets `proxy=None` to defend, but if you see weird handshake errors, `unset all_proxy` first.
@@ -1389,4 +1469,4 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 
 ---
 
-Generated from godot-cli-control v0.2.16.dev0+g206cc6f53.d20260605. Re-run `godot-cli-control init --skills-only` to refresh.
+Generated from godot-cli-control v0.2.17. Re-run `godot-cli-control init --skills-only` to refresh.

--- a/.claude/skills/godot-cli-control/SKILL.md
+++ b/.claude/skills/godot-cli-control/SKILL.md
@@ -53,7 +53,7 @@ godot-cli-control daemon stop --all --project .
 | 1 | RPC error (server returned `{"error":...}`); also `exists`/`visible`=false, `wait-node`/`wait-prop`/`wait-signal`=timeout, `daemon status`=stopped |
 | 2 | Connection / IO error (daemon not running) or infra pre-condition failure (daemon failed to start, `daemon stop` encountered a system error — these carry client code `-1006`). Also: **`daemon stop` returns 2** when the daemon stopped cleanly but `ffmpeg` transcode of the recorded `.avi`→`.mp4` failed — the raw `.avi` is kept and `.cli_control/ffmpeg.log` has the details. `run <script>` propagates this: a successful script + failed transcode still exits 2. |
 | 3 | `daemon stop --all` partial failure: at least one daemon in the registry failed to stop. Per-record `rc` is in the JSON `result.stopped[]`. |
-| 64 | Usage error — argparse parse failure (missing / invalid args, unknown subcommand), a pre-flight reject caught before connecting (`combo` with no steps / malformed `--steps-json` / `combo -` from a TTY, `hold` with a non-positive duration), a bad runtime argument (`tap` / `wait-time` given a non-number, a `set`/`call` value that fails JSON parsing), **or** `run <script>` given a non-existent path / a script with no `run(bridge)` function. All carry client code `-1003` and consistently exit 64 (#82 / #111). |
+| 64 | Usage error — argparse parse failure (missing / invalid args, unknown subcommand), a pre-flight reject caught before connecting (`combo` with no steps / malformed `--steps-json` / `combo -` from a TTY, `hold` with a non-positive duration), a bad runtime argument (`tap` / `wait-time` given a non-number, a `set`/`call` value that fails JSON parsing), **or** `run <script>` given a non-existent path / a script with no `run(bridge)` function, **or** a multi-instance targeting error (≥ 2 instances running without `--instance` / `--name`, an explicitly named instance that is not running, or `--instance` and `--name` given conflicting values). All carry client code `-1003` and consistently exit 64 (#82 / #111). |
 
 Shell-`if` works:
 
@@ -114,7 +114,7 @@ godot-cli-control --instance server daemon stop   # or: daemon stop --name serve
 godot-cli-control daemon stop --name server
 godot-cli-control daemon stop --name client1
 # or in one shot:
-godot-cli-control daemon stop --all --project /path/to/project
+godot-cli-control daemon stop --all --project .
 ```
 
 **Target-selection semantics (same for all subcommands):**
@@ -124,6 +124,8 @@ godot-cli-control daemon stop --all --project /path/to/project
 | 0 | connects to "default" (legacy fallback) | error -1003, exit 64 |
 | 1 | auto-selects the single instance | error -1003, exit 64 |
 | ≥ 2 | **error -1003, exit 64** — lists names in message | error -1003, exit 64 |
+
+> **Note**: "forgot `--instance`" (≥ 2 running, none selected) and "named instance not running" are two distinct error cases with different messages. When an explicit `--instance <name>` refers to an instance that is not running, the error message includes the list of currently-running instance names so you can pick a valid target without a separate `daemon ls` call.
 
 When ≥ 2 instances are running and you omit `--instance`, the error JSON is:
 
@@ -1469,4 +1471,4 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 
 ---
 
-Generated from godot-cli-control v0.2.17. Re-run `godot-cli-control init --skills-only` to refresh.
+Generated from godot-cli-control v0.2.19.dev15+gf9998d303. Re-run `godot-cli-control init --skills-only` to refresh.

--- a/.claude/skills/godot-cli-control/SKILL.md
+++ b/.claude/skills/godot-cli-control/SKILL.md
@@ -484,9 +484,10 @@ positional arguments:
 options:
   -h, --help           show this help message and exit
   -V, --version        show program's version number and exit
-  --port PORT          RPC 子命令连接的 GameBridge 端口（默认从 .cli_control/port 读取，否则
-                       9877）。注意：仅作用于 RPC 子命令，daemon start / run 启动 daemon
-                       时请用其各自的 --port。
+  --port PORT          RPC 子命令连接的 GameBridge 端口（默认从
+                       .cli_control/instances/<name>/port 读取，legacy
+                       .cli_control/port 作为 fallback，否则 9877）。注意：仅作用于 RPC
+                       子命令，daemon start / run 启动 daemon 时请用其各自的 --port。
   --instance INSTANCE  目标实例名；RPC 与 run/daemon 子命令通用（daemon 子命令的 --name
                        是等价写法）。多实例并行时必传；与 --port 互斥。
   --json               输出 JSON 信封（默认）
@@ -542,9 +543,8 @@ options:
 
 $ godot-cli-control daemon start --help
 usage: godot-cli-control daemon start [-h] [--record]
-                                      [--movie-path MOVIE_PATH]
-                                      [--headless | --gui] [--fps FPS]
-                                      [--port PORT]
+                                      [--movie-path MOVIE_PATH] [--headless |
+                                      --gui] [--fps FPS] [--port PORT]
                                       [--idle-timeout IDLE_TIMEOUT]
                                       [--name NAME] [--time-scale TIME_SCALE]
                                       [--json] [--text] [--no-json]
@@ -561,7 +561,8 @@ options:
                         agent）。与 --record 互斥（录制需真实渲染器）。
   --gui                 强制开窗。覆盖 isatty 自动判（例如 stdout 是 pipe 仍想看到窗口）。
   --fps FPS             录制帧率，默认 30
-  --port PORT           GameBridge 监听端口（默认 0 = OS 自动分配；写入 .cli_control/port）
+  --port PORT           GameBridge 监听端口（默认 0 = OS 自动分配；写入
+                        .cli_control/instances/<name>/port）
   --idle-timeout IDLE_TIMEOUT
                         空闲超时（如 30m / 2h / 90s / 0=关闭，默认关）。开启后 Godot 端 Timer 自动
                         quit。不传时回退读 .cli_control/config.json 的
@@ -657,7 +658,8 @@ options:
                         agent）。与 --record 互斥（录制需真实渲染器）。
   --gui                 强制开窗。覆盖 isatty 自动判（例如 stdout 是 pipe 仍想看到窗口）。
   --fps FPS             录制帧率，默认 30
-  --port PORT           GameBridge 监听端口（默认 0 = OS 自动分配；写入 .cli_control/port）
+  --port PORT           GameBridge 监听端口（默认 0 = OS 自动分配；写入
+                        .cli_control/instances/<name>/port）
   --idle-timeout IDLE_TIMEOUT
                         空闲超时（如 30m / 2h / 90s / 0=关闭，默认关）。开启后 Godot 端 Timer 自动
                         quit。不传时回退读 .cli_control/config.json 的
@@ -1414,7 +1416,7 @@ Pytest CLI options the plugin adds:
 
 | Option | Default | Purpose |
 |---|---|---|
-| `--godot-cli-port` | `(auto)` | GameBridge port. Default: read from `.cli_control/port` (which the daemon writes when it starts). |
+| `--godot-cli-port` | `(auto)` | GameBridge port. Default: read from `.cli_control/instances/<name>/port` (which the daemon writes when it starts); legacy `.cli_control/port` is read as fallback. |
 | `--godot-cli-no-headless` | off (i.e. headless) | Drop `--headless`, open a real Godot window |
 | `--godot-cli-project-root` | `pytest rootdir` | Override the Godot project root |
 | `--godot-cli-time-scale` | `None` (engine default = 1.0) | Set `Engine.time_scale` at daemon startup (e.g. `5` to run the whole suite at 5× speed). Passed as `--cli-time-scale=N` to Godot; valid range `(0, 100]`. |
@@ -1441,7 +1443,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **Daemon won't start** — check `.cli_control/godot_bin` exists and points at a real Godot 4 binary, or `export GODOT_BIN=/path/to/godot`. See `godot-cli-control init -h` for the full lookup chain.
 - **Output flags work in any position** — `--json` / `--text` / `--no-json` are accepted both before and after subcommands as of this fix.
 - **There are two independent `--port` flags — don't confuse them:**
-  - Top-level `godot-cli-control --port N <subcommand>`: the GameBridge port an RPC subcommand connects to (auto-discovered from `.cli_control/port`; override only when needed). **Must come before the subcommand.**
+  - Top-level `godot-cli-control --port N <subcommand>`: the GameBridge port an RPC subcommand connects to (auto-discovered from `.cli_control/instances/<name>/port`; legacy `.cli_control/port` is read as fallback; override only when needed). **Must come before the subcommand.**
   - `daemon start --port N`: the port the daemon itself listens on. This is a local flag of `start`, so — like any other `daemon` flag — its position doesn't matter.
 - **`combo` rejects everything with `1004`** — a combo is already running. Call `combo-cancel` (or `release-all`) to abort.
 - **`hold` / `press` persist after the command returns** — by design. Each CLI command is its own short-lived connection that closes *cleanly*, and a clean close does **not** release inputs. `hold <action> <dur>` auto-releases after `<dur>` seconds (its timer keeps running in the daemon); a sticky `press <action>` stays held until you call `release <action>` / `release-all` (or the daemon's idle-timeout shuts it down). If a character looks stuck moving, you probably left a `press` dangling — run `release-all`. (An *abnormal* drop — your client crashing or being killed mid-session — does trigger a safety `release-all`, so stuck keys can't outlive a dead client.)

--- a/.claude/skills/godot-cli-control/SKILL.md
+++ b/.claude/skills/godot-cli-control/SKILL.md
@@ -543,8 +543,9 @@ options:
 
 $ godot-cli-control daemon start --help
 usage: godot-cli-control daemon start [-h] [--record]
-                                      [--movie-path MOVIE_PATH] [--headless |
-                                      --gui] [--fps FPS] [--port PORT]
+                                      [--movie-path MOVIE_PATH]
+                                      [--headless | --gui] [--fps FPS]
+                                      [--port PORT]
                                       [--idle-timeout IDLE_TIMEOUT]
                                       [--name NAME] [--time-scale TIME_SCALE]
                                       [--json] [--text] [--no-json]
@@ -1473,4 +1474,4 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 
 ---
 
-Generated from godot-cli-control v0.2.19.dev15+gf9998d303. Re-run `godot-cli-control init --skills-only` to refresh.
+Generated from godot-cli-control v0.2.19.dev19+g7b3d89e6a. Re-run `godot-cli-control init --skills-only` to refresh.

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## [Unreleased]
 
+### Added
+- **同项目多实例（命名实例）**：`daemon start --name <inst>`（默认 `default`）可在同一项目下并行启动多个 Godot daemon；顶层 `--instance <name>` 对所有 RPC / run / daemon 子命令通用，daemon 子命令的 `--name` 是等价写法（#多实例）。
+- **状态布局迁移 `.cli_control/instances/<name>/`**：daemon 的 pid / port / log 文件从项目根平铺改为按实例子目录存放。legacy 平铺路径（旧格式 `<hash>.json` 注册记录 + `.cli_control/port` 等）仅作只读 fallback 兼容，升级期间无需手工迁移；停掉旧 daemon 后文件自动收敛。
+- **`daemon ls` 新增 instance 列**：JSON 每条 `result.daemons[]` 含 `"instance"` 字段；text 输出格式改为 `pid\tport\tinstance\tproject_root\tstarted_at`。
+- **`daemon stop --all --project <path>`**：限定停某个项目下的全部实例（原 `--all` 不带 `--project` 仍停全局所有项目的所有实例）。
+- **daemon 各子命令的 JSON envelope result 带 `"instance"` 字段**：`start` / `stop` / `status` / `logs` 均在 result 中增加 `"instance"` 键，便于 agent 确认操作目标。
+- **`GameBridge(instance=...)` / `GameClient(instance=...)`**：`port=None` 时 `instance` 参数生效，自动查找对应命名实例的端口；显式 `port` 优先（向后兼容）。
+
+### Changed
+- **多实例选靶语义（处处一致）**：0 个在跑 → 选 default（legacy fallback）；1 个在跑 → 自动选中；≥2 个在跑且未指定 `--instance` / `--name` → `-1003` / exit 64，message 列出在跑实例名（`"multiple instances running: ... — pass --instance <name>"`）。显式 `--instance nope` 但该实例未在跑 → `-1003` / exit 64，message 附当前在跑实例列表。`--instance` 与 `--port` 互斥。
+
 ## [0.2.17] - 2026-06-06
 
 ### Fixed

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -7,8 +7,8 @@
 ## [Unreleased]
 
 ### Added
-- **同项目多实例（命名实例）**：`daemon start --name <inst>`（默认 `default`）可在同一项目下并行启动多个 Godot daemon；顶层 `--instance <name>` 对所有 RPC / run / daemon 子命令通用，daemon 子命令的 `--name` 是等价写法（#多实例）。
-- **状态布局迁移 `.cli_control/instances/<name>/`**：daemon 的 pid / port / log 文件从项目根平铺改为按实例子目录存放。legacy 平铺路径（旧格式 `<hash>.json` 注册记录 + `.cli_control/port` 等）仅作只读 fallback 兼容，升级期间无需手工迁移；停掉旧 daemon 后文件自动收敛。
+- **同项目多实例（命名实例）**：`daemon start --name <inst>`（默认 `default`）可在同一项目下并行启动多个 Godot daemon；顶层 `--instance <name>` 对所有 RPC / run / daemon 子命令通用，daemon 子命令的 `--name` 是等价写法。
+- **状态布局迁移 `.cli_control/instances/<name>/`**：daemon 的 pid / port / log 文件从项目根平铺改为按实例子目录存放。legacy 平铺路径（旧格式 `<hash>.json` 注册记录 + `.cli_control/port` 等）仅作只读 fallback 兼容，升级期间无需手工迁移；停掉旧 daemon 后文件自动收敛。硬编码读 `.cli_control/port` 的脚本应改读 `.cli_control/instances/default/port`，或改用 `GameClient()`/`GameBridge()` 自动发现（支持 `instance=` 参数）以免再次硬编码。
 - **`daemon ls` 新增 instance 列**：JSON 每条 `result.daemons[]` 含 `"instance"` 字段；text 输出格式改为 `pid\tport\tinstance\tproject_root\tstarted_at`。
 - **`daemon stop --all --project <path>`**：限定停某个项目下的全部实例（原 `--all` 不带 `--project` 仍停全局所有项目的所有实例）。
 - **daemon 各子命令的 JSON envelope result 带 `"instance"` 字段**：`start` / `stop` / `status` / `logs` 均在 result 中增加 `"instance"` 键，便于 agent 确认操作目标。

--- a/addons/godot_cli_control/README.md
+++ b/addons/godot_cli_control/README.md
@@ -122,7 +122,7 @@ All methods callable via `godot-cli-control <method>` or `from godot_cli_control
 
 > **Event pipeline**: `press` / `tap` / `hold` / `combo` inject an `InputEventAction` through the engine's event pipeline — both polling (`is_action_pressed`, `get_vector`) **and** event callbacks (`_input`, `_unhandled_input`) see the input. `InputEventAction` carries no mouse coordinates; position-dependent `_gui_input` widgets need `click` instead.
 
-> **No-arg `GameClient()` / `GameBridge()`**: with no `port` argument they auto-discover the daemon's port from `.cli_control/port` (falling back to `9877`), so a single-connection script connects to a running daemon without hardcoding a port.
+> **No-arg `GameClient()` / `GameBridge()`**: with no `port` argument they auto-discover the daemon's port from `.cli_control/instances/<name>/port` (falling back to `9877`). Pass `instance="server"` to target a named instance when multiple are running (explicit `port` always wins over `instance`). A no-arg call in a single-instance environment still works as before.
 
 ### Variant encoding depth limit
 
@@ -151,7 +151,7 @@ Three numeric ranges share `error.code`; they never overlap, so a single field i
 | `-32602` | server | Invalid params (incl. blocked methods/properties from the security blacklist, `set` value-type mismatch — e.g. `Vector2` property given an array of wrong length / non-numeric elements, or `hold` given `duration ≤ 0` — use `press` for an indefinite hold; also out-of-range values like a scene `timeout` outside `(0, 3600]` sent directly via `GameClient`) |
 | `-1001` | client | Connection failure (daemon not running, port wrong, proxy hijacking localhost) |
 | `-1002` | client | Timeout waiting for response |
-| `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, a non-numeric `tap`/`wait-time` arg, a `scene-change` path not starting with `res://`/`uid://`, a `scene-reload`/`scene-change` `--timeout` outside `(0, 3600]`, a `set`/`call` value that fails JSON parsing, script path not found, or script missing `run(bridge)`). Always exits **64** (#82 / #111). |
+| `-1003` | client | CLI usage error (combo missing steps, malformed `--steps-json`, a non-numeric `tap`/`wait-time` arg, a `scene-change` path not starting with `res://`/`uid://`, a `scene-reload`/`scene-change` `--timeout` outside `(0, 3600]`, a `set`/`call` value that fails JSON parsing, script path not found, script missing `run(bridge)`, **multi-instance ambiguity** (≥2 instances running and no `--instance`/`--name` given), **named instance not running** (explicit `--instance nope` but that instance isn't up), or `--instance` / `--name` conflict). Always exits **64** (#82 / #111). |
 | `-1004` | client | Local file IO error (e.g. screenshot can't write the destination) |
 | `-1005` | client | `run <script>` user script raised an uncaught exception — fix the script |
 | `-1006` | client | Infra pre-condition failure (`daemon start`/`stop`/`run` auto-start failed at OS level — port conflict, Godot binary not found, etc.). Always exits **2** (#92). |
@@ -165,12 +165,14 @@ The daemon is the long-lived Godot process the CLI talks to (one per project roo
 
 | Command | What it does |
 |---|---|
-| `daemon start [--headless\|--gui] [--record] [--time-scale N]` | Launch Godot with the bridge listening. Headless vs GUI is auto-detected from the TTY; `--record` forces GUI (Movie Maker needs a real renderer) and is **rejected with `--headless`** (exit 2). `--time-scale N` sets `Engine.time_scale` from frame 0 (range `(0, 100]`). |
-| `daemon stop` | Stop this project's daemon. Exit 2 if it stopped cleanly but the `.avi`→`.mp4` ffmpeg transcode failed (raw `.avi` kept; see `.cli_control/ffmpeg.log`). |
+| `daemon start [--headless\|--gui] [--record] [--time-scale N] [--name <inst>]` | Launch Godot with the bridge listening. `--name` sets the instance name (default `default`); use different names to run multiple Godot daemons for the same project in parallel. Headless vs GUI is auto-detected from the TTY; `--record` forces GUI (Movie Maker needs a real renderer) and is **rejected with `--headless`** (exit 2). `--time-scale N` sets `Engine.time_scale` from frame 0 (range `(0, 100]`). |
+| `daemon stop [--name <inst>]` | Stop this project's daemon. With `--name`, stop the named instance. Exit 2 if it stopped cleanly but the `.avi`→`.mp4` ffmpeg transcode failed (raw `.avi` kept; see `.cli_control/ffmpeg.log`). |
 | `daemon stop --all` | Stop every registered daemon across all projects. **Exit 3** if at least one failed; per-record `rc` (and an `error` field on failures) is in `result.stopped[]`. |
-| `daemon stop --project <path>` | Stop the daemon for one specific project root. |
-| `daemon status` | Exit 0 = running, 1 = stopped. When stopped, the payload may carry `last_log` / `last_exit_code` to diagnose a crash. |
-| `daemon ls` | List every registered daemon (project root, pid, port). |
+| `daemon stop --all --project <path>` | Stop all instances of one specific project. |
+| `daemon stop --project <path>` | Stop the daemon for one specific project root (single-instance shorthand). |
+| `daemon status [--name <inst>]` | Exit 0 = running, 1 = stopped. Response includes `"instance"` field. When stopped, the payload may carry `last_log` / `last_exit_code` to diagnose a crash. |
+| `daemon ls` | List every registered daemon (project root, pid, port, **instance**). Text columns: `pid\tport\tinstance\tproject_root\tstarted_at`. |
+| `daemon logs [--name <inst>] [--tail N]` | Print last N lines of godot.log for the given instance. |
 
 **Project-level defaults**: drop a `.cli_control/config.json` with `{"idle_timeout": "30m"}` to give `daemon start` / `run` a default idle-timeout without passing `--idle-timeout` each time. It's consulted only when the flag is omitted (default `0`); an explicit `--idle-timeout` always wins. A long-running `wait-time` / `combo` / recording is bounded client-side by a 600s wall-time fail-safe — override it for legitimately long operations with `GODOT_CLI_LONG_OP_TIMEOUT=<seconds>`.
 

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -21,12 +21,14 @@ from .client import GameClient
 class GameBridge:
     """同步接口，内部通过事件循环调用异步 GameClient。"""
 
-    def __init__(self, port: int | None = None) -> None:
-        # port=None → GameClient 从 .cli_control/port auto-discover（issue #91）。
+    def __init__(self, port: int | None = None, instance: str | None = None) -> None:
+        # port=None → GameClient 从 .cli_control/ auto-discover（issue #91）。
         # daemon 默认 OS 自动分配端口，所以 ``GameBridge()`` 无参数也能连上正在
         # 跑的 daemon，与 README 的单连接脚本示例一致。
+        # instance：命名实例名（如 "server"），透传给 GameClient.instance；
+        # 显式 port 优先，instance 仅在 port=None 时生效（见 client.py）。
         self._loop = asyncio.new_event_loop()
-        self._client = GameClient(port=port)
+        self._client = GameClient(port=port, instance=instance)
         self._loop.run_until_complete(
             self._client.connect(retries=15, backoff=1.0, total_timeout=60.0)
         )

--- a/python/godot_cli_control/bridge.py
+++ b/python/godot_cli_control/bridge.py
@@ -28,10 +28,16 @@ class GameBridge:
         # instance：命名实例名（如 "server"），透传给 GameClient.instance；
         # 显式 port 优先，instance 仅在 port=None 时生效（见 client.py）。
         self._loop = asyncio.new_event_loop()
-        self._client = GameClient(port=port, instance=instance)
-        self._loop.run_until_complete(
-            self._client.connect(retries=15, backoff=1.0, total_timeout=60.0)
-        )
+        # 构造/连接失败时回收 loop —— 多实例歧义（InstanceAmbiguityError）在
+        # __init__ 抛出是预期用法路径，不能让每次报错都泄漏一个 event loop。
+        try:
+            self._client = GameClient(port=port, instance=instance)
+            self._loop.run_until_complete(
+                self._client.connect(retries=15, backoff=1.0, total_timeout=60.0)
+            )
+        except BaseException:
+            self._loop.close()
+            raise
 
     def close(self) -> None:
         self._loop.run_until_complete(self._client.disconnect())

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1270,8 +1270,18 @@ def cmd_daemon_start(ns: argparse.Namespace) -> int:
         _emit_top_error(ns, code=CLIENT_CODE_USAGE, message=str(e))
         return EXIT_USAGE
 
-    # --name 选靶：未传则默认 "default"
-    inst = (getattr(ns, "name", None) or "default")
+    # --name / 顶层 --instance 选靶（通过 _merge_instance_flags 统一收口）
+    merged, conflict = _merge_instance_flags(ns)
+    if conflict:
+        sub = getattr(ns, "name", None)
+        top = getattr(ns, "instance", None)
+        _emit_top_error(
+            ns,
+            code=CLIENT_CODE_USAGE,
+            message=f"--name {sub!r} 与顶层 --instance {top!r} 冲突，二选一",
+        )
+        return EXIT_USAGE
+    inst = merged or "default"
     daemon = Daemon(Path.cwd(), instance=inst)
     try:
         daemon.start(
@@ -2027,17 +2037,42 @@ def _add_instance_name_flag(p: argparse.ArgumentParser) -> None:
         "--name",
         type=_instance_name_arg,
         default=None,
-        help="实例名（默认 default；多实例并行时用于选靶，等价顶层 --instance）",
+        help="实例名（默认 default；多实例并行时用于选靶，等价顶层 --instance；两者同时传值须一致）",
     )
+
+
+def _merge_instance_flags(ns: argparse.Namespace) -> tuple[str | None, bool]:
+    """合并顶层 --instance 与子命令 --name，返回 (合并后的实例名 or None, 是否冲突)。
+
+    两者相同或只传一个 → (值, False)；两者都传且值不同 → (None, True)。
+    冲突时调用方负责 emit -1003 信封并返回 EXIT_USAGE。
+    """
+    sub = getattr(ns, "name", None)       # 子命令 --name（daemon start/stop/status/logs/run）
+    top = getattr(ns, "instance", None)   # 顶层 --instance
+    if sub is not None and top is not None and sub != top:
+        return None, True
+    return sub or top, False
 
 
 def _resolve_daemon_instance(ns: argparse.Namespace, project_root: Path) -> str | None:
     """返回实例名；歧义时 emit -1003 信封并返回 None（调用方 return EXIT_USAGE）。
 
-    0 个在跑 → "default"（保 legacy fallback 与 stopped 语义）；1 个 → 它；
-    ≥2 → 报错列名（preflight，本地 FS 判定，先于任何网络/进程操作）。
+    顶层 --instance 与子命令 --name 统一收口（通过 _merge_instance_flags）：
+    两者等价；同时传且值相同合法；值不同报冲突（用法错 -1003）。
+
+    未显式指定时：0 个在跑 → "default"（保 legacy fallback 与 stopped 语义）；
+    1 个 → 它；≥2 → 报错列名（preflight，本地 FS 判定，先于任何网络/进程操作）。
     """
-    inst = getattr(ns, "name", None)
+    inst, conflict = _merge_instance_flags(ns)
+    if conflict:
+        sub = getattr(ns, "name", None)
+        top = getattr(ns, "instance", None)
+        _emit_top_error(
+            ns,
+            code=CLIENT_CODE_USAGE,
+            message=f"--name {sub!r} 与顶层 --instance {top!r} 冲突，二选一",
+        )
+        return None
     if inst is not None:
         return inst
     from .daemon import list_live_instances
@@ -2222,8 +2257,8 @@ def build_parser() -> argparse.ArgumentParser:
         type=_instance_name_arg,
         default=None,
         help=(
-            "RPC 连接的目标实例名（多实例并行时必传；与 --port 互斥）。"
-            "daemon 子命令请用各自的 --name。"
+            "目标实例名；RPC 与 run/daemon 子命令通用（daemon 子命令的 --name 是等价写法）。"
+            "多实例并行时必传；与 --port 互斥。"
         ),
     )
     _add_output_format_flags(parser)
@@ -2630,7 +2665,7 @@ def main() -> None:
             from .daemon import InstanceAmbiguityError, discover_port
 
             try:
-                port = discover_port(instance=getattr(ns, "instance", None)) or DEFAULT_PORT
+                port = discover_port(instance=ns.instance) or DEFAULT_PORT
             except InstanceAmbiguityError as e:
                 if fmt == OUTPUT_JSON:
                     _emit_error_payload(CLIENT_CODE_USAGE, str(e))

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1579,7 +1579,8 @@ def cmd_run(ns: argparse.Namespace) -> int:
       0  脚本成功（且 daemon stop 成功）
       1  脚本运行失败（RPC 错语义；envelope `ok=false` 时也走这里）
       2  基础设施前置失败（daemon 起不来等，code -1006 PRECONDITION）
-      64 用法错（脚本路径不存在、缺 run(bridge)、idle_timeout 解析失败等，code -1003）
+      64 用法错（脚本路径不存在、缺 run(bridge)、idle_timeout 解析失败等，code -1003；
+         多实例并行且未传 --name 也属用法错，同归 64/-1003）
     """
     from .daemon import Daemon, DaemonError
 
@@ -1608,7 +1609,14 @@ def cmd_run(ns: argparse.Namespace) -> int:
                 print(f"错误：{e}", file=sys.stderr)
             return EXIT_USAGE
 
-        daemon = Daemon(Path.cwd())
+        # 多实例选靶：0 个在跑 → "default"（走既有 auto-start 分支）；
+        # 1 个命名实例在跑 → 自动选中（不会再起新实例，auto_started=False 自然成立）；
+        # N≥2 且无 --name → preflight 报歧义（CLAUDE.md 契约 #5）。
+        inst = _resolve_daemon_instance(ns, Path.cwd())
+        if inst is None:
+            # _resolve_daemon_instance 已 emit 信封
+            return EXIT_USAGE
+        daemon = Daemon(Path.cwd(), instance=inst)
         auto_started = False
         if not daemon.is_running():
             # 静态检测脚本含 screenshot 时，非 TTY 默认从 headless 翻转到 GUI
@@ -2195,7 +2203,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="version",
         version=f"godot-cli-control {getattr(_version, '__version__', 'unknown')}",
     )
-    parser.add_argument(
+    # --port 与 --instance 互斥：agent 要么明确端口、要么指定实例名，不能两者并用。
+    # 两者均未传时，CLI 通过 discover_port() 自动发现（0 实例→default fallback，
+    # 1 实例→自动选中，N≥2→preflight 报歧义）。
+    conn_grp = parser.add_mutually_exclusive_group()
+    conn_grp.add_argument(
         "--port",
         type=int,
         default=None,
@@ -2203,6 +2215,15 @@ def build_parser() -> argparse.ArgumentParser:
             f"RPC 子命令连接的 GameBridge 端口（默认从 .cli_control/port 读取，"
             f"否则 {DEFAULT_PORT}）。注意：仅作用于 RPC 子命令，daemon "
             "start / run 启动 daemon 时请用其各自的 --port。"
+        ),
+    )
+    conn_grp.add_argument(
+        "--instance",
+        type=_instance_name_arg,
+        default=None,
+        help=(
+            "RPC 连接的目标实例名（多实例并行时必传；与 --port 互斥）。"
+            "daemon 子命令请用各自的 --name。"
         ),
     )
     _add_output_format_flags(parser)
@@ -2603,9 +2624,19 @@ def main() -> None:
         port = ns.port
         if port is None:
             # 与 GameClient()/GameBridge() 共用同一发现入口（issue #91）。
-            from .daemon import discover_port
+            # --instance 指定时传入，单实例自动选中，N≥2 且无 --instance 时
+            # 抛 InstanceAmbiguityError → preflight exit 64（CLAUDE.md 契约 #5：
+            # 用法错必须在连 daemon 之前报出，不让 agent 等 30s connection retry）。
+            from .daemon import InstanceAmbiguityError, discover_port
 
-            port = discover_port() or DEFAULT_PORT
+            try:
+                port = discover_port(instance=getattr(ns, "instance", None)) or DEFAULT_PORT
+            except InstanceAmbiguityError as e:
+                if fmt == OUTPUT_JSON:
+                    _emit_error_payload(CLIENT_CODE_USAGE, str(e))
+                else:
+                    print(f"错误：{e}", file=sys.stderr)
+                sys.exit(EXIT_USAGE)
 
         rc = asyncio.run(_run_rpc(spec, ns, port, fmt))
         sys.exit(rc)

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1326,9 +1326,12 @@ def cmd_daemon_stop(ns: argparse.Namespace) -> int:
 
     fmt = _output_format(ns)
 
-    # --all 与 --name 互斥（显式校验，给出比 argparse 互斥组更友好的消息）
-    if getattr(ns, "all", False) and getattr(ns, "name", None):
-        _emit_top_error(ns, code=CLIENT_CODE_USAGE, message="--all 与 --name 互斥")
+    # --all 与实例选靶（--name / 顶层 --instance）互斥
+    # 注意：只查 ns.name 不够——顶层 --instance 落在 ns.instance，同样是"选靶"语义
+    inst_flag = getattr(ns, "name", None) or getattr(ns, "instance", None)
+    if getattr(ns, "all", False) and inst_flag:
+        _emit_top_error(ns, code=CLIENT_CODE_USAGE,
+                        message="--all 与实例选靶（--name / 顶层 --instance）互斥")
         return EXIT_USAGE
 
     if getattr(ns, "all", False):
@@ -2118,7 +2121,7 @@ def _add_daemon_flags(p: argparse.ArgumentParser) -> None:
         "--port",
         type=int,
         default=0,
-        help="GameBridge 监听端口（默认 0 = OS 自动分配；写入 .cli_control/port）",
+        help="GameBridge 监听端口（默认 0 = OS 自动分配；写入 .cli_control/instances/<name>/port）",
     )
     p.add_argument(
         "--idle-timeout",
@@ -2247,8 +2250,9 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help=(
-            f"RPC 子命令连接的 GameBridge 端口（默认从 .cli_control/port 读取，"
-            f"否则 {DEFAULT_PORT}）。注意：仅作用于 RPC 子命令，daemon "
+            f"RPC 子命令连接的 GameBridge 端口（默认从 .cli_control/instances/<name>/port 读取，"
+            f"legacy .cli_control/port 作为 fallback，否则 {DEFAULT_PORT}）。"
+            "注意：仅作用于 RPC 子命令，daemon "
             "start / run 启动 daemon 时请用其各自的 --port。"
         ),
     )

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1270,7 +1270,9 @@ def cmd_daemon_start(ns: argparse.Namespace) -> int:
         _emit_top_error(ns, code=CLIENT_CODE_USAGE, message=str(e))
         return EXIT_USAGE
 
-    daemon = Daemon(Path.cwd())
+    # --name 选靶：未传则默认 "default"
+    inst = (getattr(ns, "name", None) or "default")
+    daemon = Daemon(Path.cwd(), instance=inst)
     try:
         daemon.start(
             record=ns.record,
@@ -1291,7 +1293,7 @@ def cmd_daemon_start(ns: argparse.Namespace) -> int:
         # is_running 之间存在亚毫秒级 race；窗口够小可以忽略。
         port = daemon.current_port() or ns.port
         pid = daemon.read_pid() if daemon.is_running() else None
-        result: dict[str, Any] = {"started": True, "port": port}
+        result: dict[str, Any] = {"started": True, "instance": daemon.instance, "port": port}
         if pid is not None:
             result["pid"] = pid
         _emit_success_payload(result)
@@ -1299,12 +1301,66 @@ def cmd_daemon_start(ns: argparse.Namespace) -> int:
 
 
 def cmd_daemon_stop(ns: argparse.Namespace) -> int:
+    """停止 daemon。
+
+    选靶矩阵：
+    * ``--all``（无 --project）：全局注册表所有实例，以每条记录的 instance 字段构造 Daemon。
+    * ``--all --project <path>``：指定项目下所有活实例（扫 instances/ 目录）。
+    * ``--name <inst>``：cwd 项目（或 --project 指定项目）的指定实例。
+    * 无 --all 无 --name：自动选靶（0 个 → default；1 个 → 它；≥2 → preflight 报错）。
+
+    JSON 模式每条 entry 含 instance 字段；Text 行含 instance 字样。
+    """
     from .daemon import Daemon, DaemonError
     from . import registry
 
     fmt = _output_format(ns)
 
+    # --all 与 --name 互斥（显式校验，给出比 argparse 互斥组更友好的消息）
+    if getattr(ns, "all", False) and getattr(ns, "name", None):
+        _emit_top_error(ns, code=CLIENT_CODE_USAGE, message="--all 与 --name 互斥")
+        return EXIT_USAGE
+
     if getattr(ns, "all", False):
+        if getattr(ns, "project", None):
+            # --all --project：停指定项目下所有活实例（扫 instances/ 不查注册表）
+            from .daemon import list_live_instances
+            target = ns.project.resolve()
+            names = list_live_instances(target) or ["default"]
+            results: list[dict[str, Any]] = []
+            had_failure = False
+            for inst_name in names:
+                entry: dict[str, Any] = {
+                    "project_root": str(target),
+                    "instance": inst_name,
+                }
+                try:
+                    d = Daemon(target, instance=inst_name)
+                    entry["pid"] = d.read_pid()
+                    entry["port"] = d.current_port()
+                    rc = d.stop()
+                    entry["rc"] = rc
+                    if fmt != OUTPUT_JSON:
+                        suffix = f" (rc={rc})" if rc != 0 else ""
+                        print(f"stopped instance={inst_name} {target}{suffix}")
+                except DaemonError as e:
+                    entry["rc"] = EXIT_INFRA_ERROR
+                    entry["error"] = str(e)
+                    had_failure = True
+                    print(f"[{target}:{inst_name}] {e}", file=sys.stderr)
+                results.append(entry)
+            rc_total = EXIT_PARTIAL if had_failure else EXIT_OK
+            if fmt == OUTPUT_JSON:
+                _emit_success_payload({"stopped": results, "rc": rc_total})
+            else:
+                failed = sum(1 for x in results if "error" in x)
+                print(
+                    f"summary: {len(results) - failed}/{len(results)} stopped"
+                    + (f", {failed} failed" if failed else "")
+                )
+            return rc_total
+
+        # --all（无 --project）：全局注册表，以记录的 instance 字段构造 Daemon
         records = registry.list_all()
         if not records:
             if fmt == OUTPUT_JSON:
@@ -1312,43 +1368,48 @@ def cmd_daemon_stop(ns: argparse.Namespace) -> int:
             else:
                 print("(no running daemons)")
             return EXIT_OK
-        results: list[dict[str, Any]] = []
-        had_failure = False
+        all_results: list[dict[str, Any]] = []
+        had_failure_global = False
         for r in records:
-            entry: dict[str, Any] = {
+            r_entry: dict[str, Any] = {
                 "project_root": r.project_root,
+                "instance": r.instance,
                 "pid": r.pid,
                 "port": r.port,
             }
             try:
-                rc = Daemon(Path(r.project_root)).stop()
-                entry["rc"] = rc
+                # 以记录的 instance 构造，防止永远打 "default" 的回归
+                rc = Daemon(Path(r.project_root), instance=r.instance).stop()
+                r_entry["rc"] = rc
                 if fmt != OUTPUT_JSON:
                     suffix = f" (rc={rc})" if rc != 0 else ""
-                    print(f"stopped pid={r.pid} port={r.port} {r.project_root}{suffix}")
+                    print(f"stopped pid={r.pid} port={r.port} instance={r.instance} {r.project_root}{suffix}")
             except DaemonError as e:
-                entry["rc"] = EXIT_INFRA_ERROR
-                entry["error"] = str(e)
-                had_failure = True
-                # 单条失败不能阻止其余 daemon 收尾
-                print(f"[{r.project_root}] {e}", file=sys.stderr)
-            results.append(entry)
-        # rc 含义：0 = 全部成功；EXIT_PARTIAL = 至少一条 DaemonError。注意单条 stop
-        # 返回 2（ffmpeg 转码失败但 daemon 已停）不算"失败"，按成功汇总；调用方
-        # 想要逐条状态请看 JSON 输出 / 文本里的每行 rc=N 标记。
-        rc_total = EXIT_PARTIAL if had_failure else EXIT_OK
+                r_entry["rc"] = EXIT_INFRA_ERROR
+                r_entry["error"] = str(e)
+                had_failure_global = True
+                # 单条失败不阻止其余收尾
+                print(f"[{r.project_root}:{r.instance}] {e}", file=sys.stderr)
+            all_results.append(r_entry)
+        # rc 含义同既有：0=全成功；EXIT_PARTIAL=至少一条 DaemonError
+        rc_total_global = EXIT_PARTIAL if had_failure_global else EXIT_OK
         if fmt == OUTPUT_JSON:
-            _emit_success_payload({"stopped": results, "rc": rc_total})
+            _emit_success_payload({"stopped": all_results, "rc": rc_total_global})
         else:
-            failed = sum(1 for x in results if "error" in x)
+            failed_global = sum(1 for x in all_results if "error" in x)
             print(
-                f"summary: {len(results) - failed}/{len(results)} stopped"
-                + (f", {failed} failed" if failed else "")
+                f"summary: {len(all_results) - failed_global}/{len(all_results)} stopped"
+                + (f", {failed_global} failed" if failed_global else "")
             )
-        return rc_total
+        return rc_total_global
 
+    # 单停
     target = (ns.project.resolve() if getattr(ns, "project", None) else Path.cwd())
-    daemon = Daemon(target)
+    inst = _resolve_daemon_instance(ns, target)
+    if inst is None:
+        # 歧义，_resolve_daemon_instance 已 emit 信封
+        return EXIT_USAGE
+    daemon = Daemon(target, instance=inst)
     try:
         rc = daemon.stop()
     except DaemonError as e:
@@ -1357,7 +1418,7 @@ def cmd_daemon_stop(ns: argparse.Namespace) -> int:
     if fmt == OUTPUT_JSON:
         # rc 0=正常停 / 2=ffmpeg 转码失败但 daemon 已停。两种都算"stopped"，
         # 把 rc 透出让 agent 决定要不要 retry transcode。
-        _emit_success_payload({"stopped": True, "rc": rc, "project_root": str(target)})
+        _emit_success_payload({"stopped": True, "rc": rc, "instance": inst, "project_root": str(target)})
     return rc
 
 
@@ -1365,28 +1426,33 @@ def cmd_daemon_status(ns: argparse.Namespace) -> int:
     """打印 daemon 状态；exit 0=运行中，1=未运行。
 
     JSON 模式（默认）：
-      ``{"ok": true, "result": {"state": "running", "pid": <int>, "port": <int>}}``
+      ``{"ok": true, "result": {"state": "running", "pid": <int>, "port": <int>, "instance": <str>}}``
       / ``{"ok": true, "result": {"state": "stopped"}}``
     Text 模式：
-      ``running pid=<pid> port=<port>`` / ``stopped``
+      ``running pid=<pid> port=<port> instance=<name>`` / ``stopped``
 
+    多实例时用 --name 选靶；若只有一个实例在跑则自动选中。
     退出码语义不变（shell ``if godot-cli-control daemon status; then …`` 仍能用）。
     """
     from .daemon import Daemon
 
     fmt = _output_format(ns)
-    daemon = Daemon(Path.cwd())
+    # 选靶：--name 显式 → 直接用；否则自动选（0→default，1→它，≥2→歧义报错）
+    inst = _resolve_daemon_instance(ns, Path.cwd())
+    if inst is None:
+        return EXIT_USAGE
+    daemon = Daemon(Path.cwd(), instance=inst)
     if daemon.is_running():
         pid = daemon.read_pid()
         port = daemon.current_port()
         if fmt == OUTPUT_JSON:
-            payload: dict[str, Any] = {"state": "running", "pid": pid}
+            payload: dict[str, Any] = {"state": "running", "instance": inst, "pid": pid}
             if port is not None:
                 payload["port"] = port
             _emit_success_payload(payload)
         else:
             print(
-                f"running pid={pid} port={port if port is not None else '?'}"
+                f"running pid={pid} port={port if port is not None else '?'} instance={inst}"
             )
         return EXIT_OK
     # Stopped：若上一轮启动留下了 godot.log / last_exit_code，把诊断信息透出来。
@@ -1414,19 +1480,24 @@ def cmd_daemon_status(ns: argparse.Namespace) -> int:
 
 
 def cmd_daemon_logs(ns: argparse.Namespace) -> int:
-    """输出 .cli_control/godot.log 尾部若干行（issue #103）。
+    """输出 .cli_control/instances/<name>/godot.log 尾部若干行（issue #103）。
 
     纯客户端读文件，不走 RPC —— daemon 已退出也能 post-mortem（与
     ``daemon status`` 透出 last_log 的语义衔接：status 告诉你日志在哪，
     logs 直接把尾部喂给你，免去 agent 再 shell 出去 tail + 找路径）。
 
+    多实例时用 --name 选靶；若只有一个实例在跑则自动选中。
     JSON 模式：``{"ok": true, "result": {"path": ..., "lines": [...],
-    "returned": N}}``；无日志文件 → ``-1006`` infra 前置失败，exit 2。
+    "returned": N, "instance": <str>}}``；无日志文件 → ``-1006`` infra 前置失败，exit 2。
     """
     from .daemon import Daemon
 
     fmt = _output_format(ns)
-    daemon = Daemon(Path.cwd())
+    # 选靶：--name 显式 → 直接用；否则自动选
+    inst = _resolve_daemon_instance(ns, Path.cwd())
+    if inst is None:
+        return EXIT_USAGE
+    daemon = Daemon(Path.cwd(), instance=inst)
     if not daemon.log_file.exists():
         _emit_top_error(
             ns,
@@ -1460,8 +1531,9 @@ def cmd_daemon_ls(ns: argparse.Namespace) -> int:
     扫全局注册表（POSIX `~/.local/state/godot-cli-control/daemons/`；Windows
     `%LOCALAPPDATA%\\godot-cli-control\\daemons\\`），对每条记录探活。
     死记录会被 list_all 自动清理（连同对应项目的 .cli_control/godot.pid 与 port）。
-    JSON 模式：{"ok": true, "result": {"daemons": [...]}}（信封一致）。
-    Text 模式：每条一行 `<pid>\t<port>\t<project_root>\t<started_at>`；空时 (no running daemons)。
+    JSON 模式：{"ok": true, "result": {"daemons": [{"pid","port","instance","project_root",...}]}}。
+    Text 模式：每条一行 ``<pid>\\t<port>\\t<instance>\\t<project_root>\\t<started_at>``；
+               空时打 (no running daemons)。
     """
     from . import registry
 
@@ -1473,6 +1545,7 @@ def cmd_daemon_ls(ns: argparse.Namespace) -> int:
                 "project_root": r.project_root,
                 "pid": r.pid,
                 "port": r.port,
+                "instance": r.instance,
                 "started_at": r.started_at,
                 "godot_bin": r.godot_bin,
                 "log_path": r.log_path,
@@ -1487,7 +1560,8 @@ def cmd_daemon_ls(ns: argparse.Namespace) -> int:
             print("(no running daemons)")
         else:
             for r in records:
-                print(f"{r.pid}\t{r.port}\t{r.project_root}\t{r.started_at}")
+                # 格式：pid\tport\tinstance\tproject_root\tstarted_at
+                print(f"{r.pid}\t{r.port}\t{r.instance}\t{r.project_root}\t{r.started_at}")
     return EXIT_OK
 
 
@@ -1925,6 +1999,50 @@ def _time_scale_arg(raw: str) -> float:
     return v
 
 
+def _instance_name_arg(value: str) -> str:
+    """argparse type 校验：非法实例名 → ArgumentTypeError，触发 -1003/64 信封。"""
+    from .daemon import DaemonError, validate_instance_name
+
+    try:
+        return validate_instance_name(value)
+    except DaemonError as e:
+        raise argparse.ArgumentTypeError(str(e))
+
+
+def _add_instance_name_flag(p: argparse.ArgumentParser) -> None:
+    """daemon 子命令的实例选择 flag。独立于 _add_daemon_flags：后者全是
+    start 专属 flag（--record/--headless/...），挂到 status/logs/stop 会污染。"""
+    p.add_argument(
+        "--name",
+        type=_instance_name_arg,
+        default=None,
+        help="实例名（默认 default；多实例并行时用于选靶，等价顶层 --instance）",
+    )
+
+
+def _resolve_daemon_instance(ns: argparse.Namespace, project_root: Path) -> str | None:
+    """返回实例名；歧义时 emit -1003 信封并返回 None（调用方 return EXIT_USAGE）。
+
+    0 个在跑 → "default"（保 legacy fallback 与 stopped 语义）；1 个 → 它；
+    ≥2 → 报错列名（preflight，本地 FS 判定，先于任何网络/进程操作）。
+    """
+    inst = getattr(ns, "name", None)
+    if inst is not None:
+        return inst
+    from .daemon import list_live_instances
+
+    live = list_live_instances(project_root)
+    if len(live) > 1:
+        _emit_top_error(
+            ns,
+            code=CLIENT_CODE_USAGE,
+            message=f"multiple instances running: {', '.join(live)} — pass --name <instance>",
+        )
+        return None
+    # 0 个在跑 → "default"（legacy fallback 语义）；1 个 → 它
+    return live[0] if live else "default"
+
+
 def _add_daemon_flags(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--record",
@@ -2107,6 +2225,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="启动 Godot daemon 并写入 .cli_control/{godot.pid,port}。",
     )
     _add_daemon_flags(start_p)
+    _add_instance_name_flag(start_p)
     start_p.add_argument(
         "--time-scale",
         type=_time_scale_arg,
@@ -2119,19 +2238,22 @@ def build_parser() -> argparse.ArgumentParser:
         "stop",
         help="停止 daemon",
         description=(
-            "停止 daemon。无 flag 时停 cwd 项目；--all 停所有注册的 daemon；"
-            "--project <path> 停指定项目。"
+            "停止 daemon。无 flag 时停 cwd 项目（自动选靶：若 cwd 有多实例须加 --name）；"
+            "--all 停所有注册的 daemon；--project <path> 停指定项目；"
+            "--name <inst> 选靶指定实例（与 --all 互斥）。"
         ),
     )
-    stop_grp = stop_p.add_mutually_exclusive_group()
-    stop_grp.add_argument(
+    # 注意：--all 与 --project 不再互斥（--all --project 允许"全停某项目"），
+    # --all 与 --name 的互斥改为 cmd_daemon_stop 内显式校验（更灵活的错误消息）。
+    stop_p.add_argument(
         "--all", action="store_true",
-        help="停止注册表中所有运行中的 daemon"
+        help="停止注册的所有 daemon（配合 --project 可限定项目）"
     )
-    stop_grp.add_argument(
+    stop_p.add_argument(
         "--project", type=Path, default=None,
         help="停止指定项目根的 daemon（绝对/相对路径均可）"
     )
+    _add_instance_name_flag(stop_p)
     _add_output_format_flags(stop_p)
 
     status_p = daemon_subs.add_parser(
@@ -2139,11 +2261,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="查询 daemon 状态",
         description=(
             "打印 daemon 状态到 stdout 并以 exit code 表示："
-            "0 = 运行中（输出 running pid=<pid> port=<port>），"
+            "0 = 运行中（输出 running pid=<pid> port=<port> instance=<name>），"
             "1 = 未运行（输出 stopped）。"
+            "多实例时用 --name 选靶；若只有一个实例在跑则自动选中。"
             "默认输出 JSON 信封；加 --text 切回旧的字符串格式。"
         ),
     )
+    _add_instance_name_flag(status_p)
     _add_output_format_flags(status_p)
 
     logs_p = daemon_subs.add_parser(
@@ -2153,7 +2277,7 @@ def build_parser() -> argparse.ArgumentParser:
             "直接输出 .cli_control/godot.log 的最后 N 行（JSON 信封包裹），"
             "免去先 daemon status 拿路径再 tail。纯客户端读文件：daemon "
             "已退出时同样可用（post-mortem 排查启动失败/崩溃）。"
-            "无日志文件 → -1006，exit 2。"
+            "多实例时用 --name 选靶。无日志文件 → -1006，exit 2。"
         ),
     )
     logs_p.add_argument(
@@ -2163,6 +2287,7 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="N",
         help="返回最后 N 行（1..1000，默认 50）",
     )
+    _add_instance_name_flag(logs_p)
     _add_output_format_flags(logs_p)
 
     ls_p = daemon_subs.add_parser(
@@ -2172,6 +2297,8 @@ def build_parser() -> argparse.ArgumentParser:
             "扫描全局注册表（POSIX ~/.local/state/godot-cli-control/daemons/；"
             "Windows %LOCALAPPDATA%\\godot-cli-control\\daemons\\），"
             "列出所有探活通过的 daemon。死记录会被自动清理。"
+            "JSON：{\"daemons\": [{\"pid\", \"port\", \"instance\", \"project_root\", ...}]}；"
+            "Text：每行 pid\\tport\\tinstance\\tproject_root\\tstarted_at。"
         ),
     )
     _add_output_format_flags(ls_p)
@@ -2200,6 +2327,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run_p.add_argument("script", help="用户脚本路径，需定义 run(bridge)")
     _add_daemon_flags(run_p)
+    _add_instance_name_flag(run_p)
     run_p.add_argument(
         "--no-gui-auto",
         action="store_true",

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -1326,6 +1326,8 @@ def cmd_daemon_stop(ns: argparse.Namespace) -> int:
             # --all --project：停指定项目下所有活实例（扫 instances/ 不查注册表）
             from .daemon import list_live_instances
             target = ns.project.resolve()
+            # 空列表回退 "default"：legacy daemon（平铺布局在跑）不出现在 instances/ 扫描里，
+            # 但 default 实例的 read_pid 带 legacy fallback，仍能停到它。
             names = list_live_instances(target) or ["default"]
             results: list[dict[str, Any]] = []
             had_failure = False
@@ -1512,6 +1514,7 @@ def cmd_daemon_logs(ns: argparse.Namespace) -> int:
     text = daemon.log_file.read_text(encoding="utf-8", errors="replace")
     lines = text.splitlines()[-tail:]
     payload: dict[str, Any] = {
+        "instance": inst,
         "path": str(daemon.log_file),
         "lines": lines,
         "returned": len(lines),

--- a/python/godot_cli_control/client.py
+++ b/python/godot_cli_control/client.py
@@ -76,17 +76,22 @@ class RpcError(RuntimeError):
 class GameClient:
     """WebSocket client that connects to Godot's GameBridge service."""
 
-    def __init__(self, port: int | None = None) -> None:
-        # port=None（无显式端口）→ 从 .cli_control/port auto-discover，找不到再回退
+    def __init__(self, port: int | None = None, instance: str | None = None) -> None:
+        # port=None（无显式端口）→ 从 .cli_control/ auto-discover，找不到再回退
         # DEFAULT_PORT。daemon 默认 OS 自动分配端口，所以照 README 写
         # ``GameClient()`` 单连接脚本的用户/agent 必须经由这条发现路径才能连上
         # （issue #91）。发现逻辑收敛在 daemon.discover_port，CLI 走同一入口。
         # 延迟 import 避免 client 在 package import 时拉起 daemon→registry 这条
         # 较重的依赖链。
+        #
+        # instance：命名实例名（如 "server"/"client"）。仅在 port=None 时透传给
+        # discover_port；显式 port 全权优先，instance 不触发任何 IO。
+        # InstanceAmbiguityError 不吞，直接抛给库用户——run 脚本作者需自己决定
+        # 连哪个实例（传 instance= 消歧）。
         if port is None:
             from .daemon import discover_port
 
-            port = discover_port() or DEFAULT_PORT
+            port = discover_port(instance=instance) or DEFAULT_PORT
         self._port = port
         self._ws: ClientConnection | None = None
         self._pending: dict[str, asyncio.Future[dict]] = {}

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import signal
 import socket
@@ -23,6 +24,19 @@ class DaemonError(RuntimeError):
     """Daemon 启停过程中可恢复的错误（用户应看到 message，不必看 traceback）。"""
 
 
+# 实例名校验正则：要落进文件路径与注册表文件名，必须文件系统安全（spec 2026-06-07）。
+_INSTANCE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
+
+
+def validate_instance_name(name: str) -> str:
+    """校验实例名合法性，合法则原样返回，不合法抛 DaemonError（spec 2026-06-07）。"""
+    if not _INSTANCE_NAME_RE.fullmatch(name):
+        raise DaemonError(
+            f"非法 instance 名 {name!r}：只允许 [A-Za-z0-9_-]，长度 1-32"
+        )
+    return name
+
+
 class Daemon:
     """管理本地 Godot 实例的状态文件 + 进程。
 
@@ -30,9 +44,20 @@ class Daemon:
     ``movie_path``。文件名/语义与原 bash 版一致，使两者可互换。
     """
 
-    def __init__(self, project_root: Path, control_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        project_root: Path,
+        control_dir: Path | None = None,
+        *,
+        instance: str = "default",
+    ) -> None:
         self.project_root = Path(project_root).resolve()
-        self.control_dir = control_dir or (self.project_root / ".cli_control")
+        self.instance = validate_instance_name(instance)
+        # 多实例：状态文件按实例隔离到 instances/<name>/（spec 2026-06-07）。
+        # 显式 control_dir 仍全权 override（既有测试注入语义不变）。
+        self.control_dir = control_dir or (
+            self.project_root / ".cli_control" / "instances" / self.instance
+        )
         self.pid_file = self.control_dir / "godot.pid"
         self.port_file = self.control_dir / "port"
         self.movie_path_file = self.control_dir / "movie_path"
@@ -43,26 +68,40 @@ class Daemon:
         # 直接报「last exit: <code>」，省下一轮回溯。stop / 新一轮 start 会
         # 清掉。issue #38。
         self.exit_code_file = self.control_dir / "last_exit_code"
+        # legacy 平铺路径（迁移前布局 —— 版本升级前 default 实例写在这里）：
+        # default 实例用于只读 fallback + 防双开探活（spec 2026-06-07）。
+        # godot_bin 偏好（init 命令写）属于项目级，永远放在这里，不跟 instances/ 搬。
+        self._legacy_dir = self.project_root / ".cli_control"
 
     # ── 状态查询 ──
 
     def read_pid(self) -> int | None:
-        if not self.pid_file.exists():
-            return None
-        try:
-            return int(self.pid_file.read_text().strip())
-        except (ValueError, OSError):
-            return None
+        pid = self._read_int(self.pid_file)
+        if pid is None and self.instance == "default":
+            # default 实例 fallback：读旧平铺路径防双开（spec 2026-06-07）。
+            # 旧版本 daemon 把 pid 写到 .cli_control/godot.pid；
+            # 升级后若 instances/default/ 还不存在，依靠此 fallback 感知仍在跑的老进程。
+            pid = self._read_int(self._legacy_dir / "godot.pid")
+        return pid
 
     def is_running(self) -> bool:
         pid = self.read_pid()
         return pid is not None and _process_alive(pid)
 
     def current_port(self) -> int | None:
-        if not self.port_file.exists():
+        port = self._read_int(self.port_file)
+        if port is None and self.instance == "default":
+            # default 实例 fallback：读旧平铺路径（spec 2026-06-07）。
+            port = self._read_int(self._legacy_dir / "port")
+        return port
+
+    @staticmethod
+    def _read_int(path: Path) -> int | None:
+        """安全读单行整数文件，不存在或解析失败均返回 None。"""
+        if not path.exists():
             return None
         try:
-            return int(self.port_file.read_text().strip())
+            return int(path.read_text().strip())
         except (ValueError, OSError):
             return None
 
@@ -270,16 +309,28 @@ class Daemon:
         三者同生同死 —— ``start()`` 成功后一并写入；任何 stop 路径（包括 start
         途中失败的回滚清理）必须把它们一并清掉，否则下次 ``daemon ls`` / 启动
         校验会误以为还有进程在跑。``movie_path`` 在 stop 流程中独立处理。
+
+        default 实例额外清理旧平铺路径的残留文件（spec 2026-06-07）：
+        停掉由旧版本启动的 legacy daemon 后，不应把那两个文件留在磁盘上充「僵尸」，
+        否则下次 fallback 探活会误报有进程在跑。
         """
         self.pid_file.unlink(missing_ok=True)
         self.port_file.unlink(missing_ok=True)
+        if self.instance == "default":
+            (self._legacy_dir / "godot.pid").unlink(missing_ok=True)
+            (self._legacy_dir / "port").unlink(missing_ok=True)
         # start 失败回滚路径还没 register 时，unregister 是 unlink(missing_ok=True)，
         # 行为一致；保持一处兜底比让所有 caller 记得手动 unregister 更不易遗漏。
         _registry.unregister(self.project_root)
 
     def read_godot_bin_pref(self) -> str | None:
-        """读取 init 命令写入的 ``.cli_control/godot_bin`` 路径偏好。"""
-        pref = self.control_dir / "godot_bin"
+        """读取 init 命令写入的 ``.cli_control/godot_bin`` 路径偏好。
+
+        godot_bin 属于**项目级**偏好（由 init_cmd.py 写到平铺路径）；
+        必须从 _legacy_dir（即 .cli_control/）读取，不能跟 instances/ 搬——
+        否则命名实例（如 server）读不到 init 写的 bin 偏好（spec 2026-06-07）。
+        """
+        pref = self._legacy_dir / "godot_bin"
         if not pref.exists():
             return None
         try:

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -267,6 +267,7 @@ class Daemon:
             port=actual_port,
             godot_bin=bin_path,
             log_path=str(self.log_file),
+            instance=self.instance,
         )
         return proc.pid
 
@@ -321,7 +322,7 @@ class Daemon:
             (self._legacy_dir / "port").unlink(missing_ok=True)
         # start 失败回滚路径还没 register 时，unregister 是 unlink(missing_ok=True)，
         # 行为一致；保持一处兜底比让所有 caller 记得手动 unregister 更不易遗漏。
-        _registry.unregister(self.project_root)
+        _registry.unregister(self.project_root, instance=self.instance)
 
     def read_godot_bin_pref(self) -> str | None:
         """读取 init 命令写入的 ``.cli_control/godot_bin`` 路径偏好。

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -24,6 +24,18 @@ class DaemonError(RuntimeError):
     """Daemon 启停过程中可恢复的错误（用户应看到 message，不必看 traceback）。"""
 
 
+class InstanceAmbiguityError(RuntimeError):
+    """实例无法唯一确定（≥2 在跑且未显式指定，或显式指定的不在跑）。
+
+    CLI 把它映射成 -1003 + exit 64 的 preflight 用法错；message 自带在跑
+    实例清单，agent 看单行 JSON 即知下一步传什么（spec 2026-06-07）。
+    """
+
+    def __init__(self, message: str, names: list[str]) -> None:
+        super().__init__(message)
+        self.names = names
+
+
 # 实例名校验正则：要落进文件路径与注册表文件名，必须文件系统安全（spec 2026-06-07）。
 _INSTANCE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
 
@@ -448,19 +460,78 @@ def read_project_config(project_root: Path | None = None) -> dict:
 # ── 端口发现 ──
 
 
-def discover_port(project_root: Path | None = None) -> int | None:
-    """从 ``<project_root>/.cli_control/port`` 读取 daemon 当前监听端口。
+def list_live_instances(project_root: Path | None = None) -> list[str]:
+    """扫 ``<project_root>/.cli_control/instances/*/``，按 pid 探活返回在跑实例名（有序）。
 
-    daemon 默认以 OS 自动分配端口启动（写入 ``.cli_control/port``），所以"无显式
-    端口"的连接方都得先来这里发现实际端口，再回退 ``DEFAULT_PORT``。这是 CLI RPC
-    子命令、``GameClient()`` 与 ``GameBridge()`` 三处无显式 port 时的**唯一共用**
-    发现入口（issue #91）——与 README 承诺的 "auto-discover from ``.cli_control/port``"
-    对齐。
+    注意两个微妙点：
 
-    ``project_root`` 默认 ``Path.cwd()``（与 CLI 的工作目录约定一致）。无 port 文件
-    或解析失败时返回 ``None``，由调用方决定回退值。
+    1. **default 实例的 is_running() 带 legacy fallback**（Task 1）：若
+       ``instances/default/`` 目录存在但空，且 legacy 平铺路径有存活的 PID 文件，
+       default 会被算成 live ——这**符合预期**（legacy daemon 应算 default 在跑）。
+       而 ``instances/`` 目录整个不存在时，本函数返回 []，由 ``discover_port`` 的
+       0-命中分支通过 ``Daemon(root).current_port()`` 兜住 legacy fallback。
+
+    2. **非法目录名跳过而非抛异常**：用户手建怪目录（如含斜杠、空格、Unicode）时，
+       ``Daemon(root, instance=p.name)`` 会抛 DaemonError（validate_instance_name
+       校验）。这里用 ``_INSTANCE_NAME_RE.fullmatch`` 前置过滤：显式、无异常流，
+       无效目录名静默跳过，不污染在跑实例列表。
     """
     root = Path(project_root) if project_root is not None else Path.cwd()
+    base = root / ".cli_control" / "instances"
+    if not base.is_dir():
+        return []
+    return sorted(
+        p.name
+        for p in base.iterdir()
+        if p.is_dir()
+        and _INSTANCE_NAME_RE.fullmatch(p.name)  # 过滤非法目录名，避免 DaemonError 污染
+        and Daemon(root, instance=p.name).is_running()
+    )
+
+
+def discover_port(
+    project_root: Path | None = None, instance: str | None = None
+) -> int | None:
+    """发现 daemon 当前监听端口 —— CLI RPC、GameClient、GameBridge 三方唯一共用入口（issue #91）。
+
+    daemon 默认以 OS 自动分配端口启动，所以"无显式端口"的连接方都得先来这里发现
+    实际端口。与 README 承诺的 "auto-discover from ``.cli_control/port``" 对齐。
+
+    **多实例语义（0 / 1 / N，spec 2026-06-07）：**
+
+    - ``instance`` 显式指定：只读那一个实例的 port 文件；未在跑则抛 ``InstanceAmbiguityError``
+      并在 message 中列出当前在跑的实例名供 agent 参考。
+    - ``instance=None``（默认）：
+      - N ≥ 2 个实例在跑 → 抛 ``InstanceAmbiguityError``，message 列全部名字。
+      - N = 1 → 自动选中，返回其端口。
+      - N = 0 → 走 default 实例的 ``current_port()``，自带 legacy 只读 fallback（Task 1）；
+        如此「legacy daemon 在跑 + instances/ 不存在」时仍能返回正确端口。
+
+    ``project_root`` 默认 ``Path.cwd()``（与 CLI 工作目录约定一致）。无 port 文件
+    或解析失败返回 ``None``，由调用方决定回退值。
+    """
+    root = Path(project_root) if project_root is not None else Path.cwd()
+    if instance is not None:
+        # 显式指定：只读那一个实例
+        d = Daemon(root, instance=instance)
+        if not d.is_running():
+            live = list_live_instances(root)
+            raise InstanceAmbiguityError(
+                f"instance {instance!r} not running"
+                + (f"; running: {', '.join(live)}" if live else "; none running"),
+                live,
+            )
+        return d.current_port()
+
+    live = list_live_instances(root)
+    if len(live) > 1:
+        raise InstanceAmbiguityError(
+            f"multiple instances running: {', '.join(live)} — pass --instance <name>",
+            live,
+        )
+    if len(live) == 1:
+        return Daemon(root, instance=live[0]).current_port()
+    # 0 个在跑：default 实例的 current_port 自带 legacy 只读 fallback（Task 1）
     return Daemon(root).current_port()
 
 

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -509,6 +509,9 @@ def discover_port(
 
     ``project_root`` 默认 ``Path.cwd()``（与 CLI 工作目录约定一致）。无 port 文件
     或解析失败返回 ``None``，由调用方决定回退值。
+
+    端口文件路径：``.cli_control/instances/<name>/port``（多实例布局）；
+    legacy ``.cli_control/port`` 作为 fallback 仍可读取（单实例旧布局兼容）。
     """
     root = Path(project_root) if project_root is not None else Path.cwd()
     if instance is not None:

--- a/python/godot_cli_control/registry.py
+++ b/python/godot_cli_control/registry.py
@@ -1,8 +1,9 @@
 """Global cross-project daemon registry，目录按平台惯例选址（见 ``_user_state_dir``）。
 
-每个守护进程一份 ``<project_hash>.json``，记录 PID / 端口 / 项目路径 / 启动时刻。
-``list_all()`` 顺手探活并清理死记录。无文件锁 —— 每条记录文件名以 project_hash
-区分，写入幂等。
+每个守护进程一份 ``<project_hash>-<instance>.json``，记录 PID / 端口 / 项目路径 /
+启动时刻 / 实例名。旧格式（``<project_hash>.json``，无 instance 字段）被向后兼容
+读为 ``instance="default"``。``list_all()`` 顺手探活并清理死记录。无文件锁 ——
+每条记录文件名以 project_hash + instance 区分，写入幂等。
 """
 from __future__ import annotations
 
@@ -42,10 +43,11 @@ class DaemonRecord:
     started_at: str
     godot_bin: str
     log_path: str
+    instance: str = "default"   # 旧记录无此字段 → default（spec 2026-06-07）
 
     @property
     def record_file(self) -> Path:
-        return _REGISTRY_DIR / f"{project_hash(Path(self.project_root))}.json"
+        return _REGISTRY_DIR / f"{project_hash(Path(self.project_root))}-{self.instance}.json"
 
 
 def project_hash(project_root: Path) -> str:
@@ -59,6 +61,7 @@ def register(
     port: int,
     godot_bin: str,
     log_path: str,
+    instance: str = "default",
 ) -> None:
     _REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -68,18 +71,26 @@ def register(
         "started_at": _dt.datetime.now(_dt.timezone.utc).astimezone().isoformat(timespec="seconds"),
         "godot_bin": godot_bin,
         "log_path": log_path,
+        "instance": instance,
     }
     # 原子写：先写 .tmp 再 os.replace，避免被 SIGKILL / OOM 打断后留下 0 字节
     # 文件让 list_all 误删尚未完成的注册。docstring 的"幂等"才真正成立。
-    target = _REGISTRY_DIR / f"{project_hash(project_root)}.json"
+    # 文件名含实例名，同项目多实例各自独立记录（spec 2026-06-07）。
+    target = _REGISTRY_DIR / f"{project_hash(project_root)}-{instance}.json"
     tmp = target.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
     os.replace(tmp, target)
 
 
-def unregister(project_root: Path) -> None:
-    target = _REGISTRY_DIR / f"{project_hash(project_root)}.json"
+def unregister(project_root: Path, instance: str = "default") -> None:
+    # 删除新格式文件名（<hash>-<instance>.json）。
+    target = _REGISTRY_DIR / f"{project_hash(project_root)}-{instance}.json"
     target.unlink(missing_ok=True)
+    # default 实例额外清理旧格式文件名（<hash>.json），防止 legacy daemon 停掉后
+    # 残留旧记录让 list_all 误以为还有进程在跑（spec 2026-06-07）。
+    if instance == "default":
+        legacy = _REGISTRY_DIR / f"{project_hash(project_root)}.json"
+        legacy.unlink(missing_ok=True)
 
 
 def list_all() -> list[DaemonRecord]:
@@ -90,7 +101,10 @@ def list_all() -> list[DaemonRecord]:
     for f in sorted(_REGISTRY_DIR.glob("*.json")):
         try:
             data = json.loads(f.read_text())
-            r = DaemonRecord(**{k: data[k] for k in DaemonRecord.__dataclass_fields__})
+            # 按 data 现有键过滤构造，而非按 fields 去 data 取值：
+            # 旧记录缺 instance 字段时不触发 KeyError，dataclass 默认值 "default" 生效。
+            # 必填六键缺失时 dataclass 构造自然 TypeError，仍落入 except 清理分支。
+            r = DaemonRecord(**{k: data[k] for k in data if k in DaemonRecord.__dataclass_fields__})
         except (OSError, json.JSONDecodeError, KeyError, TypeError):
             f.unlink(missing_ok=True)
             continue
@@ -103,9 +117,17 @@ def list_all() -> list[DaemonRecord]:
 
 def _prune(record: DaemonRecord, registry_file: Path) -> None:
     registry_file.unlink(missing_ok=True)
-    ctrl = Path(record.project_root) / ".cli_control"
-    (ctrl / "godot.pid").unlink(missing_ok=True)
-    (ctrl / "port").unlink(missing_ok=True)
+    root = Path(record.project_root)
+    # 新格式：状态文件在 instances/<instance>/ 子目录（spec 2026-06-07）。
+    inst_dir = root / ".cli_control" / "instances" / record.instance
+    (inst_dir / "godot.pid").unlink(missing_ok=True)
+    (inst_dir / "port").unlink(missing_ok=True)
+    # default 实例同时清理旧版本的平铺路径（.cli_control/godot.pid 等），覆盖旧格式记录
+    # 被读为 instance="default" 的场景，防止 legacy 文件残留让 fallback 误报存活。
+    if record.instance == "default":
+        legacy_ctrl = root / ".cli_control"
+        (legacy_ctrl / "godot.pid").unlink(missing_ok=True)
+        (legacy_ctrl / "port").unlink(missing_ok=True)
 
 
 def _process_alive(pid: int) -> bool:

--- a/python/godot_cli_control/registry.py
+++ b/python/godot_cli_control/registry.py
@@ -45,13 +45,13 @@ class DaemonRecord:
     log_path: str
     instance: str = "default"   # 旧记录无此字段 → default（spec 2026-06-07）
 
-    @property
-    def record_file(self) -> Path:
-        return _REGISTRY_DIR / f"{project_hash(Path(self.project_root))}-{self.instance}.json"
-
-
 def project_hash(project_root: Path) -> str:
     return hashlib.sha1(str(Path(project_root).resolve()).encode()).hexdigest()[:12]
+
+
+def _record_path(project_root: Path, instance: str) -> Path:
+    """注册表记录文件的单一来源：``<hash>-<instance>.json``。"""
+    return _REGISTRY_DIR / f"{project_hash(project_root)}-{instance}.json"
 
 
 def register(
@@ -76,7 +76,7 @@ def register(
     # 原子写：先写 .tmp 再 os.replace，避免被 SIGKILL / OOM 打断后留下 0 字节
     # 文件让 list_all 误删尚未完成的注册。docstring 的"幂等"才真正成立。
     # 文件名含实例名，同项目多实例各自独立记录（spec 2026-06-07）。
-    target = _REGISTRY_DIR / f"{project_hash(project_root)}-{instance}.json"
+    target = _record_path(project_root, instance)
     tmp = target.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
     os.replace(tmp, target)
@@ -84,7 +84,7 @@ def register(
 
 def unregister(project_root: Path, instance: str = "default") -> None:
     # 删除新格式文件名（<hash>-<instance>.json）。
-    target = _REGISTRY_DIR / f"{project_hash(project_root)}-{instance}.json"
+    target = _record_path(project_root, instance)
     target.unlink(missing_ok=True)
     # default 实例额外清理旧格式文件名（<hash>.json），防止 legacy daemon 停掉后
     # 残留旧记录让 list_all 误以为还有进程在跑（spec 2026-06-07）。

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -53,7 +53,7 @@ godot-cli-control daemon stop --all --project .
 | 1 | RPC error (server returned `{"error":...}`); also `exists`/`visible`=false, `wait-node`/`wait-prop`/`wait-signal`=timeout, `daemon status`=stopped |
 | 2 | Connection / IO error (daemon not running) or infra pre-condition failure (daemon failed to start, `daemon stop` encountered a system error — these carry client code `-1006`). Also: **`daemon stop` returns 2** when the daemon stopped cleanly but `ffmpeg` transcode of the recorded `.avi`→`.mp4` failed — the raw `.avi` is kept and `.cli_control/ffmpeg.log` has the details. `run <script>` propagates this: a successful script + failed transcode still exits 2. |
 | 3 | `daemon stop --all` partial failure: at least one daemon in the registry failed to stop. Per-record `rc` is in the JSON `result.stopped[]`. |
-| 64 | Usage error — argparse parse failure (missing / invalid args, unknown subcommand), a pre-flight reject caught before connecting (`combo` with no steps / malformed `--steps-json` / `combo -` from a TTY, `hold` with a non-positive duration), a bad runtime argument (`tap` / `wait-time` given a non-number, a `set`/`call` value that fails JSON parsing), **or** `run <script>` given a non-existent path / a script with no `run(bridge)` function. All carry client code `-1003` and consistently exit 64 (#82 / #111). |
+| 64 | Usage error — argparse parse failure (missing / invalid args, unknown subcommand), a pre-flight reject caught before connecting (`combo` with no steps / malformed `--steps-json` / `combo -` from a TTY, `hold` with a non-positive duration), a bad runtime argument (`tap` / `wait-time` given a non-number, a `set`/`call` value that fails JSON parsing), **or** `run <script>` given a non-existent path / a script with no `run(bridge)` function, **or** a multi-instance targeting error (≥ 2 instances running without `--instance` / `--name`, an explicitly named instance that is not running, or `--instance` and `--name` given conflicting values). All carry client code `-1003` and consistently exit 64 (#82 / #111). |
 
 Shell-`if` works:
 
@@ -114,7 +114,7 @@ godot-cli-control --instance server daemon stop   # or: daemon stop --name serve
 godot-cli-control daemon stop --name server
 godot-cli-control daemon stop --name client1
 # or in one shot:
-godot-cli-control daemon stop --all --project /path/to/project
+godot-cli-control daemon stop --all --project .
 ```
 
 **Target-selection semantics (same for all subcommands):**
@@ -124,6 +124,8 @@ godot-cli-control daemon stop --all --project /path/to/project
 | 0 | connects to "default" (legacy fallback) | error -1003, exit 64 |
 | 1 | auto-selects the single instance | error -1003, exit 64 |
 | ≥ 2 | **error -1003, exit 64** — lists names in message | error -1003, exit 64 |
+
+> **Note**: "forgot `--instance`" (≥ 2 running, none selected) and "named instance not running" are two distinct error cases with different messages. When an explicit `--instance <name>` refers to an instance that is not running, the error message includes the list of currently-running instance names so you can pick a valid target without a separate `daemon ls` call.
 
 When ≥ 2 instances are running and you omit `--instance`, the error JSON is:
 

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -509,7 +509,7 @@ Pytest CLI options the plugin adds:
 
 | Option | Default | Purpose |
 |---|---|---|
-| `--godot-cli-port` | `(auto)` | GameBridge port. Default: read from `.cli_control/port` (which the daemon writes when it starts). |
+| `--godot-cli-port` | `(auto)` | GameBridge port. Default: read from `.cli_control/instances/<name>/port` (which the daemon writes when it starts); legacy `.cli_control/port` is read as fallback. |
 | `--godot-cli-no-headless` | off (i.e. headless) | Drop `--headless`, open a real Godot window |
 | `--godot-cli-project-root` | `pytest rootdir` | Override the Godot project root |
 | `--godot-cli-time-scale` | `None` (engine default = 1.0) | Set `Engine.time_scale` at daemon startup (e.g. `5` to run the whole suite at 5× speed). Passed as `--cli-time-scale=N` to Godot; valid range `(0, 100]`. |
@@ -536,7 +536,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 - **Daemon won't start** — check `.cli_control/godot_bin` exists and points at a real Godot 4 binary, or `export GODOT_BIN=/path/to/godot`. See `godot-cli-control init -h` for the full lookup chain.
 - **Output flags work in any position** — `--json` / `--text` / `--no-json` are accepted both before and after subcommands as of this fix.
 - **There are two independent `--port` flags — don't confuse them:**
-  - Top-level `godot-cli-control --port N <subcommand>`: the GameBridge port an RPC subcommand connects to (auto-discovered from `.cli_control/port`; override only when needed). **Must come before the subcommand.**
+  - Top-level `godot-cli-control --port N <subcommand>`: the GameBridge port an RPC subcommand connects to (auto-discovered from `.cli_control/instances/<name>/port`; legacy `.cli_control/port` is read as fallback; override only when needed). **Must come before the subcommand.**
   - `daemon start --port N`: the port the daemon itself listens on. This is a local flag of `start`, so — like any other `daemon` flag — its position doesn't matter.
 - **`combo` rejects everything with `1004`** — a combo is already running. Call `combo-cancel` (or `release-all`) to abort.
 - **`hold` / `press` persist after the command returns** — by design. Each CLI command is its own short-lived connection that closes *cleanly*, and a clean close does **not** release inputs. `hold <action> <dur>` auto-releases after `<dur>` seconds (its timer keeps running in the daemon); a sticky `press <action>` stays held until you call `release <action>` / `release-all` (or the daemon's idle-timeout shuts it down). If a character looks stuck moving, you probably left a `press` dangling — run `release-all`. (An *abnormal* drop — your client crashing or being killed mid-session — does trigger a safety `release-all`, so stuck keys can't outlive a dead client.)

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -26,12 +26,19 @@ Pipe straight into `jq` or `json.loads`. Add `--text` (or `--no-json`) to switch
 # One-time per Godot project (already done if you're reading this file):
 godot-cli-control init
 
-# Per session:
+# Per session (single instance):
 godot-cli-control daemon start --headless         # boots Godot in the background
 godot-cli-control daemon status                   # exit 0 = running, 1 = stopped
 godot-cli-control tree 2 | jq .result             # confirm RPC works
 # ... your work ...
 godot-cli-control daemon stop
+
+# Per session (multiple instances, e.g. server + client):
+godot-cli-control daemon start --name server --headless
+godot-cli-control daemon start --name client1 --headless
+godot-cli-control --instance server tree 2 | jq .result
+godot-cli-control --instance client1 click /root/Game/JoinButton
+godot-cli-control daemon stop --all --project .
 ```
 
 > As of this version, `daemon start` autodetects headless mode by checking `stdout.isatty()`. Pipes, CI, and agent shell-outs run headless by default; an interactive terminal still gets a window. The explicit flags below are only needed to override: `--headless` forces headless even in a TTY; `--gui` forces a window even when stdout is piped.
@@ -59,22 +66,76 @@ fi
 ## Daemon management
 
 ```bash
-godot-cli-control daemon start             # boot daemon for cwd project
-godot-cli-control daemon start --time-scale 5  # start at 5× game speed (applies Engine.time_scale from frame 0)
-godot-cli-control daemon status            # exit 0 = running, 1 = stopped
-godot-cli-control daemon stop              # stop cwd-project daemon (rc 0; rc 2 = ffmpeg transcode failed)
+godot-cli-control daemon start                           # boot daemon for cwd project (instance "default")
+godot-cli-control daemon start --name server             # boot a named instance
+godot-cli-control daemon start --name client1 --port 0   # second instance on an OS-assigned port
+godot-cli-control daemon start --time-scale 5            # start at 5× game speed
+godot-cli-control daemon status                          # exit 0 = running, 1 = stopped
+godot-cli-control daemon status --name server            # status for a specific instance
+godot-cli-control daemon stop                            # stop cwd-project daemon (auto-selects if 1 running)
+godot-cli-control daemon stop --name server              # stop a named instance
 godot-cli-control daemon stop --project /path/to/other/godot/project
-godot-cli-control daemon stop --all        # stop every registered daemon; exit 3 if any failed
-godot-cli-control daemon ls                # list all running daemons (cross-project, walks the registry)
-godot-cli-control daemon logs --tail 50    # last N lines of godot.log (works after the daemon died, too)
+godot-cli-control daemon stop --all                      # stop every registered daemon; exit 3 if any failed
+godot-cli-control daemon stop --all --project /path/to/project  # stop all instances of one project
+godot-cli-control daemon ls                              # list all running daemons (cross-project, with instance column)
+godot-cli-control daemon logs --tail 50                  # last N lines of godot.log (works after the daemon died, too)
+godot-cli-control daemon logs --name server --tail 50    # logs for a specific instance
 ```
 
-- **`daemon status` payload when running**: `{"state": "running", "pid": N, "port": M}`.
-- **`daemon status` payload when stopped**: `{"state": "stopped"}`. If the previous launch wrote `.cli_control/godot.log` or recorded an exit code, the envelope also includes `"last_log": "<path>"` and/or `"last_exit_code": <int>` — use these to diagnose why the daemon died without manually grepping under `.cli_control/`.
-- **`daemon ls` payload**: `{"daemons": [{"project_root", "pid", "port", "started_at", "godot_bin", "log_path"}, ...]}`. Dead records (PID gone) are auto-pruned on each call, so this is the canonical list of *actually-alive* daemons across all projects on the machine.
-- **`daemon stop --all` payload**: `{"stopped": [{"project_root","pid","port","rc"[, "error"]}, ...], "rc": 0|3}`. Each entry's `rc` is the per-project stop result; the top-level `rc` is the aggregate exit code.
-- **`daemon logs [--tail N]` payload**: `{"path": "<godot.log>", "lines": [...], "returned": N}` (default 50, max 1000). Reads the file client-side — **no RPC**, so it works post-mortem after the daemon crashed or stopped (the companion to `daemon status`'s `last_log` hint: status tells you where the log is, `logs` hands you the tail directly). No log file yet → `-1006`, exit 2.
+- **`daemon status` payload when running**: `{"state": "running", "pid": N, "port": M, "instance": "<name>"}`.
+- **`daemon status` payload when stopped**: `{"state": "stopped"}`. If the previous launch wrote `.cli_control/instances/<name>/godot.log` or recorded an exit code, the envelope also includes `"last_log": "<path>"` and/or `"last_exit_code": <int>` — use these to diagnose why the daemon died without manually grepping under `.cli_control/`.
+- **`daemon ls` payload**: `{"daemons": [{"project_root", "pid", "port", "instance", "started_at", "godot_bin", "log_path"}, ...]}`. Dead records (PID gone) are auto-pruned on each call, so this is the canonical list of *actually-alive* daemons across all projects on the machine. Text output columns: `pid\tport\tinstance\tproject_root\tstarted_at`.
+- **`daemon stop --all` payload**: `{"stopped": [{"project_root","pid","port","instance","rc"[, "error"]}, ...], "rc": 0|3}`. Each entry's `rc` is the per-instance stop result; the top-level `rc` is the aggregate exit code.
+- **`daemon logs [--tail N]` payload**: `{"path": "<godot.log>", "lines": [...], "returned": N, "instance": "<name>"}` (default 50, max 1000). Reads the file client-side — **no RPC**, so it works post-mortem after the daemon crashed or stopped (the companion to `daemon status`'s `last_log` hint: status tells you where the log is, `logs` hands you the tail directly). No log file yet → `-1006`, exit 2.
 - **`daemon start --time-scale N`**: sets `Engine.time_scale = N` (range `(0, 100]`) from the very first frame of the Godot process. Useful to run an entire test suite at e.g. 5× speed. **Asymmetry**: `run <script>` mode does not support `--time-scale` as a startup flag — inside the script call `bridge.time_scale(5)` on the first line instead; or use `daemon start --time-scale 5` beforehand and connect the script to the already-running daemon.
+
+## Multi-instance (multiple daemons for one project)
+
+You can run more than one Godot instance per project — for example a "server" and a "client" connected to the same game.
+
+**Starting two instances:**
+
+```bash
+godot-cli-control daemon start --name server
+godot-cli-control daemon start --name client1
+```
+
+**Sending RPC to a specific instance** — use the top-level `--instance` flag (or `--name` inside `daemon` subcommands):
+
+```bash
+godot-cli-control --instance server click /root/Game/StartButton
+godot-cli-control --instance client1 get /root/Player position
+godot-cli-control --instance server daemon stop   # or: daemon stop --name server
+```
+
+**Stopping both:**
+
+```bash
+godot-cli-control daemon stop --name server
+godot-cli-control daemon stop --name client1
+# or in one shot:
+godot-cli-control daemon stop --all --project /path/to/project
+```
+
+**Target-selection semantics (same for all subcommands):**
+
+| Running instances | No `--instance` / `--name` | Explicit `--instance nope` |
+|---|---|---|
+| 0 | connects to "default" (legacy fallback) | error -1003, exit 64 |
+| 1 | auto-selects the single instance | error -1003, exit 64 |
+| ≥ 2 | **error -1003, exit 64** — lists names in message | error -1003, exit 64 |
+
+When ≥ 2 instances are running and you omit `--instance`, the error JSON is:
+
+```json
+{"ok": false, "error": {"code": -1003, "message": "multiple instances running: client1, server — pass --instance <name>"}}
+```
+
+— read the `message`, pick a name from the list, and re-run with `--instance <name>`.
+
+`--instance` (top-level) and `--name` (daemon subcommands) are equivalent; passing both with the same value is allowed, different values → -1003 conflict error. `--instance` and `--port` are mutually exclusive (both select which daemon to talk to).
+
+**Upgrade-period note**: if you have a legacy daemon started with an older version of the CLI (its pid/port files sit directly under `.cli_control/` instead of `.cli_control/instances/<name>/`), `daemon ls` may temporarily show two lines for the same project. Stop the legacy daemon and the extra line disappears — no manual file migration needed.
 
 ## JSON envelope examples
 
@@ -356,7 +417,7 @@ Key constraints:
 
 ## Python `GameClient` API
 
-`from godot_cli_control.client import GameClient` — async WebSocket client; use as `async with GameClient() as client:`. **With no `port` argument it auto-discovers from `.cli_control/port`** (the same file the daemon writes and the CLI reads), falling back to `9877` if absent — so a no-arg `GameClient()` connects to a running daemon out of the box. Pass `GameClient(port=N)` only to override. (`GameBridge()` in `run` scripts auto-discovers identically.) **Every method below has a 1-line CLI equivalent above; only reach for Python when you need to keep a client open across many steps without the connection-per-call overhead.**
+`from godot_cli_control.client import GameClient` — async WebSocket client; use as `async with GameClient() as client:`. **With no `port` argument it auto-discovers from `.cli_control/instances/<name>/port`** (the same file the daemon writes and the CLI reads), falling back to `9877` if absent — so a no-arg `GameClient()` connects to a running daemon out of the box. Pass `GameClient(port=N)` to override with an explicit port, or `GameClient(instance="server")` to target a named instance (when `port=None`, `instance` takes effect; explicit `port` wins). (`GameBridge(instance="server")` in `run` scripts works identically.) **Every method below has a 1-line CLI equivalent above; only reach for Python when you need to keep a client open across many steps without the connection-per-call overhead.**
 
 Errors raise `RpcError(code, message)` (a `RuntimeError` subclass) that preserves the server's error code — useful for retrying `1004 "combo in progress"`.
 
@@ -466,6 +527,7 @@ pytest_plugins = ["godot_cli_control.pytest_plugin"]
 
 ## Common pitfalls
 
+- **Multiple instances running and you forgot `--instance`** — exit 64 / code `-1003`, message lists all running instance names: `"multiple instances running: client1, server — pass --instance <name>"`. Read the message, pick the name you want, and re-run with `godot-cli-control --instance <name> <subcommand>`. The same applies to `daemon` subcommands (use `--name <instance>` instead of `--instance`).
 - **`{"ok": false, "error": {"code": -1001, ...}}` on every RPC** — daemon isn't running. Run `godot-cli-control daemon status` to confirm, then `daemon start`.
 - **Node paths must be absolute** — start with `/root/...`. Relative paths return `node not found`.
 - **`InvalidMessage` / `did not receive a valid HTTP response`** — `all_proxy` / `http_proxy` env var is hijacking localhost. The client sets `proxy=None` to defend, but if you see weird handshake errors, `unset all_proxy` first.

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,20 @@
+"""pytest 共享 fixtures —— 跨测试模块复用（DRY）。"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def dead_pid() -> int:
+    """一个 100% 已死、跨平台稳定的 PID。
+
+    起一个立即退出的子进程并 reap（wait）掉，其 PID 此后保证不存活——
+    比硬编码 magic PID（如 2_000_000）稳：后者依赖 OS 的 PID 上限，
+    Linux pid_max=4194304 下长跑系统理论上可能真有进程占到该 PID 而 flaky。
+    """
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait()
+    return proc.pid

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -20,8 +20,9 @@ from godot_cli_control.client import DEFAULT_PORT
 class _StubClient:
     """替代 GameClient 的桩。所有 async 方法把调用记录到 ``calls`` 并返回预置值。"""
 
-    def __init__(self, port: int = DEFAULT_PORT) -> None:
+    def __init__(self, port: int = DEFAULT_PORT, instance: str | None = None) -> None:
         self.port = port
+        self.instance = instance
         self.calls: list[tuple[str, tuple, dict]] = []
         # 每个方法的预置返回值；默认 None
         self.returns: dict[str, Any] = {}
@@ -161,8 +162,9 @@ def stub_client(monkeypatch: pytest.MonkeyPatch) -> _StubClient:
     """patch 模块级 GameClient 符号，让 GameBridge() 实例化时拿到桩。"""
     holder: dict[str, _StubClient] = {}
 
-    def _factory(port: int = DEFAULT_PORT) -> _StubClient:
-        c = _StubClient(port=port)
+    def _factory(port: int = DEFAULT_PORT, instance: str | None = None) -> _StubClient:
+        # instance 参数接入后 GameBridge 会透传过来，桩需接收以避免 TypeError
+        c = _StubClient(port=port, instance=instance)
         holder["client"] = c
         return c
 
@@ -703,3 +705,38 @@ def test_errors_passes_cursor(stub_client: dict) -> None:
     assert result["marker"] == 5
     assert c.calls[-1] == ("errors", (), {"since": 3, "limit": 7})
     b.close()
+
+
+# ── Task 4: instance 参数透传 ──
+
+
+def test_bridge_instance_param_forwarded_to_game_client(stub_client: dict) -> None:
+    """GameBridge(instance="server") 必须把 instance 透传给 GameClient。
+
+    stub_client fixture 已 patch 掉 bridge_mod.GameClient → _StubClient。
+    _StubClient.__init__ 只接受 port=，不接受 instance=，
+    所以需要升级 _StubClient 以验证透传行为。
+    本测试另开一条 monkeypatch 路径：记录构造参数。
+    """
+    received_kwargs: dict = {}
+
+    class _CapturingStub(_StubClient):
+        def __init__(self, port: int = DEFAULT_PORT, instance: str | None = None) -> None:
+            super().__init__(port=port)
+            received_kwargs["port"] = port
+            received_kwargs["instance"] = instance
+
+    import godot_cli_control.bridge as _bridge_mod
+
+    # 临时用 _CapturingStub 替换，不影响其他测试
+    original = _bridge_mod.GameClient
+    _bridge_mod.GameClient = _CapturingStub  # type: ignore
+    try:
+        b = GameBridge(instance="server")
+        b.close()
+    finally:
+        _bridge_mod.GameClient = original
+
+    assert received_kwargs.get("instance") == "server", (
+        f"GameBridge 应把 instance='server' 透传给 GameClient，实际收到 {received_kwargs}"
+    )

--- a/python/tests/test_bridge.py
+++ b/python/tests/test_bridge.py
@@ -740,3 +740,74 @@ def test_bridge_instance_param_forwarded_to_game_client(stub_client: dict) -> No
     assert received_kwargs.get("instance") == "server", (
         f"GameBridge 应把 instance='server' 透传给 GameClient，实际收到 {received_kwargs}"
     )
+
+
+# ── Task 4: event loop 泄漏防御 ──
+
+
+def test_loop_closed_when_client_constructor_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GameClient 构造抛异常（如 InstanceAmbiguityError）时，
+    已建的 event loop 必须被 close，避免 ResourceWarning 和 fd 累积。
+
+    策略：monkeypatch asyncio.new_event_loop，捕获建立的 loop 对象；
+    再 patch bridge_mod.GameClient 构造直接抛错；
+    最后断言 captured_loop.is_closed()。
+    """
+    import asyncio as _asyncio
+
+    captured: list[_asyncio.AbstractEventLoop] = []
+    real_new_event_loop = _asyncio.new_event_loop
+
+    def _capturing_new_event_loop() -> _asyncio.AbstractEventLoop:
+        loop = real_new_event_loop()
+        captured.append(loop)
+        return loop
+
+    monkeypatch.setattr(_asyncio, "new_event_loop", _capturing_new_event_loop)
+
+    import godot_cli_control.bridge as _bridge_mod
+
+    class _BoomClient:
+        def __init__(self, port: int = DEFAULT_PORT, instance: str | None = None) -> None:
+            raise RuntimeError("构造爆炸（模拟 InstanceAmbiguityError）")
+
+    monkeypatch.setattr(_bridge_mod, "GameClient", _BoomClient)
+
+    with pytest.raises(RuntimeError, match="构造爆炸"):
+        GameBridge()
+
+    assert len(captured) == 1, "应恰好创建了一个 event loop"
+    assert captured[0].is_closed(), "构造失败后 event loop 必须已 close，否则会泄漏"
+
+
+def test_loop_closed_when_connect_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """connect() 抛异常（ConnectionError 等）时，event loop 同样必须 close。
+
+    此路径在多实例 feature 上线后变为常见路径（daemon 未启动即连接），
+    不能每次都泄漏一个 selector fd。
+    """
+    import asyncio as _asyncio
+
+    captured: list[_asyncio.AbstractEventLoop] = []
+    real_new_event_loop = _asyncio.new_event_loop
+
+    def _capturing_new_event_loop() -> _asyncio.AbstractEventLoop:
+        loop = real_new_event_loop()
+        captured.append(loop)
+        return loop
+
+    monkeypatch.setattr(_asyncio, "new_event_loop", _capturing_new_event_loop)
+
+    import godot_cli_control.bridge as _bridge_mod
+
+    class _ConnectBoomClient(_StubClient):
+        async def connect(self, **kwargs: object) -> None:
+            raise ConnectionError("连接爆炸（模拟 daemon 未启动）")
+
+    monkeypatch.setattr(_bridge_mod, "GameClient", _ConnectBoomClient)
+
+    with pytest.raises(ConnectionError, match="连接爆炸"):
+        GameBridge()
+
+    assert len(captured) == 1, "应恰好创建了一个 event loop"
+    assert captured[0].is_closed(), "connect 失败后 event loop 必须已 close，否则会泄漏"

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -3332,58 +3332,29 @@ def test_rpc_ambiguity_is_preflight(
 
     discover_port 在本地 FS 即可判定歧义（N≥2），CLI 必须在 _run_rpc 之前
     报错，不让 agent 等 30s connection retry（CLAUDE.md 契约 #5）。
+
+    驱动真实 main()，而非复现其内部逻辑——防止 port-discovery 分支重构后测试失联。
     """
-    import argparse
     import json as _json
 
     import godot_cli_control.cli as cli_mod
-    from godot_cli_control.cli import EXIT_USAGE, OUTPUT_JSON, RPC_BY_NAME
+    from godot_cli_control.cli import EXIT_USAGE, main
 
     _make_two_live_instances(tmp_path)
     monkeypatch.chdir(tmp_path)
 
-    # 断言 _run_rpc 没有被调用（即使调用了，AsyncMock 也会立即抛以防漏过）
-    _run_rpc_called: list[bool] = []
+    # 哨兵：_run_rpc 一旦被调就 fail——preflight 必须在它之前短路
+    async def _sentinel(*_a: Any, **_kw: Any) -> int:
+        pytest.fail("_run_rpc 不应被调用：preflight 应在 InstanceAmbiguityError 时短路")
+        return 0  # 永不到达，满足类型检查
 
-    async def _fake_run_rpc(*_a: Any, **_kw: Any) -> int:
-        _run_rpc_called.append(True)
-        return 0
+    monkeypatch.setattr(cli_mod, "_run_rpc", _sentinel)
+    monkeypatch.setattr(sys, "argv", ["godot-cli-control", "tree"])
 
-    monkeypatch.setattr(cli_mod, "_run_rpc", _fake_run_rpc)
+    with pytest.raises(SystemExit) as exc:
+        main()
 
-    ns = argparse.Namespace(
-        cmd="tree",
-        port=None,
-        instance=None,  # 顶层 --instance 未传
-        output_format=OUTPUT_JSON,
-    )
-    spec = RPC_BY_NAME["tree"]
-    # 直接调用 main() 路径等价物：复用 main 内的 RPC 分支逻辑
-    # 用 monkeypatch 补上 preflight = None 的 spec，直接走 port 发现分支
-    import asyncio
-
-    from godot_cli_control.cli import (
-        CLIENT_CODE_USAGE,
-        _emit_error_payload,
-        _output_format,
-    )
-    from godot_cli_control.daemon import InstanceAmbiguityError, discover_port
-
-    fmt = _output_format(ns)
-    port = ns.port
-    error_emitted = False
-    exit_code_got: int | None = None
-    if port is None:
-        try:
-            port = discover_port(instance=ns.instance) or 7777
-        except InstanceAmbiguityError as e:
-            _emit_error_payload(CLIENT_CODE_USAGE, str(e))
-            error_emitted = True
-            exit_code_got = EXIT_USAGE
-
-    assert error_emitted, "应在 InstanceAmbiguityError 时直接报错"
-    assert exit_code_got == EXIT_USAGE
-    assert not _run_rpc_called, "_run_rpc 不应被调用"
+    assert exc.value.code == EXIT_USAGE
     out = capsys.readouterr().out.strip()
     payload = _json.loads(out)
     assert payload["ok"] is False
@@ -3397,12 +3368,15 @@ def test_rpc_explicit_instance_not_running_preflight(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """只有 server 活、--instance nope → 64/-1003，message 含运行中实例名。"""
+    """只有 server 活、--instance nope → 64/-1003，message 含运行中实例名。
+
+    驱动真实 main()，而非复现其内部逻辑——防止 port-discovery 分支重构后测试失联。
+    """
     import json as _json
     import os
 
-    from godot_cli_control.cli import CLIENT_CODE_USAGE, EXIT_USAGE, _emit_error_payload
-    from godot_cli_control.daemon import InstanceAmbiguityError, discover_port
+    import godot_cli_control.cli as cli_mod
+    from godot_cli_control.cli import EXIT_USAGE, main
 
     inst_dir = tmp_path / ".cli_control" / "instances" / "server"
     inst_dir.mkdir(parents=True)
@@ -3410,14 +3384,18 @@ def test_rpc_explicit_instance_not_running_preflight(
     (inst_dir / "port").write_text("7042")
     monkeypatch.chdir(tmp_path)
 
-    try:
-        discover_port(instance="nope")
-        pytest.fail("应抛 InstanceAmbiguityError")
-    except InstanceAmbiguityError as e:
-        _emit_error_payload(CLIENT_CODE_USAGE, str(e))
-        exit_code = EXIT_USAGE
+    # 哨兵：_run_rpc 一旦被调就 fail
+    async def _sentinel(*_a: Any, **_kw: Any) -> int:
+        pytest.fail("_run_rpc 不应被调用：--instance nope 应在连接前报错")
+        return 0
 
-    assert exit_code == EXIT_USAGE
+    monkeypatch.setattr(cli_mod, "_run_rpc", _sentinel)
+    monkeypatch.setattr(sys, "argv", ["godot-cli-control", "--instance", "nope", "tree"])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == EXIT_USAGE
     out = capsys.readouterr().out.strip()
     payload = _json.loads(out)
     assert payload["ok"] is False
@@ -3430,11 +3408,14 @@ def test_rpc_single_instance_auto_selected(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """唯一实例 server（port 7042）→ _run_rpc 收到 port=7042。"""
-    import asyncio
+    """唯一实例 server（port 7042）→ main() 经 discover_port 把 port=7042 传给 _run_rpc。
+
+    驱动真实 main()，而非复现其内部逻辑——防止 port-discovery 分支重构后测试失联。
+    """
     import os
 
     import godot_cli_control.cli as cli_mod
+    from godot_cli_control.cli import main
 
     inst_dir = tmp_path / ".cli_control" / "instances" / "server"
     inst_dir.mkdir(parents=True)
@@ -3449,28 +3430,12 @@ def test_rpc_single_instance_auto_selected(
         return 0
 
     monkeypatch.setattr(cli_mod, "_run_rpc", _fake_run_rpc)
+    monkeypatch.setattr(sys, "argv", ["godot-cli-control", "tree"])
 
-    # 直接调用 main 的 RPC 分支逻辑（discover_port + _run_rpc）
-    from godot_cli_control.cli import DEFAULT_PORT, RPC_BY_NAME, _output_format
-    from godot_cli_control.daemon import InstanceAmbiguityError, discover_port
+    with pytest.raises(SystemExit) as exc:
+        main()
 
-    import argparse
-
-    ns = argparse.Namespace(
-        cmd="tree",
-        port=None,
-        instance=None,
-        output_format="json",
-    )
-    fmt = _output_format(ns)
-    spec = RPC_BY_NAME["tree"]
-    port = ns.port
-    if port is None:
-        try:
-            port = discover_port(instance=ns.instance) or DEFAULT_PORT
-        except InstanceAmbiguityError:
-            pytest.fail("单实例不应歧义")
-    asyncio.run(cli_mod._run_rpc(spec, ns, port, fmt))
+    assert exc.value.code == 0
     assert captured_port == [7042], f"应选 7042，实际 {captured_port}"
 
 
@@ -3479,16 +3444,30 @@ def test_rpc_explicit_instance_resolves_port(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """两实例活，--instance client1（port 7002）→ discover_port 返回 7002。"""
-    import os
+    """两实例活，--instance client1（port 7002）→ main() 把 port=7002 传给 _run_rpc。
 
-    from godot_cli_control.daemon import InstanceAmbiguityError, discover_port
+    驱动真实 main()，验证 --instance 选靶经过完整 CLI 路径正确解析到 7002。
+    """
+    import godot_cli_control.cli as cli_mod
+    from godot_cli_control.cli import main
 
     _make_two_live_instances(tmp_path)
     monkeypatch.chdir(tmp_path)
 
-    port = discover_port(instance="client1")
-    assert port == 7002, f"应返回 7002，实际 {port}"
+    captured_port: list[int] = []
+
+    async def _fake_run_rpc(spec: Any, ns: Any, port: int, fmt: str) -> int:
+        captured_port.append(port)
+        return 0
+
+    monkeypatch.setattr(cli_mod, "_run_rpc", _fake_run_rpc)
+    monkeypatch.setattr(sys, "argv", ["godot-cli-control", "--instance", "client1", "tree"])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == 0
+    assert captured_port == [7002], f"应选 7002，实际 {captured_port}"
 
 
 def test_run_ambiguous_without_name(

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -3286,3 +3286,312 @@ def test_status_auto_selects_single_named_instance(
     assert payload["ok"] is True
     assert payload["result"]["state"] == "running"
     assert payload["result"].get("instance") == "server"
+
+
+# ── Task 6：顶层 --instance 选靶 + cmd_run 实例解析 ──
+
+
+def test_top_level_instance_and_port_mutually_exclusive(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--instance x --port 1 tree`` → SystemExit(64) + -1003 信封。
+
+    argparse mutually_exclusive_group 报错经 _EnvelopeArgumentParser.error()
+    落进 JSON 信封，exit code 64。
+    """
+    import json as _json
+
+    from godot_cli_control.cli import EXIT_USAGE, build_parser
+
+    with pytest.raises(SystemExit) as exc:
+        build_parser().parse_args(["--instance", "x", "--port", "1", "tree"])
+    assert exc.value.code == EXIT_USAGE
+    out = capsys.readouterr().out.strip()
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+
+
+def _make_two_live_instances(tmp_path: Path) -> None:
+    """在 tmp_path 下铺两个活实例 server + client1（pid = os.getpid()）。"""
+    import os
+
+    for name in ("server", "client1"):
+        d = tmp_path / ".cli_control" / "instances" / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "godot.pid").write_text(str(os.getpid()))
+        (d / "port").write_text("7001" if name == "server" else "7002")
+
+
+def test_rpc_ambiguity_is_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """两实例活、无 --instance → preflight exit 64/-1003，不发网络连接。
+
+    discover_port 在本地 FS 即可判定歧义（N≥2），CLI 必须在 _run_rpc 之前
+    报错，不让 agent 等 30s connection retry（CLAUDE.md 契约 #5）。
+    """
+    import argparse
+    import json as _json
+
+    import godot_cli_control.cli as cli_mod
+    from godot_cli_control.cli import EXIT_USAGE, OUTPUT_JSON, RPC_BY_NAME
+
+    _make_two_live_instances(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # 断言 _run_rpc 没有被调用（即使调用了，AsyncMock 也会立即抛以防漏过）
+    _run_rpc_called: list[bool] = []
+
+    async def _fake_run_rpc(*_a: Any, **_kw: Any) -> int:
+        _run_rpc_called.append(True)
+        return 0
+
+    monkeypatch.setattr(cli_mod, "_run_rpc", _fake_run_rpc)
+
+    ns = argparse.Namespace(
+        cmd="tree",
+        port=None,
+        instance=None,  # 顶层 --instance 未传
+        output_format=OUTPUT_JSON,
+    )
+    spec = RPC_BY_NAME["tree"]
+    # 直接调用 main() 路径等价物：复用 main 内的 RPC 分支逻辑
+    # 用 monkeypatch 补上 preflight = None 的 spec，直接走 port 发现分支
+    import asyncio
+
+    from godot_cli_control.cli import (
+        CLIENT_CODE_USAGE,
+        _emit_error_payload,
+        _output_format,
+    )
+    from godot_cli_control.daemon import InstanceAmbiguityError, discover_port
+
+    fmt = _output_format(ns)
+    port = ns.port
+    error_emitted = False
+    exit_code_got: int | None = None
+    if port is None:
+        try:
+            port = discover_port(instance=ns.instance) or 7777
+        except InstanceAmbiguityError as e:
+            _emit_error_payload(CLIENT_CODE_USAGE, str(e))
+            error_emitted = True
+            exit_code_got = EXIT_USAGE
+
+    assert error_emitted, "应在 InstanceAmbiguityError 时直接报错"
+    assert exit_code_got == EXIT_USAGE
+    assert not _run_rpc_called, "_run_rpc 不应被调用"
+    out = capsys.readouterr().out.strip()
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert "server" in payload["error"]["message"]
+    assert "client1" in payload["error"]["message"]
+
+
+def test_rpc_explicit_instance_not_running_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """只有 server 活、--instance nope → 64/-1003，message 含运行中实例名。"""
+    import json as _json
+    import os
+
+    from godot_cli_control.cli import CLIENT_CODE_USAGE, EXIT_USAGE, _emit_error_payload
+    from godot_cli_control.daemon import InstanceAmbiguityError, discover_port
+
+    inst_dir = tmp_path / ".cli_control" / "instances" / "server"
+    inst_dir.mkdir(parents=True)
+    (inst_dir / "godot.pid").write_text(str(os.getpid()))
+    (inst_dir / "port").write_text("7042")
+    monkeypatch.chdir(tmp_path)
+
+    try:
+        discover_port(instance="nope")
+        pytest.fail("应抛 InstanceAmbiguityError")
+    except InstanceAmbiguityError as e:
+        _emit_error_payload(CLIENT_CODE_USAGE, str(e))
+        exit_code = EXIT_USAGE
+
+    assert exit_code == EXIT_USAGE
+    out = capsys.readouterr().out.strip()
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert "server" in payload["error"]["message"]
+
+
+def test_rpc_single_instance_auto_selected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """唯一实例 server（port 7042）→ _run_rpc 收到 port=7042。"""
+    import asyncio
+    import os
+
+    import godot_cli_control.cli as cli_mod
+
+    inst_dir = tmp_path / ".cli_control" / "instances" / "server"
+    inst_dir.mkdir(parents=True)
+    (inst_dir / "godot.pid").write_text(str(os.getpid()))
+    (inst_dir / "port").write_text("7042")
+    monkeypatch.chdir(tmp_path)
+
+    captured_port: list[int] = []
+
+    async def _fake_run_rpc(spec: Any, ns: Any, port: int, fmt: str) -> int:
+        captured_port.append(port)
+        return 0
+
+    monkeypatch.setattr(cli_mod, "_run_rpc", _fake_run_rpc)
+
+    # 直接调用 main 的 RPC 分支逻辑（discover_port + _run_rpc）
+    from godot_cli_control.cli import DEFAULT_PORT, RPC_BY_NAME, _output_format
+    from godot_cli_control.daemon import InstanceAmbiguityError, discover_port
+
+    import argparse
+
+    ns = argparse.Namespace(
+        cmd="tree",
+        port=None,
+        instance=None,
+        output_format="json",
+    )
+    fmt = _output_format(ns)
+    spec = RPC_BY_NAME["tree"]
+    port = ns.port
+    if port is None:
+        try:
+            port = discover_port(instance=ns.instance) or DEFAULT_PORT
+        except InstanceAmbiguityError:
+            pytest.fail("单实例不应歧义")
+    asyncio.run(cli_mod._run_rpc(spec, ns, port, fmt))
+    assert captured_port == [7042], f"应选 7042，实际 {captured_port}"
+
+
+def test_rpc_explicit_instance_resolves_port(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """两实例活，--instance client1（port 7002）→ discover_port 返回 7002。"""
+    import os
+
+    from godot_cli_control.daemon import InstanceAmbiguityError, discover_port
+
+    _make_two_live_instances(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    port = discover_port(instance="client1")
+    assert port == 7002, f"应返回 7002，实际 {port}"
+
+
+def test_run_ambiguous_without_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """两实例活，run x.py 无 --name → 64/-1003，不启 daemon。"""
+    import argparse
+    import json as _json
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control.cli import EXIT_USAGE, OUTPUT_JSON, cmd_run
+
+    _make_two_live_instances(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # daemon start/is_running 不应被调用（断言不会 raise）
+    _daemon_start_called: list[bool] = []
+
+    def _boom_start(self: Any, **__: Any) -> None:
+        _daemon_start_called.append(True)
+        raise AssertionError("不应启动 daemon")
+
+    monkeypatch.setattr(daemon_mod.Daemon, "start", _boom_start)
+
+    script = tmp_path / "x.py"
+    script.write_text("def run(bridge): pass\n", encoding="utf-8")
+
+    ns = argparse.Namespace(
+        script=str(script),
+        name=None,  # 无 --name
+        record=False,
+        movie_path=None,
+        headless=False,
+        gui=False,
+        fps=30,
+        port=0,
+        idle_timeout="0",
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_run(ns)
+    assert rc == EXIT_USAGE
+    out = capsys.readouterr().out.strip()
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert not _daemon_start_called, "不应调用 daemon.start"
+
+
+def test_run_auto_selects_single_named_instance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """唯一 server 实例活 → cmd_run 用 instance='server'，auto_started=False。"""
+    import argparse
+    import os
+
+    import godot_cli_control.daemon as daemon_mod
+    import godot_cli_control.cli as cli_mod
+    from godot_cli_control.cli import OUTPUT_JSON, cmd_run
+
+    inst_dir = tmp_path / ".cli_control" / "instances" / "server"
+    inst_dir.mkdir(parents=True)
+    (inst_dir / "godot.pid").write_text(str(os.getpid()))
+    (inst_dir / "port").write_text("7042")
+    monkeypatch.chdir(tmp_path)
+
+    # 桩掉 _exec_user_script，捕获收到的 port
+    captured_port: list[int] = []
+
+    def _fake_exec(script_path: Any, port: int, **kw: Any) -> int:
+        captured_port.append(port)
+        return 0
+
+    monkeypatch.setattr(cli_mod, "_exec_user_script", _fake_exec)
+
+    # daemon.start 不应被调用（auto_started 应为 False）
+    _start_called: list[bool] = []
+
+    def _boom_start(self: Any, **__: Any) -> None:
+        _start_called.append(True)
+        raise AssertionError("不应启动 daemon（实例已在跑）")
+
+    monkeypatch.setattr(daemon_mod.Daemon, "start", _boom_start)
+
+    script = tmp_path / "x.py"
+    script.write_text("def run(bridge): pass\n", encoding="utf-8")
+
+    ns = argparse.Namespace(
+        script=str(script),
+        name=None,  # 不传 --name，自动选唯一实例
+        record=False,
+        movie_path=None,
+        headless=False,
+        gui=False,
+        fps=30,
+        port=0,
+        idle_timeout="0",
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_run(ns)
+    assert rc == 0, f"脚本应成功退出，got {rc}"
+    assert captured_port == [7042], f"应连 port 7042，实际 {captured_port}"
+    assert not _start_called, "不应调用 daemon.start（server 实例已在跑）"

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -2915,6 +2915,7 @@ def test_daemon_logs_returns_tail_lines(
     assert payload["result"]["lines"] == [f"line{i}" for i in range(90, 100)]
     assert payload["result"]["returned"] == 10
     assert payload["result"]["path"].endswith("godot.log")
+    assert payload["result"]["instance"] == "default"
 
 
 def test_daemon_logs_missing_file_is_infra_error(

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -3764,3 +3764,52 @@ def test_name_and_instance_same_value_ok(
     assert stopped_instances == ["server"], (
         f"相同值时应正常停 server，实际 {stopped_instances}"
     )
+
+
+# ── I1 回归：stop --all 拦截顶层 --instance ──
+
+
+def test_stop_all_with_top_level_instance_is_usage_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """``--instance server daemon stop --all`` 必须被拦截为用法错误 (exit 64 / -1003)。
+
+    顶层 ``--instance`` 是实例选靶语义，与 ``--all`` 互斥。
+    原先只查 ``ns.name``，导致顶层 ``--instance`` 被静默吞掉——全局停掉所有实例。
+    修复后应立即报错，且 Daemon.stop 和 registry.list_all 均不应被调用。
+    """
+    import json as _json
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control import registry
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    # 哨兵：任何 stop / list_all 调用都算断言失败
+    def _should_not_stop(self: Any) -> int:
+        raise AssertionError("stop --all 拦截失效：Daemon.stop 不应被调用")
+
+    def _should_not_list_all() -> list:
+        raise AssertionError("stop --all 拦截失效：registry.list_all 不应被调用")
+
+    monkeypatch.setattr(daemon_mod.Daemon, "stop", _should_not_stop)
+    monkeypatch.setattr(registry, "list_all", _should_not_list_all)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["godot-cli-control", "--instance", "server", "daemon", "stop", "--all"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == EXIT_USAGE, f"期望 exit 64，实际 {exc.value.code}"
+    out = capsys.readouterr().out.strip()
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    # 消息应提到互斥语义，便于 agent 理解
+    msg = payload["error"]["message"]
+    assert "--all" in msg, f"message 应含 '--all'，实际：{msg!r}"

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -3590,8 +3590,6 @@ def test_top_level_instance_works_for_daemon_stop(
     若不生效，_resolve_daemon_instance 会看到 N≥2 且无 --name，报歧义 exit 64。
     驱动真实 main()，验证完整 CLI 路径不静默吞掉 --instance。
     """
-    import json as _json
-
     import godot_cli_control.daemon as daemon_mod
     from godot_cli_control.cli import EXIT_OK, main
 
@@ -3629,7 +3627,6 @@ def test_top_level_instance_works_for_run(
     顶层 --instance 在 run 子命令路径（_resolve_daemon_instance）也必须生效。
     驱动真实 main()，防止重构失联。
     """
-    import json as _json
     import os
 
     import godot_cli_control.cli as cli_mod

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -931,10 +931,13 @@ def test_daemon_status_json_envelope_running(
     rc = cmd_daemon_status(ns)
     assert rc == 0
     payload = _json.loads(capsys.readouterr().out)
-    assert payload == {
-        "ok": True,
-        "result": {"state": "running", "pid": 4242, "port": 9877},
-    }
+    # Task 5 起 result 含 instance 字段（默认 "default"）
+    assert payload["ok"] is True
+    result = payload["result"]
+    assert result["state"] == "running"
+    assert result["pid"] == 4242
+    assert result["port"] == 9877
+    assert "instance" in result  # 新增字段，默认 "default"
 
 
 def test_daemon_status_json_envelope_stopped(
@@ -2146,10 +2149,11 @@ def test_daemon_stop_subcommand_parses_all_and_project() -> None:
     # 所以与 Path("/tmp/x") 比较保证跨平台。
     assert ns.project == Path("/tmp/x")
 
-    # mutually exclusive — argparse should refuse both
-    import pytest as _pt
-    with _pt.raises(SystemExit):
-        build_parser().parse_args(["daemon", "stop", "--all", "--project", "/tmp/x"])
+    # Task 5 起 --all --project 是允许的（"停某项目下所有实例"），
+    # --all 与 --name 的互斥改为 cmd_daemon_stop 内显式校验，argparse 层不拦。
+    ns = build_parser().parse_args(["daemon", "stop", "--all", "--project", "/tmp/x"])
+    assert ns.all is True
+    assert ns.project == Path("/tmp/x")
 
 
 def test_daemon_start_idle_timeout_flag_parses() -> None:
@@ -2932,3 +2936,352 @@ def test_daemon_logs_missing_file_is_infra_error(
     payload = _json.loads(capsys.readouterr().out.strip())
     assert payload["ok"] is False
     assert payload["error"]["code"] == CLIENT_CODE_PRECONDITION
+
+
+# ---------------------------------------------------------------------------
+# Task 5: daemon 子命令 --name 选靶 + stop 矩阵 + ls instance 列
+# ---------------------------------------------------------------------------
+
+
+def test_daemon_subcommands_accept_name() -> None:
+    """start/run/status/logs/stop 五个子命令均接受 --name，
+    且 status/logs/stop 不长出 start 专属 flag（如 --record）。"""
+    from godot_cli_control.cli import build_parser
+
+    parser = build_parser()
+    # status / logs / stop 接受 --name
+    for argv in (
+        ["daemon", "status", "--name", "server"],
+        ["daemon", "logs", "--name", "server"],
+        ["daemon", "stop", "--name", "server"],
+    ):
+        ns = parser.parse_args(argv)
+        assert ns.name == "server", f"argv={argv} ns.name 应为 'server'"
+
+    # start 接受 --name
+    ns = parser.parse_args(["daemon", "start", "--name", "server"])
+    assert ns.name == "server"
+
+    # run 接受 --name（Task 6 才真正用它；这里只校验注册）
+    ns = parser.parse_args(["run", "x.py", "--name", "server"])
+    assert ns.name == "server"
+
+    # status 不应有 start 专属 --record
+    with pytest.raises(SystemExit):
+        parser.parse_args(["daemon", "status", "--record"])
+
+
+def test_invalid_instance_name_usage_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """非法实例名（含 /）→ argparse type 校验失败 → exit 64 + -1003 信封。"""
+    import json as _json
+
+    from godot_cli_control.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["daemon", "start", "--name", "a/b"])
+    assert exc_info.value.code == 64
+    out = capsys.readouterr().out.strip()
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+
+
+def test_stop_all_with_name_is_usage_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--all --name 组合非法 → exit 64 + -1003 信封。"""
+    import json as _json
+
+    from godot_cli_control.cli import EXIT_USAGE, OUTPUT_JSON, cmd_daemon_stop
+
+    ns = __import__("argparse").Namespace(
+        all=True,
+        name="server",
+        project=None,
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_daemon_stop(ns)
+    assert rc == EXIT_USAGE
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+
+
+def test_stop_ambiguous_without_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """cwd 有两个活实例但未传 --name → exit 64 + -1003，message 含两个实例名。"""
+    import json as _json
+
+    from godot_cli_control.cli import EXIT_USAGE, OUTPUT_JSON, cmd_daemon_stop
+
+    # 铺两个活实例目录（pid=os.getpid() 确保探活通过）
+    import os
+
+    for name in ("server", "client1"):
+        inst_dir = tmp_path / ".cli_control" / "instances" / name
+        inst_dir.mkdir(parents=True)
+        (inst_dir / "godot.pid").write_text(str(os.getpid()))
+
+    monkeypatch.chdir(tmp_path)
+    ns = __import__("argparse").Namespace(
+        all=False,
+        name=None,
+        project=None,
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_daemon_stop(ns)
+    assert rc == EXIT_USAGE
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    # message 应包含两个实例名
+    msg = payload["error"]["message"]
+    assert "server" in msg
+    assert "client1" in msg
+
+
+def test_stop_all_threads_instance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--all 全局停止时，以每条记录的 instance 字段构造 Daemon（防止永远打 default 回归）。"""
+    import json as _json
+
+    import godot_cli_control.registry as reg_mod
+    from godot_cli_control.cli import EXIT_OK, OUTPUT_JSON, cmd_daemon_stop
+    from godot_cli_control.registry import DaemonRecord
+
+    # 两条不同实例的注册记录
+    records = [
+        DaemonRecord(
+            project_root=str(tmp_path),
+            pid=99991,
+            port=9991,
+            started_at="2026-01-01T00:00:00+00:00",
+            godot_bin="/usr/bin/godot",
+            log_path=str(tmp_path / "a.log"),
+            instance="server",
+        ),
+        DaemonRecord(
+            project_root=str(tmp_path),
+            pid=99992,
+            port=9992,
+            started_at="2026-01-01T00:00:00+00:00",
+            godot_bin="/usr/bin/godot",
+            log_path=str(tmp_path / "b.log"),
+            instance="client1",
+        ),
+    ]
+    monkeypatch.setattr(reg_mod, "list_all", lambda: records)
+
+    # 收集 Daemon.stop() 收到的 (project_root, instance)
+    stop_calls: list[tuple[str, str]] = []
+
+    import godot_cli_control.daemon as daemon_mod
+
+    def _fake_stop(self: Any) -> int:
+        stop_calls.append((str(self.project_root), self.instance))
+        return 0
+
+    monkeypatch.setattr(daemon_mod.Daemon, "stop", _fake_stop)
+
+    ns = __import__("argparse").Namespace(
+        all=True,
+        name=None,
+        project=None,
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_daemon_stop(ns)
+    assert rc == EXIT_OK
+    # 两个实例各自被独立 stop
+    assert sorted(stop_calls) == sorted(
+        [(str(tmp_path), "server"), (str(tmp_path), "client1")]
+    ), f"stop_calls={stop_calls}"
+    # 信封包含 instance 字段
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload["ok"] is True
+    stopped = payload["result"]["stopped"]
+    assert {e["instance"] for e in stopped} == {"server", "client1"}
+
+
+def test_stop_all_project_combination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--all --project <tmp>：tmp 下两个活实例都被 stop。"""
+    import json as _json
+    import os
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control.cli import EXIT_OK, OUTPUT_JSON, cmd_daemon_stop
+
+    # 铺两个活实例目录
+    for name in ("alpha", "beta"):
+        inst_dir = tmp_path / ".cli_control" / "instances" / name
+        inst_dir.mkdir(parents=True)
+        (inst_dir / "godot.pid").write_text(str(os.getpid()))
+
+    stop_calls: list[tuple[str, str]] = []
+
+    def _fake_stop(self: Any) -> int:
+        stop_calls.append((str(self.project_root), self.instance))
+        return 0
+
+    monkeypatch.setattr(daemon_mod.Daemon, "stop", _fake_stop)
+
+    ns = __import__("argparse").Namespace(
+        all=True,
+        name=None,
+        project=tmp_path,
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_daemon_stop(ns)
+    assert rc == EXIT_OK
+    assert sorted(i for _, i in stop_calls) == ["alpha", "beta"]
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload["ok"] is True
+
+
+def test_ls_json_includes_instance(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """daemon ls JSON 模式：每条记录含 instance 字段。"""
+    import json as _json
+
+    import godot_cli_control.registry as reg_mod
+    from godot_cli_control.cli import OUTPUT_JSON, cmd_daemon_ls
+    from godot_cli_control.registry import DaemonRecord
+
+    records = [
+        DaemonRecord(
+            project_root="/tmp/proj",
+            pid=1234,
+            port=9999,
+            started_at="2026-01-01T00:00:00+00:00",
+            godot_bin="/usr/bin/godot",
+            log_path="/tmp/proj/.cli_control/instances/server/godot.log",
+            instance="server",
+        )
+    ]
+    monkeypatch.setattr(reg_mod, "list_all", lambda: records)
+
+    ns = __import__("argparse").Namespace(output_format=OUTPUT_JSON)
+    rc = cmd_daemon_ls(ns)
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload["ok"] is True
+    daemons = payload["result"]["daemons"]
+    assert len(daemons) == 1
+    assert daemons[0]["instance"] == "server"
+
+
+def test_ls_text_has_instance_column(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """daemon ls text 模式：行格式含 instance 列（pid\\tport\\tinstance\\tproject_root\\tstarted_at）。"""
+    import godot_cli_control.registry as reg_mod
+    from godot_cli_control.cli import OUTPUT_TEXT, cmd_daemon_ls
+    from godot_cli_control.registry import DaemonRecord
+
+    records = [
+        DaemonRecord(
+            project_root="/tmp/proj",
+            pid=5678,
+            port=9988,
+            started_at="2026-01-01T00:00:00+00:00",
+            godot_bin="/usr/bin/godot",
+            log_path="/tmp/proj/.cli_control/instances/server/godot.log",
+            instance="server",
+        )
+    ]
+    monkeypatch.setattr(reg_mod, "list_all", lambda: records)
+
+    ns = __import__("argparse").Namespace(output_format=OUTPUT_TEXT)
+    rc = cmd_daemon_ls(ns)
+    assert rc == 0
+    out = capsys.readouterr().out
+    # 行格式：pid\tport\tinstance\tproject_root\tstarted_at
+    assert "server" in out
+    cols = out.strip().split("\t")
+    assert cols[2] == "server", f"第 3 列应为 instance，实际: {cols}"
+
+
+def test_daemon_start_json_includes_instance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """daemon start 成功时 JSON 信封 result 包含 instance 字段。"""
+    import json as _json
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control.cli import OUTPUT_JSON, cmd_daemon_start
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(daemon_mod.Daemon, "start", lambda self, **kw: None)
+    monkeypatch.setattr(daemon_mod.Daemon, "is_running", lambda self: True)
+    monkeypatch.setattr(daemon_mod.Daemon, "current_port", lambda self: 9876)
+    monkeypatch.setattr(daemon_mod.Daemon, "read_pid", lambda self: 12345)
+
+    ns = __import__("argparse").Namespace(
+        name="server",
+        record=False,
+        movie_path=None,
+        headless=True,
+        gui=False,
+        fps=30,
+        port=0,
+        idle_timeout="0",
+        time_scale=None,
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_daemon_start(ns)
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload["ok"] is True
+    assert payload["result"]["instance"] == "server"
+    assert payload["result"]["started"] is True
+
+
+def test_status_auto_selects_single_named_instance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """只有一个命名实例在跑时，daemon status 不传 --name 也能自动选中并正确报 running。"""
+    import json as _json
+    import os
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control.cli import OUTPUT_JSON, cmd_daemon_status
+
+    # 铺 instances/server 活实例目录（pid=os.getpid()）
+    inst_dir = tmp_path / ".cli_control" / "instances" / "server"
+    inst_dir.mkdir(parents=True)
+    (inst_dir / "godot.pid").write_text(str(os.getpid()))
+    (inst_dir / "port").write_text("9876")
+
+    monkeypatch.chdir(tmp_path)
+    # 不 patch is_running，让真实 list_live_instances 探活（pid=os.getpid() 自身在跑）
+    monkeypatch.setattr(daemon_mod.Daemon, "read_pid", lambda self: os.getpid())
+    monkeypatch.setattr(daemon_mod.Daemon, "current_port", lambda self: 9876)
+
+    ns = __import__("argparse").Namespace(
+        name=None,
+        output_format=OUTPUT_JSON,
+    )
+    rc = cmd_daemon_status(ns)
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert payload["ok"] is True
+    assert payload["result"]["state"] == "running"
+    assert payload["result"].get("instance") == "server"

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -971,8 +971,9 @@ def test_daemon_status_stopped_includes_last_log(
     import godot_cli_control.daemon as daemon_mod
 
     monkeypatch.chdir(tmp_path)
-    control_dir = tmp_path / ".cli_control"
-    control_dir.mkdir()
+    # Task 1 后状态文件移入 instances/default/（spec 2026-06-07）
+    control_dir = tmp_path / ".cli_control" / "instances" / "default"
+    control_dir.mkdir(parents=True)
     log = control_dir / "godot.log"
     log.write_text("ERROR: autoload failed\n")
 
@@ -1000,8 +1001,9 @@ def test_daemon_status_stopped_includes_last_exit_code(
     import godot_cli_control.daemon as daemon_mod
 
     monkeypatch.chdir(tmp_path)
-    control_dir = tmp_path / ".cli_control"
-    control_dir.mkdir()
+    # Task 1 后状态文件移入 instances/default/（spec 2026-06-07）
+    control_dir = tmp_path / ".cli_control" / "instances" / "default"
+    control_dir.mkdir(parents=True)
     (control_dir / "godot.log").write_text("FATAL\n")
     (control_dir / "last_exit_code").write_text("137")
 
@@ -1026,8 +1028,9 @@ def test_daemon_status_stopped_text_mode_includes_last_log(
     import godot_cli_control.daemon as daemon_mod
 
     monkeypatch.chdir(tmp_path)
-    control_dir = tmp_path / ".cli_control"
-    control_dir.mkdir()
+    # Task 1 后状态文件移入 instances/default/（spec 2026-06-07）
+    control_dir = tmp_path / ".cli_control" / "instances" / "default"
+    control_dir.mkdir(parents=True)
     (control_dir / "godot.log").write_text("crash\n")
     (control_dir / "last_exit_code").write_text("11")
 
@@ -2893,8 +2896,9 @@ def test_daemon_logs_returns_tail_lines(
 
     from godot_cli_control.cli import EXIT_OK, cmd_daemon_logs
 
-    control = tmp_path / ".cli_control"
-    control.mkdir()
+    # Task 1 后日志文件移入 instances/default/（spec 2026-06-07）
+    control = tmp_path / ".cli_control" / "instances" / "default"
+    control.mkdir(parents=True)
     (control / "godot.log").write_text(
         "\n".join(f"line{i}" for i in range(100)), encoding="utf-8"
     )

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -3574,3 +3574,193 @@ def test_run_auto_selects_single_named_instance(
     assert rc == 0, f"脚本应成功退出，got {rc}"
     assert captured_port == [7042], f"应连 port 7042，实际 {captured_port}"
     assert not _start_called, "不应调用 daemon.start（server 实例已在跑）"
+
+
+# ── I1 修复：顶层 --instance 对 run/daemon 子命令生效 ──
+
+
+def test_top_level_instance_works_for_daemon_stop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """两实例活、``--instance server daemon stop``（无 --name）→ 停 server，不报歧义。
+
+    顶层 --instance 是 --name 的等价写法，在 daemon 子命令路径也必须生效。
+    若不生效，_resolve_daemon_instance 会看到 N≥2 且无 --name，报歧义 exit 64。
+    驱动真实 main()，验证完整 CLI 路径不静默吞掉 --instance。
+    """
+    import json as _json
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control.cli import EXIT_OK, main
+
+    # 铺两个活实例，若 --instance 被吞 _resolve_daemon_instance 会报歧义
+    _make_two_live_instances(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    stopped_instances: list[str] = []
+
+    def _fake_stop(self: Any) -> int:
+        stopped_instances.append(self.instance)
+        return 0  # cmd_daemon_stop 把此返回值作为 exit code
+
+    monkeypatch.setattr(daemon_mod.Daemon, "stop", _fake_stop)
+
+    monkeypatch.setattr(
+        sys, "argv", ["godot-cli-control", "--instance", "server", "daemon", "stop"]
+    )
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == EXIT_OK, f"期望 exit 0，实际 {exc.value.code}"
+    assert stopped_instances == ["server"], (
+        f"顶层 --instance 应选靶 server，实际 stop 收到 {stopped_instances}"
+    )
+
+
+def test_top_level_instance_works_for_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--instance server run x.py`` → cmd_run 用 Daemon(instance='server')。
+
+    顶层 --instance 在 run 子命令路径（_resolve_daemon_instance）也必须生效。
+    驱动真实 main()，防止重构失联。
+    """
+    import json as _json
+    import os
+
+    import godot_cli_control.cli as cli_mod
+    from godot_cli_control.cli import EXIT_OK, main
+
+    inst_dir = tmp_path / ".cli_control" / "instances" / "server"
+    inst_dir.mkdir(parents=True)
+    (inst_dir / "godot.pid").write_text(str(os.getpid()))
+    (inst_dir / "port").write_text("7001")
+    monkeypatch.chdir(tmp_path)
+
+    script = tmp_path / "x.py"
+    script.write_text("def run(bridge): pass\n", encoding="utf-8")
+
+    captured_exec: list[tuple[Any, int]] = []
+
+    def _fake_exec(script_path: Any, port: int, **kw: Any) -> int:
+        captured_exec.append((script_path, port))
+        return 0
+
+    monkeypatch.setattr(cli_mod, "_exec_user_script", _fake_exec)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["godot-cli-control", "--instance", "server", "run", str(script)],
+    )
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == EXIT_OK, f"期望 exit 0，实际 {exc.value.code}"
+    assert captured_exec, "cmd_run 应调用 _exec_user_script"
+    assert captured_exec[0][1] == 7001, (
+        f"应连 server 实例的 port 7001，实际 {captured_exec[0][1]}"
+    )
+
+
+def test_name_and_instance_conflict_is_usage_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--instance a daemon stop --name b`` → exit 64/-1003，message 含两名字。
+
+    顶层 --instance 与子命令 --name 同时传且值不同，属于用法错误，
+    必须在连 daemon 之前报错并以 JSON 信封返回。
+    """
+    import json as _json
+    import os
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    inst_dir = tmp_path / ".cli_control" / "instances" / "a"
+    inst_dir.mkdir(parents=True)
+    (inst_dir / "godot.pid").write_text(str(os.getpid()))
+    (inst_dir / "port").write_text("7001")
+    monkeypatch.chdir(tmp_path)
+
+    stop_called: list[bool] = []
+
+    def _boom_stop(self: Any) -> None:
+        stop_called.append(True)
+        raise AssertionError("不应调用 stop：冲突应在 preflight 报错")
+
+    monkeypatch.setattr(daemon_mod.Daemon, "stop", _boom_stop)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["godot-cli-control", "--instance", "a", "daemon", "stop", "--name", "b"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == EXIT_USAGE, f"期望 exit 64，实际 {exc.value.code}"
+    out = capsys.readouterr().out.strip()
+    payload = _json.loads(out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert "a" in payload["error"]["message"], "message 应含 --instance 值 a"
+    assert "b" in payload["error"]["message"], "message 应含 --name 值 b"
+    assert not stop_called, "不应调用 stop"
+
+
+def test_name_and_instance_same_value_ok(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--instance server daemon stop --name server`` → 正常，不报冲突。
+
+    相同值的冗余传参是合法写法（脚本模板可能同时传两个），不应报错。
+    驱动真实 main()。
+    """
+    import os
+
+    import godot_cli_control.daemon as daemon_mod
+    from godot_cli_control.cli import EXIT_OK, main
+
+    inst_dir = tmp_path / ".cli_control" / "instances" / "server"
+    inst_dir.mkdir(parents=True)
+    (inst_dir / "godot.pid").write_text(str(os.getpid()))
+    (inst_dir / "port").write_text("7001")
+    monkeypatch.chdir(tmp_path)
+
+    stopped_instances: list[str] = []
+
+    def _fake_stop(self: Any) -> int:
+        stopped_instances.append(self.instance)
+        return 0  # cmd_daemon_stop 把此返回值作为 exit code
+
+    monkeypatch.setattr(daemon_mod.Daemon, "stop", _fake_stop)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "godot-cli-control",
+            "--instance",
+            "server",
+            "daemon",
+            "stop",
+            "--name",
+            "server",
+        ],
+    )
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == EXIT_OK, f"期望 exit 0，实际 {exc.value.code}"
+    assert stopped_instances == ["server"], (
+        f"相同值时应正常停 server，实际 {stopped_instances}"
+    )

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -1049,7 +1050,7 @@ async def test_errors_defaults() -> None:
 # ---- Task 4: instance 参数接入实例解析单入口 ----
 
 
-def test_client_instance_param_resolves_port(tmp_path: "pytest.TempPathFactory", monkeypatch: pytest.MonkeyPatch) -> None:
+def test_client_instance_param_resolves_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """GameClient(instance="server") 应通过 discover_port 解析端口（issue #91 多实例扩展）。
 
     验证：当 port=None 且 instance="server" 时，client 从注册表目录读到端口
@@ -1065,7 +1066,7 @@ def test_client_instance_param_resolves_port(tmp_path: "pytest.TempPathFactory",
     assert c._port == 7042
 
 
-def test_client_port_takes_precedence_over_instance(tmp_path: "pytest.TempPathFactory", monkeypatch: pytest.MonkeyPatch) -> None:
+def test_client_port_takes_precedence_over_instance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """显式 port 优先，instance 不触发任何发现 IO（即使目录不存在也不报错）。
 
     确保 ``GameClient(port=1234, instance="server")`` 直接用 1234，不碰文件系统。

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -1043,3 +1044,33 @@ async def test_errors_defaults() -> None:
     finally:
         client_mod.GameClient.request = orig
     assert captured["params"] == {"since": 0, "limit": 100}
+
+
+# ---- Task 4: instance 参数接入实例解析单入口 ----
+
+
+def test_client_instance_param_resolves_port(tmp_path: "pytest.TempPathFactory", monkeypatch: pytest.MonkeyPatch) -> None:
+    """GameClient(instance="server") 应通过 discover_port 解析端口（issue #91 多实例扩展）。
+
+    验证：当 port=None 且 instance="server" 时，client 从注册表目录读到端口
+    7042，而非回退 DEFAULT_PORT。
+    """
+    # 构造 instances/server 目录（模拟已运行的命名实例）
+    inst = tmp_path / ".cli_control" / "instances" / "server"
+    inst.mkdir(parents=True)
+    (inst / "godot.pid").write_text(str(os.getpid()))
+    (inst / "port").write_text("7042")
+    monkeypatch.chdir(tmp_path)
+    c = GameClient(instance="server")
+    assert c._port == 7042
+
+
+def test_client_port_takes_precedence_over_instance(tmp_path: "pytest.TempPathFactory", monkeypatch: pytest.MonkeyPatch) -> None:
+    """显式 port 优先，instance 不触发任何发现 IO（即使目录不存在也不报错）。
+
+    确保 ``GameClient(port=1234, instance="server")`` 直接用 1234，不碰文件系统。
+    """
+    monkeypatch.chdir(tmp_path)
+    # instance="server" 对应目录不存在；若 instance 触发了 IO 则会报错/回退 DEFAULT_PORT
+    c = GameClient(port=1234, instance="server")
+    assert c._port == 1234

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -1557,7 +1557,74 @@ def test_start_rejects_time_scale_above_max(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-import godot_cli_control.daemon as daemon_mod  # noqa: E402  模块级引用，方便 monkeypatch
+import godot_cli_control.daemon as daemon_mod  # noqa: E402  模块级引用，方便 monkeypatch 与直接引用新 API
+
+
+# ---------------------------------------------------------------------------
+# Task 3：实例解析单入口 discover_port / list_live_instances（spec 2026-06-07）
+# ---------------------------------------------------------------------------
+
+
+class TestInstanceResolution:
+    def _mk_live(self, proj: Path, name: str, port: int) -> None:
+        """在 proj/.cli_control/instances/<name>/ 写本进程 PID + port，模拟在跑的实例。"""
+        d = proj / ".cli_control" / "instances" / name
+        d.mkdir(parents=True)
+        (d / "godot.pid").write_text(str(os.getpid()))  # 本进程 = 必活
+        (d / "port").write_text(str(port))
+
+    def test_zero_running_falls_back_legacy_then_none(self, tmp_path: Path) -> None:
+        """无任何实例在跑时：无 legacy 返回 None；有 legacy port 文件则 fallback 返回它。"""
+        assert daemon_mod.discover_port(tmp_path) is None
+        legacy = tmp_path / ".cli_control"
+        legacy.mkdir()
+        (legacy / "port").write_text("9999")
+        assert daemon_mod.discover_port(tmp_path) == 9999  # legacy 只读 fallback
+
+    def test_single_running_auto_selected(self, tmp_path: Path) -> None:
+        """只有 1 个实例在跑时，不管名字，自动选中返回其端口。"""
+        self._mk_live(tmp_path, "server", 7001)
+        assert daemon_mod.discover_port(tmp_path) == 7001
+
+    def test_multiple_running_raises_ambiguity(self, tmp_path: Path) -> None:
+        """≥2 个实例在跑且未显式指定 → 抛 InstanceAmbiguityError，message 列出所有名字。"""
+        self._mk_live(tmp_path, "server", 7001)
+        self._mk_live(tmp_path, "client1", 7002)
+        with pytest.raises(daemon_mod.InstanceAmbiguityError) as ei:
+            daemon_mod.discover_port(tmp_path)
+        # message 必须列出全部实例名，agent 靠它知道下一步传什么
+        assert "client1" in str(ei.value) and "server" in str(ei.value)
+
+    def test_explicit_instance_reads_only_that_dir(self, tmp_path: Path) -> None:
+        """显式 instance 时只读那一个目录，无论同时有多少别的实例。"""
+        self._mk_live(tmp_path, "server", 7001)
+        self._mk_live(tmp_path, "client1", 7002)
+        assert daemon_mod.discover_port(tmp_path, instance="client1") == 7002
+
+    def test_explicit_instance_not_running_raises(self, tmp_path: Path) -> None:
+        """显式指定的实例未在跑 → 抛 InstanceAmbiguityError，message 含在跑实例名。"""
+        self._mk_live(tmp_path, "server", 7001)
+        with pytest.raises(daemon_mod.InstanceAmbiguityError, match="server"):
+            daemon_mod.discover_port(tmp_path, instance="nope")
+
+    def test_dead_pid_instance_ignored(self, tmp_path: Path, dead_pid: int) -> None:
+        """PID 已死的实例不算「在跑」，不影响唯一活实例的自动选中。"""
+        self._mk_live(tmp_path, "server", 7001)
+        d = tmp_path / ".cli_control" / "instances" / "ghost"
+        d.mkdir(parents=True)
+        (d / "godot.pid").write_text(str(dead_pid))
+        (d / "port").write_text("7099")
+        assert daemon_mod.discover_port(tmp_path) == 7001  # 死实例不算「在跑」
+
+    def test_legacy_daemon_running_without_instances_dir(self, tmp_path: Path) -> None:
+        """legacy daemon 在跑 + instances/ 目录不存在：list_live_instances 返回 []，
+        但 discover_port 经 0-命中分支拿到 legacy port（default 实例 fallback）。"""
+        legacy = tmp_path / ".cli_control"
+        legacy.mkdir()
+        (legacy / "godot.pid").write_text(str(os.getpid()))
+        (legacy / "port").write_text("8888")
+        assert daemon_mod.list_live_instances(tmp_path) == []
+        assert daemon_mod.discover_port(tmp_path) == 8888
 
 
 class TestInstanceLayout:

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -1460,7 +1460,8 @@ def test_start_registers_in_global_registry(
 
     # 注册表隔离由 autouse fixture _isolate_registry 统一重定向到 tmp_path/reg。
     daemon, _ = _setup_start_env(tmp_path, monkeypatch)
-    record_file = tmp_path / "reg" / f"{registry.project_hash(tmp_path)}.json"
+    # 文件名格式：<hash>-<instance>.json（spec 2026-06-07）
+    record_file = tmp_path / "reg" / f"{registry.project_hash(tmp_path)}-default.json"
 
     daemon.start(port=0)
     assert record_file.exists(), "start() 后注册表 JSON 应存在"

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -42,7 +42,7 @@ def test_is_running_false_when_no_pid_file(tmp_path: Path) -> None:
 def test_is_running_false_when_pid_dead(tmp_path: Path) -> None:
     """一个永远不会存在的 PID（极大数）应被识别为非存活。"""
     daemon = Daemon(tmp_path)
-    daemon.control_dir.mkdir()
+    daemon.control_dir.mkdir(parents=True, exist_ok=True)
     daemon.pid_file.write_text("999999999")  # 极大概率不存在
     assert _process_alive(999999999) is False
     assert daemon.is_running() is False
@@ -50,14 +50,14 @@ def test_is_running_false_when_pid_dead(tmp_path: Path) -> None:
 
 def test_current_port_reads_file(tmp_path: Path) -> None:
     daemon = Daemon(tmp_path)
-    daemon.control_dir.mkdir()
+    daemon.control_dir.mkdir(parents=True, exist_ok=True)
     daemon.port_file.write_text("12345\n")
     assert daemon.current_port() == 12345
 
 
 def test_current_port_none_when_garbage(tmp_path: Path) -> None:
     daemon = Daemon(tmp_path)
-    daemon.control_dir.mkdir()
+    daemon.control_dir.mkdir(parents=True, exist_ok=True)
     daemon.port_file.write_text("not a port\n")
     assert daemon.current_port() is None
 
@@ -115,7 +115,12 @@ def test_start_rejects_when_godot_bin_missing(
 
 
 def test_read_godot_bin_pref_file(tmp_path: Path) -> None:
-    """init 写的 .cli_control/godot_bin 优先于自动检测。"""
+    """init 写的 .cli_control/godot_bin（项目级）优先于自动检测。
+
+    godot_bin 是项目级偏好（init_cmd.py 写到 .cli_control/），不随实例迁入
+    instances/；read_godot_bin_pref 必须从 _legacy_dir 读，而非 control_dir
+    （spec 2026-06-07）。
+    """
     fake_bin = tmp_path / "godot_fake"
     fake_bin.write_text("")
     fake_bin.chmod(0o755)
@@ -123,8 +128,9 @@ def test_read_godot_bin_pref_file(tmp_path: Path) -> None:
     project = tmp_path / "proj"
     project.mkdir()
     daemon = Daemon(project)
-    daemon.control_dir.mkdir()
-    (daemon.control_dir / "godot_bin").write_text(str(fake_bin) + "\n")
+    # init 写到项目级 .cli_control/godot_bin，不是 instances/default/godot_bin
+    daemon._legacy_dir.mkdir(parents=True, exist_ok=True)
+    (daemon._legacy_dir / "godot_bin").write_text(str(fake_bin) + "\n")
 
     assert daemon.read_godot_bin_pref() == str(fake_bin)
 
@@ -136,8 +142,8 @@ def test_read_godot_bin_pref_ignores_missing_file(tmp_path: Path) -> None:
 
 def test_read_godot_bin_pref_ignores_dead_path(tmp_path: Path) -> None:
     daemon = Daemon(tmp_path)
-    daemon.control_dir.mkdir()
-    (daemon.control_dir / "godot_bin").write_text("/not/real/godot\n")
+    daemon._legacy_dir.mkdir(parents=True, exist_ok=True)
+    (daemon._legacy_dir / "godot_bin").write_text("/not/real/godot\n")
     assert daemon.read_godot_bin_pref() is None
 
 
@@ -236,7 +242,7 @@ def test_stop_handles_missing_pid_file(tmp_path: Path) -> None:
 
 def test_stop_cleans_dead_pid_file(tmp_path: Path) -> None:
     daemon = Daemon(tmp_path)
-    daemon.control_dir.mkdir()
+    daemon.control_dir.mkdir(parents=True, exist_ok=True)
     daemon.pid_file.write_text("999999999")
     assert daemon.stop() == 0
     assert not daemon.pid_file.exists()
@@ -245,7 +251,7 @@ def test_stop_cleans_dead_pid_file(tmp_path: Path) -> None:
 def test_stop_cleans_port_file_when_pid_dead(tmp_path: Path) -> None:
     """死 PID 路径也清 port_file —— 避免 stale port 把 RPC 引向错误端点。"""
     daemon = Daemon(tmp_path)
-    daemon.control_dir.mkdir()
+    daemon.control_dir.mkdir(parents=True, exist_ok=True)
     daemon.pid_file.write_text("999999999")
     daemon.port_file.write_text("12345")
     assert daemon.stop() == 0
@@ -619,7 +625,7 @@ def test_stop_refuses_when_pid_not_godot(
 ) -> None:
     """PID 复用情景：现役进程名不像 Godot → 拒绝 SIGTERM 以免误杀别人的进程。"""
     daemon = Daemon(tmp_path)
-    daemon.control_dir.mkdir()
+    daemon.control_dir.mkdir(parents=True, exist_ok=True)
     daemon.pid_file.write_text(str(os.getpid()))  # 当前 python 进程，肯定 alive
     monkeypatch.setattr(
         "godot_cli_control.daemon._process_alive", lambda pid: True
@@ -855,7 +861,7 @@ def test_stop_returns_2_when_transcode_fails(
 ) -> None:
     """录制转码失败但进程已停 → stop 返回 2，让 CI 能感知录制问题。"""
     daemon = Daemon(tmp_path)
-    daemon.control_dir.mkdir()
+    daemon.control_dir.mkdir(parents=True, exist_ok=True)
     daemon.pid_file.write_text(str(os.getpid()))
     daemon.movie_path_file.write_text(str(tmp_path / "rec.avi"))
     (tmp_path / "rec.avi").write_bytes(b"data")
@@ -881,7 +887,7 @@ def test_stop_returns_0_when_no_movie_to_transcode(
 ) -> None:
     """常规 stop（没开录制）→ 不调 _transcode_movie，返回 0。"""
     daemon = Daemon(tmp_path)
-    daemon.control_dir.mkdir()
+    daemon.control_dir.mkdir(parents=True, exist_ok=True)
     daemon.pid_file.write_text(str(os.getpid()))
 
     transcode_called: list = []
@@ -1291,7 +1297,7 @@ def test_start_clears_stale_exit_code(
 
 def test_read_last_exit_code_handles_garbage(tmp_path: Path) -> None:
     daemon = Daemon(tmp_path)
-    daemon.control_dir.mkdir()
+    daemon.control_dir.mkdir(parents=True, exist_ok=True)
     daemon.exit_code_file.write_text("not a number")
     assert daemon.read_last_exit_code() is None
 
@@ -1543,3 +1549,60 @@ def test_start_rejects_time_scale_above_max(tmp_path: Path) -> None:
     daemon = Daemon(tmp_path)
     with pytest.raises(DaemonError, match="time-scale"):
         daemon.start(time_scale=101)
+
+
+# ---------------------------------------------------------------------------
+# Task 1：多实例状态目录隔离（spec 2026-06-07）
+# ---------------------------------------------------------------------------
+
+
+import godot_cli_control.daemon as daemon_mod  # noqa: E402  模块级引用，方便 monkeypatch
+
+
+class TestInstanceLayout:
+    def test_default_instance_uses_instances_dir(self, tmp_path: Path) -> None:
+        """默认实例状态目录应落在 instances/default/，而非旧平铺路径。"""
+        d = daemon_mod.Daemon(tmp_path)
+        assert d.control_dir == tmp_path / ".cli_control" / "instances" / "default"
+        assert d.pid_file == d.control_dir / "godot.pid"
+        assert d.port_file == d.control_dir / "port"
+
+    def test_named_instance_dir(self, tmp_path: Path) -> None:
+        """命名实例目录应与实例名一致。"""
+        d = daemon_mod.Daemon(tmp_path, instance="server")
+        assert d.control_dir == tmp_path / ".cli_control" / "instances" / "server"
+
+    def test_explicit_control_dir_wins(self, tmp_path: Path) -> None:
+        """显式传入 control_dir 时 override 优先，不受 instance 影响。"""
+        custom = tmp_path / "custom"
+        d = daemon_mod.Daemon(tmp_path, custom, instance="server")
+        assert d.control_dir == custom
+
+    @pytest.mark.parametrize("bad", ["", "a/b", "a b", "x" * 33, "中文", "a.b"])
+    def test_invalid_instance_name_rejected(self, tmp_path: Path, bad: str) -> None:
+        """非法实例名应在构造时立即抛 DaemonError，message 含 'instance'。"""
+        with pytest.raises(daemon_mod.DaemonError, match="instance"):
+            daemon_mod.Daemon(tmp_path, instance=bad)
+
+    def test_default_read_pid_falls_back_to_legacy(self, tmp_path: Path) -> None:
+        """default 实例：新路径无文件时，read_pid/current_port 应 fallback 到旧平铺路径。
+
+        这是防双开的安全网（spec 2026-06-07）：旧版本 daemon 写在 .cli_control/
+        平铺路径，升级后 default 实例必须还能探活到它们。
+        """
+        legacy = tmp_path / ".cli_control"
+        legacy.mkdir()
+        (legacy / "godot.pid").write_text(str(os.getpid()))
+        (legacy / "port").write_text("12345")
+        d = daemon_mod.Daemon(tmp_path)  # default 实例
+        assert d.read_pid() == os.getpid()      # legacy fallback
+        assert d.current_port() == 12345
+        assert d.is_running()                   # 防双开：legacy 存活 = running
+
+    def test_named_instance_no_legacy_fallback(self, tmp_path: Path) -> None:
+        """命名实例不应读 legacy 平铺路径（只有 default 才有 fallback）。"""
+        legacy = tmp_path / ".cli_control"
+        legacy.mkdir()
+        (legacy / "godot.pid").write_text(str(os.getpid()))
+        d = daemon_mod.Daemon(tmp_path, instance="server")
+        assert d.read_pid() is None             # 命名实例不读 legacy

--- a/python/tests/test_e2e_multi_instance.py
+++ b/python/tests/test_e2e_multi_instance.py
@@ -284,15 +284,12 @@ def test_instance_targeting_no_crosstalk(multi_project: Path) -> None:
         bridge_a.set_property("/root/Main", "value", 100)
         bridge_b.set_property("/root/Main", "value", 200)
 
-        # 各自读回，不应互混
+        # 各自读回自己写的值，互不污染
+        # bridge_a 连 server 实例，应读到 100；bridge_b 连 client1 实例，应读到 200
         v_a = bridge_a.get_property("/root/Main", "value")
         v_b = bridge_b.get_property("/root/Main", "value")
         assert v_a == 100, f"server value 应为 100，实际 {v_a!r}（串台了？）"
         assert v_b == 200, f"client1 value 应为 200，实际 {v_b!r}（串台了？）"
-
-        # 交叉读：通过对方的 bridge 读自己写的值，应不同
-        # bridge_b 连 client1 实例，读出来应是 200（非 server 的 100）
-        assert v_b != v_a, "两实例 value 不同，说明 RPC 打到了正确的独立实例"
 
     finally:
         if bridge_a is not None:
@@ -307,3 +304,12 @@ def test_instance_targeting_no_crosstalk(multi_project: Path) -> None:
                 pass
         _safe_stop(a, "server")
         _safe_stop(b, "client1")
+
+    # 7. stop 后注册表中本项目记录应清空（在 finally 外断言，确保 stop 已完成）
+    remaining = [
+        r for r in registry.list_all()
+        if Path(r.project_root) == project.resolve()
+    ]
+    assert not remaining, (
+        f"stop 后注册表应清空本项目记录，仍剩 {remaining}"
+    )

--- a/python/tests/test_e2e_multi_instance.py
+++ b/python/tests/test_e2e_multi_instance.py
@@ -19,7 +19,6 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
 
 import pytest
 

--- a/python/tests/test_e2e_multi_instance.py
+++ b/python/tests/test_e2e_multi_instance.py
@@ -1,0 +1,309 @@
+"""端到端回归：同项目双实例隔离 + 歧义解析 + --instance 选靶。
+
+验证点（全部 headless）：
+  1. 同项目启动 server / client1 两实例，端口互不相同（OS 自动分配隔离）。
+  2. 用 GameBridge(instance=...) 各自连，tree() 均可成功——证明连接存活且互不串台。
+  3. 各自 set/get 不同值，交叉断言不污染——证明 RPC 打到独立 daemon。
+  4. discover_port(project) 无 instance 且双实例在跑 → 抛 InstanceAmbiguityError。
+  5. discover_port(project, instance="server") 返回 server 实例的端口。
+  6. registry.list_all() 包含两条本项目记录，instance 字段互不重叠。
+  7. 分别 stop 两实例，stop 后注册表中本项目记录清空。
+
+需要真实 Godot 4：PATH 里有 godot（或设 GODOT_BIN），否则整文件 skip。
+截图走 GUI 路径（headless 拿不到 viewport texture），不在此覆盖。
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from godot_cli_control import registry
+from godot_cli_control.bridge import GameBridge
+from godot_cli_control.daemon import (
+    Daemon,
+    InstanceAmbiguityError,
+    discover_port,
+    find_godot_binary,
+)
+
+_GODOT_BIN = find_godot_binary()
+_ADDON_SRC = Path(__file__).resolve().parents[2] / "addons" / "godot_cli_control"
+
+# GODOT_BIN 缺失时整文件 skip（与其它 e2e 约定一致）。
+pytestmark = pytest.mark.skipif(
+    not _GODOT_BIN,
+    reason="需要真实 Godot 4：把 godot 装进 PATH 或设 GODOT_BIN，否则整文件 skip",
+)
+
+# ── 最小 Godot 项目模板 ──
+# 暴露可读写属性 value（int），供跨实例交叉断言不串台。
+# GameBridgeNode autoload + plugin 段与其它 e2e 一致（等价于 init 的 patch）。
+
+_PROJECT_GODOT = """\
+config_version=5
+
+[application]
+config/name="gcc-multi-instance-e2e"
+run/main_scene="res://main.tscn"
+config/features=PackedStringArray("4.4")
+
+[rendering]
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"
+
+[autoload]
+
+GameBridgeNode="*res://addons/godot_cli_control/bridge/game_bridge.gd"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/godot_cli_control/plugin.cfg")
+"""
+
+# 主场景：挂带 value 属性的脚本，headless 下直接可读写，无需任何 UI 节点。
+_MAIN_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://main.gd" id="1_main"]
+
+[node name="Main" type="Node"]
+script = ExtResource("1_main")
+"""
+
+# 脚本：暴露 value 属性用于交叉断言（不在 property blacklist）。
+_MAIN_GD = """\
+extends Node
+
+var value: int = 0
+"""
+
+
+@pytest.fixture(scope="module")
+def multi_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """构建最小 Godot 项目并做一次编辑器导入（注册 GameBridge class）。
+
+    scope=module：整个文件共用一份 tmp 项目目录，只导入一次——导入耗时最长，
+    不必每条用例重复。两个测试函数各自独立管理 daemon 生命周期，互不影响。
+    """
+    proj = tmp_path_factory.mktemp("gcc_multi_e2e")
+    (proj / "project.godot").write_text(_PROJECT_GODOT, encoding="utf-8")
+    (proj / "main.tscn").write_text(_MAIN_TSCN, encoding="utf-8")
+    (proj / "main.gd").write_text(_MAIN_GD, encoding="utf-8")
+    (proj / "addons").mkdir()
+    shutil.copytree(_ADDON_SRC, proj / "addons" / "godot_cli_control")
+
+    # 编辑器导入：注册 global class GameBridge，否则 autoload 找不到 class_name。
+    imp = subprocess.run(
+        [_GODOT_BIN, "--headless", "--editor", "--quit", "--path", str(proj)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert imp.returncode == 0, (
+        f"Godot 导入失败：\nstdout={imp.stdout}\nstderr={imp.stderr}"
+    )
+    return proj
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# 辅助：安全停止（stop 失败也打印 stderr 但不再抛，确保 finally 能完整清理）
+# ────────────────────────────────────────────────────────────────────────────
+
+def _safe_stop(d: Daemon, label: str) -> None:
+    """安全停止指定 daemon；失败时 print 到 stderr 但不抛异常，确保清理兜底。
+
+    try/finally 里的 stop 失败不应掩盖更上层的断言失败——所以这里吞掉错误，
+    只在 stderr 留痕，方便事后 debug。
+    """
+    try:
+        d.stop()
+    except Exception as exc:  # noqa: BLE001
+        print(f"[{label}] stop 失败（已忽略）：{exc}", file=sys.stderr)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test 1：双实例端口隔离 + 歧义解析 + registry 双记录 + stop 后清空
+# ────────────────────────────────────────────────────────────────────────────
+
+def test_two_instances_isolated(multi_project: Path) -> None:
+    """同项目双实例（server / client1）隔离全链路验证。
+
+    范围：端口互不同 → 各连各的 tree() 成功 → discover_port 无 instance 抛歧义 →
+    显式 instance 选靶正确 → registry 双记录 → stop 后记录清空。
+    所有 bridge 操作在 headless 模式下进行（无 UI，只验证连接存活 + 属性隔离）。
+    """
+    project = multi_project
+
+    # 1. 启动双实例（OS 自动分配端口，保证互不碰撞）
+    a = Daemon(project, instance="server")
+    b = Daemon(project, instance="client1")
+    bridge_a: GameBridge | None = None
+    bridge_b: GameBridge | None = None
+
+    try:
+        a.start(headless=True)
+        b.start(headless=True)
+
+        # 端口必须不同——两个 OS 自动分配端口永远不会相同
+        port_a = a.current_port()
+        port_b = b.current_port()
+        assert port_a is not None, "server 实例端口文件未写入"
+        assert port_b is not None, "client1 实例端口文件未写入"
+        assert port_a != port_b, (
+            f"两实例端口相同（{port_a}）——OS 自动分配应保证互不碰撞"
+        )
+
+        # 2. 各自连接，用 tree() 验证连接存活且互不串台
+        # GameBridge(instance=...) cwd 默认 Path.cwd()，需传 port 以免
+        # discover_port(cwd) 可能解析到别的项目；直接用端口最稳。
+        bridge_a = GameBridge(port=port_a)
+        bridge_b = GameBridge(port=port_b)
+
+        tree_a = bridge_a.get_scene_tree(depth=2)
+        tree_b = bridge_b.get_scene_tree(depth=2)
+        assert isinstance(tree_a, dict) and tree_a, "server bridge 的 get_scene_tree 应返回非空 dict"
+        assert isinstance(tree_b, dict) and tree_b, "client1 bridge 的 get_scene_tree 应返回非空 dict"
+
+        # 3. 交叉断言：各自 set 不同值，读回验证不串台
+        bridge_a.set_property("/root/Main", "value", 111)
+        bridge_b.set_property("/root/Main", "value", 222)
+        # 关闭再重开连接，模拟独立 bridge 读（防止 cache 等）
+        bridge_a.close()
+        bridge_a = None
+        bridge_b.close()
+        bridge_b = None
+
+        fresh_a = GameBridge(port=port_a)
+        fresh_b = GameBridge(port=port_b)
+        try:
+            val_a = fresh_a.get_property("/root/Main", "value")
+            val_b = fresh_b.get_property("/root/Main", "value")
+        finally:
+            fresh_a.close()
+            fresh_b.close()
+
+        assert val_a == 111, (
+            f"server 实例 value 应为 111（set 的值），实际 {val_a!r}——两实例可能串台"
+        )
+        assert val_b == 222, (
+            f"client1 实例 value 应为 222（set 的值），实际 {val_b!r}——两实例可能串台"
+        )
+
+        # 4. 歧义：discover_port(project) 无 instance → InstanceAmbiguityError
+        # 两实例都在跑，不指定 instance 时必须报歧义让调用方明确选靶。
+        with pytest.raises(InstanceAmbiguityError) as exc_info:
+            discover_port(project)
+        # 错误信息应包含两个实例名，让 agent 看单行 JSON 就知道怎么选
+        err_msg = str(exc_info.value)
+        assert "server" in err_msg, f"歧义错误信息应含 'server'，实际：{err_msg!r}"
+        assert "client1" in err_msg, f"歧义错误信息应含 'client1'，实际：{err_msg!r}"
+
+        # 5. 显式选靶：discover_port(project, instance="server") == server 端口
+        found_port = discover_port(project, instance="server")
+        assert found_port == port_a, (
+            f"discover_port(..., instance='server') 应返回 {port_a}，实际 {found_port}"
+        )
+
+        # 6. registry 双记录：两条记录 instance 字段互不重叠
+        recs = [
+            r for r in registry.list_all()
+            if Path(r.project_root) == project.resolve()
+        ]
+        assert len(recs) == 2, (
+            f"注册表中本项目应有 2 条记录，实际 {len(recs)} 条：{recs}"
+        )
+        instances_in_registry = {r.instance for r in recs}
+        assert instances_in_registry == {"server", "client1"}, (
+            f"注册表 instance 字段应为 {{'server', 'client1'}}，实际 {instances_in_registry}"
+        )
+
+    finally:
+        # 兜底清理：哪怕断言失败也必须 stop 两实例，不留泄漏进程
+        if bridge_a is not None:
+            try:
+                bridge_a.close()
+            except Exception:  # noqa: BLE001
+                pass
+        if bridge_b is not None:
+            try:
+                bridge_b.close()
+            except Exception:  # noqa: BLE001
+                pass
+        _safe_stop(a, "server")
+        _safe_stop(b, "client1")
+
+    # 7. stop 后注册表中本项目记录应清空（在 finally 外断言，确保 stop 已完成）
+    remaining = [
+        r for r in registry.list_all()
+        if Path(r.project_root) == project.resolve()
+    ]
+    assert not remaining, (
+        f"stop 后注册表应清空本项目记录，仍剩 {remaining}"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test 2：库面双连接互不污染（--instance 选靶 + 值隔离）
+# ────────────────────────────────────────────────────────────────────────────
+
+def test_instance_targeting_no_crosstalk(multi_project: Path) -> None:
+    """库面双 bridge 交叉写/读断言：server 写 100、client1 写 200，交叉读不混淆。
+
+    补充 Test 1 的"关闭重开再读"路径，本条在同一组 bridge 对象上连续操作，
+    验证相同 bridge 持续连接也不会把 value 写串到另一个实例。
+    """
+    project = multi_project
+
+    a = Daemon(project, instance="server")
+    b = Daemon(project, instance="client1")
+    bridge_a: GameBridge | None = None
+    bridge_b: GameBridge | None = None
+
+    try:
+        a.start(headless=True)
+        b.start(headless=True)
+
+        port_a = a.current_port()
+        port_b = b.current_port()
+        assert port_a is not None and port_b is not None
+
+        bridge_a = GameBridge(port=port_a)
+        bridge_b = GameBridge(port=port_b)
+
+        # 初始化：两边都重置为 0，避免前一条测试遗留值干扰
+        bridge_a.set_property("/root/Main", "value", 0)
+        bridge_b.set_property("/root/Main", "value", 0)
+
+        # server 写 100，client1 写 200
+        bridge_a.set_property("/root/Main", "value", 100)
+        bridge_b.set_property("/root/Main", "value", 200)
+
+        # 各自读回，不应互混
+        v_a = bridge_a.get_property("/root/Main", "value")
+        v_b = bridge_b.get_property("/root/Main", "value")
+        assert v_a == 100, f"server value 应为 100，实际 {v_a!r}（串台了？）"
+        assert v_b == 200, f"client1 value 应为 200，实际 {v_b!r}（串台了？）"
+
+        # 交叉读：通过对方的 bridge 读自己写的值，应不同
+        # bridge_b 连 client1 实例，读出来应是 200（非 server 的 100）
+        assert v_b != v_a, "两实例 value 不同，说明 RPC 打到了正确的独立实例"
+
+    finally:
+        if bridge_a is not None:
+            try:
+                bridge_a.close()
+            except Exception:  # noqa: BLE001
+                pass
+        if bridge_b is not None:
+            try:
+                bridge_b.close()
+            except Exception:  # noqa: BLE001
+                pass
+        _safe_stop(a, "server")
+        _safe_stop(b, "client1")

--- a/python/tests/test_e2e_multi_instance.py
+++ b/python/tests/test_e2e_multi_instance.py
@@ -257,6 +257,9 @@ def test_instance_targeting_no_crosstalk(multi_project: Path) -> None:
 
     补充 Test 1 的"关闭重开再读"路径，本条在同一组 bridge 对象上连续操作，
     验证相同 bridge 持续连接也不会把 value 写串到另一个实例。
+
+    选靶方式：``GameBridge(port=...)`` 显式端口（从 Daemon.current_port() 读取）。
+    ``GameBridge(instance=...)`` 路径由单测覆盖，不在此重复。
     """
     project = multi_project
 

--- a/python/tests/test_e2e_scene.py
+++ b/python/tests/test_e2e_scene.py
@@ -138,9 +138,13 @@ def test_scene_change_missing_scene_returns_1008(daemon: Any) -> None:
 def test_bridge_scene_reload_roundtrip(daemon: Any) -> None:
     """fresh_scene fixture 的核心调用（bridge.scene_reload）真链路验证。"""
     from godot_cli_control.bridge import GameBridge
+    from godot_cli_control.daemon import discover_port
 
     project = daemon
-    port = int((project / ".cli_control" / "port").read_text().strip())
+    # 端口用 discover_port 统一入口读取：多实例迁移后端口文件在
+    # instances/default/port，旧路径 .cli_control/port 已不存在（#multi-instance）。
+    port = discover_port(project)
+    assert port is not None, "daemon 已起但 discover_port 返回 None"
     b = GameBridge(port=port)
     try:
         result = b.scene_reload()

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -126,3 +126,75 @@ def test_user_state_dir_posix_keeps_xdg_state(
     assert registry._user_state_dir() == Path.home() / ".local" / "state" / "godot-cli-control"
     monkeypatch.setattr(registry.sys, "platform", "darwin")
     assert registry._user_state_dir() == Path.home() / ".local" / "state" / "godot-cli-control"
+
+
+# ── 多实例支持（spec 2026-06-07）──
+
+
+def test_register_with_instance_filename(reg_dir: Path, tmp_path: Path) -> None:
+    """instance 参数应改变注册表文件名为 <hash>-<instance>.json。"""
+    proj = tmp_path / "p1"
+    proj.mkdir()
+    registry.register(proj, pid=os.getpid(), port=1, godot_bin="x",
+                      log_path="x", instance="server")
+    files = list(reg_dir.glob("*.json"))
+    assert len(files) == 1
+    assert files[0].name == f"{registry.project_hash(proj)}-server.json"
+    r = registry.list_all()[0]
+    assert r.instance == "server"
+
+
+def test_same_project_two_instances_coexist(reg_dir: Path, tmp_path: Path) -> None:
+    """同一项目的两个实例可以同时在注册表中共存（各自独立的 JSON 文件）。"""
+    proj = tmp_path / "p1"
+    proj.mkdir()
+    registry.register(proj, pid=os.getpid(), port=1, godot_bin="x",
+                      log_path="x", instance="server")
+    registry.register(proj, pid=os.getpid(), port=2, godot_bin="x",
+                      log_path="x", instance="client1")
+    assert {r.instance for r in registry.list_all()} == {"server", "client1"}
+
+
+def test_legacy_record_read_as_default(reg_dir: Path, tmp_path: Path) -> None:
+    """无 instance 字段的旧格式记录被读为 instance="default"（向后兼容）。"""
+    import json as _json
+
+    proj = tmp_path / "p1"
+    proj.mkdir()
+    reg_dir.mkdir(parents=True, exist_ok=True)
+    legacy = reg_dir / f"{registry.project_hash(proj)}.json"
+    legacy.write_text(_json.dumps({
+        "project_root": str(proj.resolve()), "pid": os.getpid(), "port": 7,
+        "started_at": "2026-01-01T00:00:00+00:00", "godot_bin": "x", "log_path": "x",
+    }))  # 旧格式：无 instance 字段
+    r = registry.list_all()[0]
+    assert r.instance == "default"
+
+
+def test_unregister_targets_instance(reg_dir: Path, tmp_path: Path) -> None:
+    """unregister 精确删除指定实例；不存在的实例是 no-op；删存在的才清除记录。"""
+    proj = tmp_path / "p1"
+    proj.mkdir()
+    registry.register(proj, pid=os.getpid(), port=1, godot_bin="x",
+                      log_path="x", instance="server")
+    registry.unregister(proj, instance="client1")  # 不存在的实例 → no-op
+    assert len(registry.list_all()) == 1
+    registry.unregister(proj, instance="server")
+    assert registry.list_all() == []
+
+
+def test_prune_dead_new_format_cleans_instance_dir(
+    reg_dir: Path, tmp_path: Path, dead_pid: int
+) -> None:
+    """dead PID 的新格式记录被 prune 时，会清理 instances/<name>/ 下的状态文件。"""
+    proj = tmp_path / "p1"
+    proj.mkdir()
+    inst_dir = proj / ".cli_control" / "instances" / "server"
+    inst_dir.mkdir(parents=True)
+    (inst_dir / "godot.pid").write_text(str(dead_pid))
+    (inst_dir / "port").write_text("1")
+    registry.register(proj, pid=dead_pid, port=1, godot_bin="x",
+                      log_path="x", instance="server")
+    assert registry.list_all() == []
+    assert not (inst_dir / "godot.pid").exists()
+    assert not (inst_dir / "port").exists()

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -2,8 +2,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -16,18 +14,6 @@ def reg_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(registry, "_REGISTRY_DIR", tmp_path / "registry")
     return tmp_path / "registry"
 
-
-@pytest.fixture
-def dead_pid() -> int:
-    """一个 100% 已死、跨平台稳定的 PID。
-
-    起一个立即退出的子进程并 reap（wait）掉，其 PID 此后保证不存活——
-    比硬编码 magic PID（如 2_000_000）稳：后者依赖 OS 的 PID 上限，
-    Linux pid_max=4194304 下长跑系统理论上可能真有进程占到该 PID 而 flaky。
-    """
-    proc = subprocess.Popen([sys.executable, "-c", ""])
-    proc.wait()
-    return proc.pid
 
 
 def test_register_creates_record(reg_dir: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

同一 Godot 项目可同时跑多个命名 daemon 实例（典型场景：联机测试 server + N client），CLI 每条命令可精确选靶。Spec：`docs/superpowers/specs/2026-06-07-multi-instance-cli-design.md`（两轮 spec review 通过）。

- **命名实例**：`daemon start --name server`（缺省 `default`，现有单实例工作流零变化）
- **状态布局**：迁入 `.cli_control/instances/<name>/`；legacy 平铺路径只读 fallback + 防双开（旧 daemon 在跑时新版 start 报 already running）
- **选靶语义（处处一致）**：0 在跑→default（legacy fallback）；1 在跑→自动选中；≥2→preflight 报 `-1003`/exit 64 并列出实例名（先于网络往返，agent 照 message 重试即可）
- **顶层 `--instance`**：对 RPC / run / daemon 子命令通用（daemon 子命令 `--name` 等价，冲突报错）；与 `--port` argparse 互斥
- **stop 矩阵**：`--name` / 自动选靶 / `--all`（全局）/ `--all --project .`（本项目全部）/ `--all`+实例选靶拒绝（防误停全局）
- **注册表**：`<hash>-<instance>.json`，legacy 文件名兼容读、双格式 prune，升级零手工迁移
- **库面**：`GameClient(instance=)` / `GameBridge(instance=)`（显式 port 优先；构造失败回收 event loop）
- **GDScript 侧零改动**；错误码无新增（歧义/非法名/冲突均 `-1003`+64）
- SKILL.md 模板 + addon README + CHANGELOG `[Unreleased]` 同步，仓内渲染副本 Python 3.12 重渲

## Review 备注

- 实施采用 subagent-driven development：9 任务 ×（实现 + spec 合规 review + 质量 review），外加最终整体 review；过程中修复 review 发现的 8 项（含 stop `--all` 未拦截顶层 `--instance` 的误停全局坑、bridge event loop 泄漏、preflight 测试改驱动真实 main 等）
- Task 7 质量 review 曾报「歧义 message 文档与代码不符」Critical，经核证为**误报**：歧义 message 有两个来源（RPC 路径 `daemon.py:discover_port` → `pass --instance <name>`；daemon 子命令路径 `cli.py:_resolve_daemon_instance` → `pass --name <instance>`），各自精确匹配 agent 刚跑失败的命令形态，SKILL.md 样例与 pitfalls 分别如实记载两者
- 纯观察类未修项（无实际后果）：e2e 库面 `GameBridge(instance=)` 仅单测覆盖（真机用显式端口更稳）；半迁移态 pid/port fallback 来源理论上可能不一致（竞态窗口毫秒级）

## Test plan

- [x] pytest 全量 614 passed / 4 skipped（GUI gate，既有）/ 0 failed
- [x] coverage 90%（门禁 80%）
- [x] GUT 205/205（GDScript 零改动确认）
- [x] e2e 真 Godot 双实例：端口隔离、RPC 不串台、歧义解析、registry 双记录、stop 收敛
- [x] SKILL.md 渲染 drift：Python 3.12 + COLUMNS=80 与 CI 同法复现，零差异
- [x] 升级兼容：legacy port/pid fallback、注册表旧文件名兼容读、防双开均有测试钉住

🤖 Generated with [Claude Code](https://claude.com/claude-code)