### PR TITLE
feat(pytest): godot_instances 多实例工厂 fixture（#143）

### DIFF
--- a/.claude/skills/godot-cli-control/SKILL.md
+++ b/.claude/skills/godot-cli-control/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: godot-cli-control
-description: Use when driving a Godot 4 game from a script or terminal — clicking buttons, simulating input actions, taking screenshots, dumping the scene tree, reading or writing node properties, calling node methods, listing InputMap actions, writing pytest end-to-end tests against a live Godot scene (via the bundled pytest plugin / `godot_daemon` + `bridge` fixtures), or recording video / screen capture / demo replays (Godot Movie Maker, `--write-movie`, auto-transcoded to mp4 via ffmpeg). Trigger when the user mentions godot-cli-control, the godot-cli-control CLI/daemon, the `bridge` / `godot_daemon` pytest fixtures, or asks to automate / scrape / black-box-test / record / capture / film / e2e-test a Godot scene.
+description: Use when driving a Godot 4 game from a script or terminal — clicking buttons, simulating input actions, taking screenshots, dumping the scene tree, reading or writing node properties, calling node methods, listing InputMap actions, writing pytest end-to-end tests against a live Godot scene (via the bundled pytest plugin / `godot_daemon` + `bridge` fixtures, or the `godot_instances` multi-instance factory for server + client multiplayer e2e), or recording video / screen capture / demo replays (Godot Movie Maker, `--write-movie`, auto-transcoded to mp4 via ffmpeg). Trigger when the user mentions godot-cli-control, the godot-cli-control CLI/daemon, the `bridge` / `godot_daemon` / `godot_instances` pytest fixtures, or asks to automate / scrape / black-box-test / record / capture / film / e2e-test a Godot scene.
 ---
 
 # godot-cli-control
@@ -140,6 +140,8 @@ When ≥ 2 instances are running and you omit `--instance`, the error JSON is:
 `--instance` (top-level) and `--name` (daemon subcommands) are equivalent; passing both with the same value is allowed, different values → -1003 conflict error. `--instance` and `--port` are mutually exclusive (both select which daemon to talk to).
 
 **Upgrade-period note**: if you have a legacy daemon started with an older version of the CLI (its pid/port files sit directly under `.cli_control/` instead of `.cli_control/instances/<name>/`), `daemon ls` may temporarily show two lines for the same project. Stop the legacy daemon and the extra line disappears — no manual file migration needed.
+
+**In pytest suites**, don't hand-roll this lifecycle — the `godot_instances` fixture (see the pytest plugin section) starts named instances, hands you connected `GameBridge` objects, and stops everything it started at teardown.
 
 ## JSON envelope examples
 
@@ -1390,7 +1392,7 @@ def run(bridge):
 
 ## pytest plugin (preferred for end-to-end test suites)
 
-`pip install godot-cli-control[pytest]` registers a `pytest11` entry-point that exposes four fixtures, so a Godot e2e test is a one-liner:
+`pip install godot-cli-control[pytest]` registers a `pytest11` entry-point that exposes five fixtures, so a Godot e2e test is a one-liner:
 
 ```python
 def test_jump(godot_daemon, bridge):
@@ -1403,6 +1405,17 @@ def test_jump(godot_daemon, bridge):
 - **`bridge`** *(function-scoped)*: a fresh `GameBridge` per test; on teardown it calls `release_all()` and closes the socket so a `hold`/`press` left dangling by one test can't bleed into the next. It also restores engine-global time state: best-effort `unpause` + reset `Engine.time_scale` to the value snapshotted at test setup (so `--godot-cli-time-scale 5` suite-wide acceleration survives), preventing a test that crashed after `pause` or `time-scale` from freezing / fast-forwarding every later test.
 - **`fresh_scene`** *(function-scoped)*: reloads the current scene before the test so it starts from a clean state; yields the same `bridge` object. Use this as a lightweight per-test isolation primitive whenever leftover scene state between tests would cause flakiness — it's cheaper than restarting the daemon. Requires the project to actually *have* a current scene: in autoload-only / no-main-scene startup states (`get_tree().current_scene == null`) the setup's `scene_reload` fails loudly with error `1008` before the test body runs — drive the project into a scene first (e.g. `scene-change res://...`), or don't use this fixture for those cases.
 - **`no_push_errors`** *(function-scoped, opt-in)*: the test fails if the game emitted any new `push_error` during it — the e2e defense against silently-swallowed failures (business assertions green, but the game logged an error). Snapshots the `errors` marker at setup, queries the increment at teardown; yields the same `bridge` object. Warnings don't fail it (query `bridge.errors()` yourself for stricter policies). Two caveats: the failure surfaces as a pytest **ERROR** (teardown-phase) rather than FAIL — same red, different label; and it needs Godot 4.5+ (`Logger` API) — on older engines setup raises `RpcError 1012` (fail-loud beats fake-green).
+- **`godot_instances`** *(scope configurable, default function)*: multi-instance factory for multiplayer e2e — get a server bridge **and** client bridges inside one test, with zero manual daemon lifecycle code:
+
+  ```python
+  def test_join(godot_instances):
+      server = godot_instances.start("server")
+      client = godot_instances.start("client1")
+      # both are connected GameBridge objects; teardown stops every
+      # instance this fixture started (and only those)
+  ```
+
+  `start(name)` is idempotent get-or-start; `headless` / `time_scale` default to the global CLI options and can be overridden per call (e.g. `start("server", headless=False)` to watch just the server); `port` always defaults to 0 (OS-assigned — multiple instances cannot share one fixed port). An instance already running before the test is connected to but **not** restarted or stopped at teardown (same dev/CI handover semantics as `godot_daemon`). `stop(name)` stops one instance mid-test (disconnect-scenario testing; the name can be `start`ed again afterwards), `daemon(name)` exposes the underlying `Daemon` (`current_port()` etc.); both raise `KeyError` for names never started. With `--godot-cli-instances-scope session` one shared set of instances serves the whole suite — saves per-test startup seconds, but game state carries over between tests.
 
 On a test failure (call phase, test used `bridge`, daemon **not** headless), the plugin also saves a screenshot to `<project_root>/.cli_control/failures/<nodeid>.png` automatically and notes the path in the report sections — CI debugging goes from "re-run with extra logging" to "look at the picture". Headless runs skip this (dummy renderer can't screenshot); screenshot failures never mask the original test failure.
 
@@ -1423,6 +1436,7 @@ Pytest CLI options the plugin adds:
 | `--godot-cli-no-headless` | off (i.e. headless) | Drop `--headless`, open a real Godot window |
 | `--godot-cli-project-root` | `pytest rootdir` | Override the Godot project root |
 | `--godot-cli-time-scale` | `None` (engine default = 1.0) | Set `Engine.time_scale` at daemon startup (e.g. `5` to run the whole suite at 5× speed). Passed as `--cli-time-scale=N` to Godot; valid range `(0, 100]`. |
+| `--godot-cli-instances-scope` | `function` | Scope of the `godot_instances` fixture: `function` (each test starts/stops its own instances — best isolation) or `session` (one shared set for the whole suite — faster, game state not isolated between tests). |
 
 If the entry-point isn't picking up automatically (rare — usually means an editable install glitch), fall back to listing it in `conftest.py`:
 

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **`daemon stop --all --project <path>`**：限定停某个项目下的全部实例（原 `--all` 不带 `--project` 仍停全局所有项目的所有实例）。
 - **daemon 各子命令的 JSON envelope result 带 `"instance"` 字段**：`start` / `stop` / `status` / `logs` 均在 result 中增加 `"instance"` 键，便于 agent 确认操作目标。
 - **`GameBridge(instance=...)` / `GameClient(instance=...)`**：`port=None` 时 `instance` 参数生效，自动查找对应命名实例的端口；显式 `port` 优先（向后兼容）。
+- **pytest 多实例工厂 fixture `godot_instances`**（#143）：联机 e2e 在单测里同时拿 server / client bridge——`godot_instances.start("server")` 幂等启动命名实例并返回已连接 `GameBridge`，teardown 自动停掉本 fixture 起的全部实例（已在跑的只连不杀）；`stop(name)` 支持中途显式停（掉线场景）后重启，`daemon(name)` 暴露底层 `Daemon`。新增 pytest 选项 `--godot-cli-instances-scope=function|session`（默认 function 每用例隔离；session 整套共享省启动时间）。
 
 ### Changed
 - **多实例选靶语义（处处一致）**：0 个在跑 → 选 default（legacy fallback）；1 个在跑 → 自动选中；≥2 个在跑且未指定 `--instance` / `--name` → `-1003` / exit 64，message 列出在跑实例名（`"multiple instances running: ... — pass --instance <name>"`）。显式 `--instance nope` 但该实例未在跑 → `-1003` / exit 64，message 附当前在跑实例列表。`--instance` 与 `--port` 互斥。

--- a/python/README.md
+++ b/python/README.md
@@ -83,6 +83,15 @@ def test_jump(godot_daemon, bridge):
 - `bridge` (function-scoped) gives a fresh `GameBridge`; on teardown it best-effort restores global engine state — `unpause()`, `time_scale` back to its setup-time snapshot, `release_all()` — so a `hold`/`pause`/speed-up left behind by one case can't bleed into the next, then closes the connection.
 - `fresh_scene` (function-scoped, opt-in) calls `scene_reload()` at setup so the case starts on a pristine scene. Node references cached before the reload are invalid afterwards.
 - `no_push_errors` (function-scoped, opt-in) records an `errors` marker at setup and fails the case if any new `push_error` was emitted during it (warnings don't fail). Requires Godot 4.5+ (Logger API) — older engines raise `RpcError` 1012 at setup, loudly.
+- `godot_instances` (scope configurable, default function) is a multi-instance factory for multiplayer e2e — start a named server **and** clients inside one test and get connected `GameBridge` objects back; teardown stops everything the fixture started (and only that):
+
+  ```python
+  def test_join(godot_instances):
+      server = godot_instances.start("server")
+      client = godot_instances.start("client1")
+  ```
+
+  `start(name)` is idempotent get-or-start (`headless`/`time_scale` follow the global options, overridable per call; `port` always defaults to 0 = OS-assigned); `stop(name)` stops one instance mid-test (restartable); `daemon(name)` exposes the underlying `Daemon`. `--godot-cli-instances-scope session` shares one set of instances across the whole suite (faster, no state isolation between tests).
 - On a test failure (non-headless daemon only) a best-effort screenshot is saved to `.cli_control/failures/<nodeid>.png` and the path is attached to the pytest report.
 
 CLI options:
@@ -92,6 +101,7 @@ CLI options:
 --godot-cli-no-headless      # open a real Godot window
 --godot-cli-project-root=DIR # default: pytest rootdir
 --godot-cli-time-scale=X     # Engine.time_scale applied at daemon startup (e.g. 5 to speed up the suite)
+--godot-cli-instances-scope=function|session  # godot_instances fixture scope (default: function)
 ```
 
 ## CLI

--- a/python/godot_cli_control/pytest_plugin.py
+++ b/python/godot_cli_control/pytest_plugin.py
@@ -1,4 +1,5 @@
-"""pytest 插件：``godot_daemon`` (session) + ``bridge`` (function) + ``fresh_scene`` (function) fixtures。
+"""pytest 插件：``godot_daemon`` (session) + ``bridge`` (function) + ``fresh_scene`` (function)
++ ``godot_instances``（多实例工厂，scope 可配）fixtures。
 
 加载路径：
   - ``pip install godot-cli-control[pytest]`` 装上 pytest 后，pytest 启动时
@@ -12,16 +13,27 @@
         bridge.tap("jump")
         assert bridge.get_property("/root/Player", "on_floor") is False
 
+联机玩法 e2e 在单测里同时拿 server / client bridge（issue #143）：
+
+    def test_join(godot_instances):
+        server = godot_instances.start("server")
+        client = godot_instances.start("client1")
+        # 均为 GameBridge；teardown 自动 stop 本 fixture 起的全部实例
+
 CLI 选项：
   --godot-cli-port            GameBridge 端口（默认 0 = OS 自动分配）
   --godot-cli-no-headless     带窗口跑（默认 headless）
   --godot-cli-project-root    指定 Godot 项目根（默认 pytest rootdir）
   --godot-cli-time-scale      Engine.time_scale（整套 suite 加速用，如 5）
+  --godot-cli-instances-scope godot_instances 的 scope：function（默认，每用例
+                              各起各停）或 session（整套共享一组实例，省启动
+                              时间，换取用例间游戏状态不隔离）
 """
 
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator
 
@@ -30,6 +42,12 @@ import pytest
 from .bridge import GameBridge
 from .client import DEFAULT_PORT
 from .daemon import Daemon, DaemonError
+
+
+def _project_root(config: pytest.Config) -> Path:
+    """--godot-cli-project-root（缺省 pytest rootdir）→ resolve 后的绝对路径。"""
+    opt = config.getoption("--godot-cli-project-root")
+    return Path(opt).resolve() if opt else Path(str(config.rootpath)).resolve()
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -59,6 +77,17 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help="Engine.time_scale applied at daemon startup (e.g. 5 to speed up the whole suite).",
     )
+    group.addoption(
+        "--godot-cli-instances-scope",
+        action="store",
+        choices=("function", "session"),
+        default="function",
+        help=(
+            "Scope of the godot_instances fixture: 'function' (default; each test"
+            " starts/stops its own instances) or 'session' (one shared set for the"
+            " whole suite — faster, but game state is not isolated between tests)."
+        ),
+    )
 
 
 @pytest.fixture(scope="session")
@@ -72,17 +101,9 @@ def godot_daemon(request: pytest.FixtureRequest) -> Iterator[Daemon]:
     config = request.config
     port = int(config.getoption("--godot-cli-port"))
     headless = not config.getoption("--godot-cli-no-headless")
-
-    project_root_opt = config.getoption("--godot-cli-project-root")
-    project_root = (
-        Path(project_root_opt).resolve()
-        if project_root_opt
-        else Path(str(config.rootpath)).resolve()
-    )
-
     time_scale: float | None = config.getoption("--godot-cli-time-scale")
 
-    daemon = Daemon(project_root)
+    daemon = Daemon(_project_root(config))
     started_by_us = False
     if not daemon.is_running():
         try:
@@ -186,6 +207,154 @@ def no_push_errors(bridge: GameBridge) -> Iterator[GameBridge]:
         )
 
 
+@dataclass
+class _InstanceEntry:
+    daemon: Daemon
+    bridge: GameBridge
+    started_by_us: bool
+
+
+class GodotInstances:
+    """``godot_instances`` fixture 的工厂句柄：按名字起 / 连 / 停同项目多个 Godot 实例。
+
+    - ``start(name)`` 幂等 get-or-start：已起过的名字直接返回同一 GameBridge；
+    - 实例已在跑（开发者手动起的）只连不重启，teardown 也不杀——与
+      ``godot_daemon`` 的 dev / CI 衔接语义一致；
+    - ``stop(name)`` 显式中途停（模拟 server 掉线类场景），之后可重新 ``start``；
+    - teardown 自动断开全部连接并 stop 本 fixture 起的实例。
+    """
+
+    def __init__(
+        self,
+        project_root: Path,
+        *,
+        headless: bool,
+        time_scale: float | None,
+    ) -> None:
+        self._project_root = project_root
+        self._default_headless = headless
+        self._default_time_scale = time_scale
+        self._entries: dict[str, _InstanceEntry] = {}
+
+    def start(
+        self,
+        name: str,
+        *,
+        headless: bool | None = None,
+        port: int = 0,
+        time_scale: float | None = None,
+    ) -> GameBridge:
+        """启动（或连上）命名实例，返回已连接的 GameBridge。
+
+        ``port`` 默认恒 0（OS 自动分配）——多实例不能共享 ``--godot-cli-port``
+        的固定端口。``headless`` / ``time_scale`` 缺省跟全局 CLI 选项，可逐实例
+        关键字覆盖（如给 server 实例单独开窗观察）。
+        """
+        entry = self._entries.get(name)
+        if entry is not None:
+            return entry.bridge
+        daemon = Daemon(self._project_root, instance=name)
+        started_by_us = False
+        if not daemon.is_running():
+            try:
+                daemon.start(
+                    headless=self._default_headless if headless is None else headless,
+                    port=port,
+                    time_scale=(
+                        self._default_time_scale if time_scale is None else time_scale
+                    ),
+                )
+            except DaemonError as e:
+                pytest.fail(f"无法启动 Godot 实例 {name!r}：{e}", pytrace=False)
+            started_by_us = True
+        bridge_port = daemon.current_port()
+        if bridge_port is None:
+            # 不退 DEFAULT_PORT —— 多实例都退到同一默认端口必然串台，fail-loud。
+            if started_by_us:
+                try:
+                    daemon.stop()
+                except DaemonError:
+                    pass
+            pytest.fail(f"实例 {name!r} 的端口文件不可读，无法建立连接", pytrace=False)
+        bridge = GameBridge(port=bridge_port)
+        self._entries[name] = _InstanceEntry(daemon, bridge, started_by_us)
+        return bridge
+
+    def daemon(self, name: str) -> Daemon:
+        """访问底层 Daemon（current_port / read_pid 等）。未 start 的名字 → KeyError。"""
+        return self._require(name).daemon
+
+    def stop(self, name: str) -> None:
+        """显式停掉一个实例：断连 + （若是本 fixture 起的）stop 进程。
+
+        之后同名可重新 ``start``。借用的实例（fixture 没起的）只断连不杀进程。
+        ``daemon.stop()`` 的失败向上抛——中途显式 stop 是测试逻辑的一部分，
+        失败应让用例红，而非静默放过。
+        """
+        entry = self._require(name)
+        del self._entries[name]
+        try:
+            entry.bridge.release_all()
+        except Exception:  # noqa: BLE001 — 关闭路径，残留输入清理 best-effort
+            pass
+        try:
+            entry.bridge.close()
+        except Exception:  # noqa: BLE001 — 连接可能已断，不阻塞 stop 流程
+            pass
+        if entry.started_by_us:
+            entry.daemon.stop()
+
+    def stop_all(self) -> None:
+        """teardown 兜底：逐实例 stop，单个失败不拦住其余实例的清理。"""
+        for name in list(self._entries):
+            try:
+                self.stop(name)
+            except Exception:  # noqa: BLE001 — teardown 路径，保证全部实例都被尝试
+                pass
+
+    def _require(self, name: str) -> _InstanceEntry:
+        entry = self._entries.get(name)
+        if entry is None:
+            raise KeyError(
+                f"instance {name!r} was not started via this fixture"
+                f" (known: {sorted(self._entries)})"
+            )
+        return entry
+
+
+def _godot_instances_scope(fixture_name: str, config: pytest.Config) -> str:
+    """``godot_instances`` 的 dynamic scope：--godot-cli-instances-scope（默认 function）。"""
+    return config.getoption("--godot-cli-instances-scope")
+
+
+@pytest.fixture(scope=_godot_instances_scope)
+def godot_instances(request: pytest.FixtureRequest) -> Iterator[GodotInstances]:
+    """多实例工厂（issue #143）：联机 e2e 在单测里同时拿 server / client bridge。
+
+        def test_join(godot_instances):
+            server = godot_instances.start("server")
+            client = godot_instances.start("client1")
+            # server / client 均为 GameBridge，teardown 自动 stop 全部
+
+    scope 由 ``--godot-cli-instances-scope`` 控制：function（默认）每用例各起
+    各停，隔离最好；session 整套共享一组实例，省掉每用例数秒的启动开销，代价
+    是游戏状态跨用例不隔离——套件自己负责状态复位。
+
+    与 ``godot_daemon`` / ``bridge`` 共存：那对管 default 实例，本 fixture 管
+    命名实例，互不相干。
+    """
+    config = request.config
+    inst = GodotInstances(
+        _project_root(config),
+        headless=not config.getoption("--godot-cli-no-headless"),
+        time_scale=config.getoption("--godot-cli-time-scale"),
+    )
+    try:
+        yield inst
+    finally:
+        inst.stop_all()
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
     """失败自动截图（issue #103）：用例 call 阶段失败且用了 bridge、daemon
@@ -205,12 +374,7 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
     headless = not config.getoption("--godot-cli-no-headless")
     if headless:
         return
-    project_root_opt = config.getoption("--godot-cli-project-root")
-    root = (
-        Path(project_root_opt).resolve()
-        if project_root_opt
-        else Path(str(config.rootpath)).resolve()
-    )
+    root = _project_root(config)
     safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", item.nodeid)[:150]
     path = root / ".cli_control" / "failures" / f"{safe}.png"
     try:

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: godot-cli-control
-description: Use when driving a Godot 4 game from a script or terminal — clicking buttons, simulating input actions, taking screenshots, dumping the scene tree, reading or writing node properties, calling node methods, listing InputMap actions, writing pytest end-to-end tests against a live Godot scene (via the bundled pytest plugin / `godot_daemon` + `bridge` fixtures), or recording video / screen capture / demo replays (Godot Movie Maker, `--write-movie`, auto-transcoded to mp4 via ffmpeg). Trigger when the user mentions godot-cli-control, the godot-cli-control CLI/daemon, the `bridge` / `godot_daemon` pytest fixtures, or asks to automate / scrape / black-box-test / record / capture / film / e2e-test a Godot scene.
+description: Use when driving a Godot 4 game from a script or terminal — clicking buttons, simulating input actions, taking screenshots, dumping the scene tree, reading or writing node properties, calling node methods, listing InputMap actions, writing pytest end-to-end tests against a live Godot scene (via the bundled pytest plugin / `godot_daemon` + `bridge` fixtures, or the `godot_instances` multi-instance factory for server + client multiplayer e2e), or recording video / screen capture / demo replays (Godot Movie Maker, `--write-movie`, auto-transcoded to mp4 via ffmpeg). Trigger when the user mentions godot-cli-control, the godot-cli-control CLI/daemon, the `bridge` / `godot_daemon` / `godot_instances` pytest fixtures, or asks to automate / scrape / black-box-test / record / capture / film / e2e-test a Godot scene.
 ---
 
 # godot-cli-control
@@ -140,6 +140,8 @@ When ≥ 2 instances are running and you omit `--instance`, the error JSON is:
 `--instance` (top-level) and `--name` (daemon subcommands) are equivalent; passing both with the same value is allowed, different values → -1003 conflict error. `--instance` and `--port` are mutually exclusive (both select which daemon to talk to).
 
 **Upgrade-period note**: if you have a legacy daemon started with an older version of the CLI (its pid/port files sit directly under `.cli_control/` instead of `.cli_control/instances/<name>/`), `daemon ls` may temporarily show two lines for the same project. Stop the legacy daemon and the extra line disappears — no manual file migration needed.
+
+**In pytest suites**, don't hand-roll this lifecycle — the `godot_instances` fixture (see the pytest plugin section) starts named instances, hands you connected `GameBridge` objects, and stops everything it started at teardown.
 
 ## JSON envelope examples
 
@@ -482,7 +484,7 @@ def run(bridge):
 
 ## pytest plugin (preferred for end-to-end test suites)
 
-`pip install godot-cli-control[pytest]` registers a `pytest11` entry-point that exposes four fixtures, so a Godot e2e test is a one-liner:
+`pip install godot-cli-control[pytest]` registers a `pytest11` entry-point that exposes five fixtures, so a Godot e2e test is a one-liner:
 
 ```python
 def test_jump(godot_daemon, bridge):
@@ -495,6 +497,17 @@ def test_jump(godot_daemon, bridge):
 - **`bridge`** *(function-scoped)*: a fresh `GameBridge` per test; on teardown it calls `release_all()` and closes the socket so a `hold`/`press` left dangling by one test can't bleed into the next. It also restores engine-global time state: best-effort `unpause` + reset `Engine.time_scale` to the value snapshotted at test setup (so `--godot-cli-time-scale 5` suite-wide acceleration survives), preventing a test that crashed after `pause` or `time-scale` from freezing / fast-forwarding every later test.
 - **`fresh_scene`** *(function-scoped)*: reloads the current scene before the test so it starts from a clean state; yields the same `bridge` object. Use this as a lightweight per-test isolation primitive whenever leftover scene state between tests would cause flakiness — it's cheaper than restarting the daemon. Requires the project to actually *have* a current scene: in autoload-only / no-main-scene startup states (`get_tree().current_scene == null`) the setup's `scene_reload` fails loudly with error `1008` before the test body runs — drive the project into a scene first (e.g. `scene-change res://...`), or don't use this fixture for those cases.
 - **`no_push_errors`** *(function-scoped, opt-in)*: the test fails if the game emitted any new `push_error` during it — the e2e defense against silently-swallowed failures (business assertions green, but the game logged an error). Snapshots the `errors` marker at setup, queries the increment at teardown; yields the same `bridge` object. Warnings don't fail it (query `bridge.errors()` yourself for stricter policies). Two caveats: the failure surfaces as a pytest **ERROR** (teardown-phase) rather than FAIL — same red, different label; and it needs Godot 4.5+ (`Logger` API) — on older engines setup raises `RpcError 1012` (fail-loud beats fake-green).
+- **`godot_instances`** *(scope configurable, default function)*: multi-instance factory for multiplayer e2e — get a server bridge **and** client bridges inside one test, with zero manual daemon lifecycle code:
+
+  ```python
+  def test_join(godot_instances):
+      server = godot_instances.start("server")
+      client = godot_instances.start("client1")
+      # both are connected GameBridge objects; teardown stops every
+      # instance this fixture started (and only those)
+  ```
+
+  `start(name)` is idempotent get-or-start; `headless` / `time_scale` default to the global CLI options and can be overridden per call (e.g. `start("server", headless=False)` to watch just the server); `port` always defaults to 0 (OS-assigned — multiple instances cannot share one fixed port). An instance already running before the test is connected to but **not** restarted or stopped at teardown (same dev/CI handover semantics as `godot_daemon`). `stop(name)` stops one instance mid-test (disconnect-scenario testing; the name can be `start`ed again afterwards), `daemon(name)` exposes the underlying `Daemon` (`current_port()` etc.); both raise `KeyError` for names never started. With `--godot-cli-instances-scope session` one shared set of instances serves the whole suite — saves per-test startup seconds, but game state carries over between tests.
 
 On a test failure (call phase, test used `bridge`, daemon **not** headless), the plugin also saves a screenshot to `<project_root>/.cli_control/failures/<nodeid>.png` automatically and notes the path in the report sections — CI debugging goes from "re-run with extra logging" to "look at the picture". Headless runs skip this (dummy renderer can't screenshot); screenshot failures never mask the original test failure.
 
@@ -515,6 +528,7 @@ Pytest CLI options the plugin adds:
 | `--godot-cli-no-headless` | off (i.e. headless) | Drop `--headless`, open a real Godot window |
 | `--godot-cli-project-root` | `pytest rootdir` | Override the Godot project root |
 | `--godot-cli-time-scale` | `None` (engine default = 1.0) | Set `Engine.time_scale` at daemon startup (e.g. `5` to run the whole suite at 5× speed). Passed as `--cli-time-scale=N` to Godot; valid range `(0, 100]`. |
+| `--godot-cli-instances-scope` | `function` | Scope of the `godot_instances` fixture: `function` (each test starts/stops its own instances — best isolation) or `session` (one shared set for the whole suite — faster, game state not isolated between tests). |
 
 If the entry-point isn't picking up automatically (rare — usually means an editable install glitch), fall back to listing it in `conftest.py`:
 

--- a/python/tests/test_pytest_plugin.py
+++ b/python/tests/test_pytest_plugin.py
@@ -53,7 +53,13 @@ def test_fixtures_listed(pytester: pytest.Pytester) -> None:
         """
     )
     result = pytester.runpytest("--fixtures")
-    for name in ("godot_daemon", "bridge", "fresh_scene", "no_push_errors"):
+    for name in (
+        "godot_daemon",
+        "bridge",
+        "fresh_scene",
+        "no_push_errors",
+        "godot_instances",
+    ):
         result.stdout.fnmatch_lines([f"{name}*-- *pytest_plugin.py*"])
 
 
@@ -857,6 +863,324 @@ class FakeBridge:
     assert "screenshot:" in output, "失败后应自动截图"
     assert ".cli_control" in output and "failures" in output
     assert "test_boom" in output.split("screenshot:")[1].splitlines()[0]
+
+
+# ---------------------------------------------------------------------------
+# godot_instances 多实例工厂 fixture（issue #143）
+# ---------------------------------------------------------------------------
+
+# 共享假桩：Daemon 记 instance 维度的调用流水，Bridge 记端口维度的；
+# PORTS 给每个实例固定不同端口，断言「各连各的」不串台。
+
+_INSTANCES_CONFTEST = """
+from __future__ import annotations
+import godot_cli_control.pytest_plugin as plugin
+
+CALLS: list = []
+PORTS = {"server": 9001, "client1": 9002}
+
+class FakeDaemon:
+    def __init__(self, project_root, instance="default", **kw):
+        CALLS.append(f"Daemon:{instance}")
+        self.instance = instance
+    def is_running(self): return False
+    def start(self, **kw):
+        CALLS.append(
+            f"start:{self.instance}:headless={kw.get('headless')},"
+            f"port={kw.get('port')},time_scale={kw.get('time_scale')}"
+        )
+    def stop(self):
+        CALLS.append(f"stop:{self.instance}")
+        return 0
+    def current_port(self): return PORTS.get(self.instance, 9999)
+
+class FakeBridge:
+    def __init__(self, port):
+        CALLS.append(f"Bridge:{port}")
+        self.port = port
+    def release_all(self): CALLS.append(f"release_all:{self.port}")
+    def close(self): CALLS.append(f"close:{self.port}")
+
+plugin.Daemon = FakeDaemon
+plugin.GameBridge = FakeBridge
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    terminalreporter.write_line(f"CALLS={CALLS}")
+"""
+
+
+def test_instances_scope_option_registered_in_help(
+    pytester: pytest.Pytester,
+) -> None:
+    """--godot-cli-instances-scope 出现在 --help，默认 function。"""
+    result = pytester.runpytest("--help")
+    result.stdout.fnmatch_lines(["*--godot-cli-instances-scope*"])
+
+
+def test_instances_scope_invalid_value_gives_usage_error(
+    pytester: pytest.Pytester,
+) -> None:
+    """--godot-cli-instances-scope bogus → argparse choices 用法错（exit 4）。"""
+    result = pytester.runpytest("--godot-cli-instances-scope", "bogus")
+    assert result.ret == 4
+    result.stderr.fnmatch_lines(["*invalid choice*"])
+
+
+def test_instances_two_instances_lifecycle(pytester: pytest.Pytester) -> None:
+    """start 两实例：Daemon 各带 instance 名构造、各 start 一次、bridge 各连各端口；
+    teardown 对每个实例 release_all → close → stop（close 先于 stop）。
+    """
+    pytester.makeconftest(_INSTANCES_CONFTEST)
+    pytester.makepyfile(
+        """
+        def test_two(godot_instances):
+            server = godot_instances.start("server")
+            client = godot_instances.start("client1")
+            assert server is not client
+            assert server.port == 9001
+            assert client.port == 9002
+        """
+    )
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(passed=1)
+    output = result.stdout.str()
+    for needle in (
+        "Daemon:server",
+        "Daemon:client1",
+        "'Bridge:9001'",
+        "'Bridge:9002'",
+        "stop:server",
+        "stop:client1",
+        "close:9001",
+        "close:9002",
+    ):
+        assert needle in output, f"missing {needle}: {output}"
+    assert output.count("start:server") == 1
+    assert output.count("start:client1") == 1
+    # 每实例：close 先于 stop（先断连接再杀进程）
+    calls_line = [ln for ln in output.splitlines() if ln.startswith("CALLS=")][0]
+    assert calls_line.index("close:9001") < calls_line.index("stop:server")
+    assert calls_line.index("close:9002") < calls_line.index("stop:client1")
+
+
+def test_instances_start_idempotent(pytester: pytest.Pytester) -> None:
+    """同名重复 start 返回同一 bridge 对象，Daemon.start 只调一次（get-or-start）。"""
+    pytester.makeconftest(_INSTANCES_CONFTEST)
+    pytester.makepyfile(
+        """
+        def test_idem(godot_instances):
+            a = godot_instances.start("server")
+            b = godot_instances.start("server")
+            assert a is b
+        """
+    )
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(passed=1)
+    output = result.stdout.str()
+    assert output.count("start:server") == 1
+    assert output.count("'Bridge:9001'") == 1
+
+
+def test_instances_daemon_accessor(pytester: pytest.Pytester) -> None:
+    """daemon(name) 返回底层 Daemon；未 start 的名字 → KeyError。"""
+    pytester.makeconftest(_INSTANCES_CONFTEST)
+    pytester.makepyfile(
+        """
+        import pytest
+
+        def test_accessor(godot_instances):
+            godot_instances.start("server")
+            assert godot_instances.daemon("server").current_port() == 9001
+            with pytest.raises(KeyError):
+                godot_instances.daemon("nope")
+        """
+    )
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(passed=1)
+
+
+def test_instances_global_options_and_per_call_override(
+    pytester: pytest.Pytester,
+) -> None:
+    """headless / time_scale 默认跟全局选项（--godot-cli-time-scale 3 + 默认 headless），
+    start() 的关键字参数可逐实例覆盖。port 默认恒 0（OS 自动分配，多实例不能共享
+    --godot-cli-port 的固定端口）。
+    """
+    pytester.makeconftest(_INSTANCES_CONFTEST)
+    pytester.makepyfile(
+        """
+        def test_opts(godot_instances):
+            godot_instances.start("server")
+            godot_instances.start("client1", headless=False, time_scale=1.5)
+        """
+    )
+    result = pytester.runpytest("-s", "--godot-cli-time-scale", "3")
+    result.assert_outcomes(passed=1)
+    output = result.stdout.str()
+    assert "start:server:headless=True,port=0,time_scale=3.0" in output, output
+    assert "start:client1:headless=False,port=0,time_scale=1.5" in output, output
+
+
+def test_instances_reuses_running_daemon(pytester: pytest.Pytester) -> None:
+    """实例已在跑（开发者手动起的）→ 不重启、teardown 不杀，但连接照常建照常收。"""
+    pytester.makeconftest(
+        _INSTANCES_CONFTEST.replace(
+            "    def is_running(self): return False",
+            "    def is_running(self): return True",
+        )
+    )
+    pytester.makepyfile(
+        """
+        def test_borrow(godot_instances):
+            godot_instances.start("server")
+        """
+    )
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(passed=1)
+    output = result.stdout.str()
+    assert "start:server" not in output, "已运行的实例不应被重启"
+    assert "stop:server" not in output, "fixture 没起的实例 teardown 不该杀它"
+    assert "close:9001" in output, "借用的实例 teardown 仍要断开连接"
+
+
+def test_instances_explicit_stop_allows_restart(
+    pytester: pytest.Pytester,
+) -> None:
+    """stop(name) 中途显式停（掉线类场景）→ 立即 close + stop；之后可重新 start。"""
+    pytester.makeconftest(_INSTANCES_CONFTEST)
+    pytester.makepyfile(
+        """
+        def test_restart(godot_instances):
+            godot_instances.start("server")
+            godot_instances.stop("server")
+            godot_instances.start("server")
+        """
+    )
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(passed=1)
+    output = result.stdout.str()
+    assert output.count("start:server") == 2
+    assert output.count("stop:server") == 2  # 显式 1 次 + teardown 1 次
+    assert output.count("close:9001") == 2
+
+
+def test_instances_stop_unknown_name_raises(pytester: pytest.Pytester) -> None:
+    """stop 一个没 start 过的名字 → KeyError（抓 typo，不静默吞）。"""
+    pytester.makeconftest(_INSTANCES_CONFTEST)
+    pytester.makepyfile(
+        """
+        import pytest
+
+        def test_unknown(godot_instances):
+            with pytest.raises(KeyError) as exc_info:
+                godot_instances.stop("nope")
+            assert "nope" in str(exc_info.value)
+        """
+    )
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(passed=1)
+
+
+def test_instances_start_failure_fails_loud(pytester: pytest.Pytester) -> None:
+    """Daemon.start 抛 DaemonError → pytest.fail 透传原始原因（不吞）。"""
+    pytester.makeconftest(
+        """
+        from __future__ import annotations
+        import godot_cli_control.pytest_plugin as plugin
+        from godot_cli_control.daemon import DaemonError
+
+        class FailDaemon:
+            def __init__(self, project_root, instance="default", **kw): pass
+            def is_running(self): return False
+            def start(self, **kw):
+                raise DaemonError("Godot binary not found")
+            def stop(self): return 0
+            def current_port(self): return None
+
+        class FakeBridge:
+            def __init__(self, port): pass
+            def release_all(self): pass
+            def close(self): pass
+
+        plugin.Daemon = FailDaemon
+        plugin.GameBridge = FakeBridge
+        """
+    )
+    pytester.makepyfile(
+        """
+        def test_boom(godot_instances):
+            godot_instances.start("server")
+        """
+    )
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=1)
+    output = result.stdout.str()
+    assert "Godot binary not found" in output
+    assert "server" in output, "失败消息应指明是哪个实例起不来"
+
+
+def test_instances_teardown_runs_even_when_test_raises(
+    pytester: pytest.Pytester,
+) -> None:
+    """用户测试体抛异常 → 全部已起实例仍被 close + stop（不留泄漏进程）。"""
+    pytester.makeconftest(_INSTANCES_CONFTEST)
+    pytester.makepyfile(
+        """
+        def test_crash(godot_instances):
+            godot_instances.start("server")
+            godot_instances.start("client1")
+            raise RuntimeError("user code went bang")
+        """
+    )
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(failed=1)
+    output = result.stdout.str()
+    for needle in ("close:9001", "stop:server", "close:9002", "stop:client1"):
+        assert needle in output, f"missing {needle}: {output}"
+
+
+def test_instances_function_scope_isolates_tests_by_default(
+    pytester: pytest.Pytester,
+) -> None:
+    """默认 function scope：两个用例各起各停（互不共享实例）。"""
+    pytester.makeconftest(_INSTANCES_CONFTEST)
+    pytester.makepyfile(
+        """
+        def test_a(godot_instances):
+            godot_instances.start("server")
+
+        def test_b(godot_instances):
+            godot_instances.start("server")
+        """
+    )
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(passed=2)
+    output = result.stdout.str()
+    assert output.count("start:server") == 2
+    assert output.count("stop:server") == 2
+
+
+def test_instances_session_scope_shares_across_tests(
+    pytester: pytest.Pytester,
+) -> None:
+    """--godot-cli-instances-scope session：跨用例共享实例，start 1 次、
+    session 末 stop 1 次（联机 e2e 套件起一组 server/client 全程复用）。
+    """
+    pytester.makeconftest(_INSTANCES_CONFTEST)
+    pytester.makepyfile(
+        """
+        def test_a(godot_instances):
+            godot_instances.start("server")
+
+        def test_b(godot_instances):
+            godot_instances.start("server")
+        """
+    )
+    result = pytester.runpytest("-s", "--godot-cli-instances-scope", "session")
+    result.assert_outcomes(passed=2)
+    output = result.stdout.str()
+    assert output.count("start:server") == 1
+    assert output.count("stop:server") == 1
 
 
 def test_failure_screenshot_skipped_when_headless(


### PR DESCRIPTION
Closes #143

## 改了什么

pytest plugin 新增 **`godot_instances`** 多实例工厂 fixture——联机玩法 e2e 在单测里同时拿 server / client bridge，不再需要手写 daemon 生命周期管理（对比 `test_e2e_multi_instance.py` 的手工模式）：

```python
def test_join(godot_instances):
    server = godot_instances.start("server")
    client = godot_instances.start("client1")
    # 均为已连接 GameBridge；teardown 自动 stop 本 fixture 起的全部实例
```

### API / 语义

- **`start(name, *, headless=None, port=0, time_scale=None)`** 幂等 get-or-start，返回已连接 `GameBridge`。`headless` / `time_scale` 缺省跟全局 CLI 选项、可逐实例覆盖（如只给 server 开窗观察）；`port` 恒默认 0（OS 自动分配——多实例不能共享 `--godot-cli-port` 固定端口；端口文件不可读时 fail-loud，不退 `DEFAULT_PORT` 串台）
- **已在跑的实例只连不重启、teardown 不杀**——对齐 `godot_daemon` 的 dev/CI 衔接语义
- **`stop(name)`** 显式中途停（模拟 server 掉线类场景），之后可重新 `start`；未知名 `KeyError` 抓 typo。**`daemon(name)`** 暴露底层 `Daemon`
- **scope 可配**：`--godot-cli-instances-scope=function`（默认，每用例各起各停、隔离最好）`| session`（整套共享一组实例省启动时间，游戏状态跨用例不隔离由套件自担），pytest dynamic scope 实现
- teardown 逐实例 release_all → close → stop，单实例失败不拦其余清理
- 与 `godot_daemon` / `bridge` 共存：那对管 default 实例，本 fixture 管命名实例，互不相干

### 顺带

- project root 解析三处重复（`godot_daemon` / makereport hook / 新 fixture）收敛为 `_project_root()` 帮助函数

## 测试

- pytester 假桩 13 条新增：生命周期（close 先于 stop）/ 幂等 start / 选项透传与逐实例覆盖 / 借用已跑实例 / 显式 stop 后重启 / DaemonError fail-loud / 用例异常仍全清理 / 双 scope 行为 / 选项注册与非法值
- 全量：**640 passed / 4 skipped**（含 GODOT_BIN 真跑 e2e），coverage **90%**（门槛 80%），ruff 0 错

## 文档（契约 #7）

- SKILL.md 模板：frontmatter 触发词、pytest 段 fixture 条目 + 示例 + 选项表、多实例段交叉引用；渲染副本 Python 3.12 + COLUMNS=80 重渲，drift 自检 IN SYNC
- python/README.md（PyPI description）pytest fixtures 段同步
- CHANGELOG `[Unreleased]` Added 1 条

🤖 Generated with [Claude Code](https://claude.com/claude-code)