### PR TITLE
fix: --record 的 --movie-path 启动前校验扩展名 ∈ {.avi,.png}（#152）

### DIFF
--- a/.claude/skills/godot-cli-control/SKILL.md
+++ b/.claude/skills/godot-cli-control/SKILL.md
@@ -429,6 +429,7 @@ godot-cli-control daemon stop          # → produces out.mp4
 Key constraints:
 
 - `--record` **requires** `--movie-path` (daemon refuses to start otherwise).
+- `--movie-path` must end in **`.avi` or `.png`** (case-insensitive) — that's all Godot Movie Maker can write. Anything else (e.g. `.mp4`) used to make Godot log "Can't find movie writer" and keep running **without recording anything** (false-success exit 0); the CLI now rejects other extensions up front with a `-1003` usage error (exit 64). Want an `.mp4`? Pass `.avi` — the transcode at `daemon stop` produces it.
 - `--record` needs a **real renderer**, so it cannot run with `--headless`: Godot Movie Maker's `add_frame()` reads the viewport texture, which the headless dummy renderer leaves null → SIGSEGV on the first frame. The daemon therefore **rejects `--record --headless` with exit code 2** before launching Godot. You don't need to pass `--gui`: when `--record` is set the daemon auto-opens a window even in a non-TTY (subagent / pipe / CI) shell that would otherwise default to headless.
 - The `.mp4` is produced **only when `daemon stop` runs**; `kill -9` leaves the raw `.avi` behind.
 - `ffmpeg` must be on `PATH` for transcoding. If transcoding fails, the raw `.avi` is kept and `daemon stop` exits with code `2` (transcode log at `.cli_control/ffmpeg.log`).
@@ -586,7 +587,8 @@ options:
   --record              启动后录制 demo（写到 .cli_control/movie_path）。需真实渲染器，不能与
                         --headless 同用；没指定时会自动开窗（即使非 TTY）。
   --movie-path MOVIE_PATH
-                        demo 输出路径，默认 .cli_control 下自动命名
+                        demo 输出路径，只接受 .avi/.png（Godot Movie Maker 所限；stop
+                        时自动转码出 .mp4）
   --headless            无窗口模式。默认值：stdout 非 TTY 时自动 headless（CI / pipe /
                         agent）。与 --record 互斥（录制需真实渲染器）。
   --gui                 强制开窗。覆盖 isatty 自动判（例如 stdout 是 pipe 仍想看到窗口）。
@@ -683,7 +685,8 @@ options:
   --record              启动后录制 demo（写到 .cli_control/movie_path）。需真实渲染器，不能与
                         --headless 同用；没指定时会自动开窗（即使非 TTY）。
   --movie-path MOVIE_PATH
-                        demo 输出路径，默认 .cli_control 下自动命名
+                        demo 输出路径，只接受 .avi/.png（Godot Movie Maker 所限；stop
+                        时自动转码出 .mp4）
   --headless            无窗口模式。默认值：stdout 非 TTY 时自动 headless（CI / pipe /
                         agent）。与 --record 互斥（录制需真实渲染器）。
   --gui                 强制开窗。覆盖 isatty 自动判（例如 stdout 是 pipe 仍想看到窗口）。

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **#152 `--movie-path` 非 .avi/.png 时启动前拒绝（-1003 / exit 64）**：此前传 `.mp4` 等后缀 Godot 打 "Can't find movie writer" 后继续正常跑——脚本照常执行、exit 0，但什么都没录（假成功）。现 `daemon start` / `run` 的 `--record` 在 argparse 层校验扩展名（大小写不敏感），错误信息指路「传 .avi，stop 时自动转码出 .mp4」；直接调 `Daemon.start()` 的 API 路径同样拒绝（DaemonError）。
+
 ## [0.3.0] - 2026-06-07
 
 ### Added

--- a/python/godot_cli_control/cli.py
+++ b/python/godot_cli_control/cli.py
@@ -2074,6 +2074,22 @@ def _time_scale_arg(raw: str) -> float:
     return v
 
 
+def _movie_path_arg(raw: str) -> str:
+    """argparse type：``--movie-path`` 的扩展名校验（错误走 -1003 + 64）。
+
+    Godot Movie Maker 只认 .avi/.png；传 .mp4 时 Godot 打 "Can't find movie
+    writer" 后**继续正常跑**——脚本照常执行、exit 0，但什么都没录（#152 假成功）。
+    「stop 时自动转码出 .mp4」的设计又让人直觉传 .mp4，所以启动前 fail-loud。
+    # 合法后缀集与 daemon.start 的 belt 校验对齐，改动需两处同步
+    """
+    if Path(raw).suffix.lower() not in {".avi", ".png"}:
+        raise argparse.ArgumentTypeError(
+            f"Godot Movie Maker 只支持 .avi/.png，收到 {raw!r}；"
+            "传 .avi 即可，CLI 会在 daemon stop 时自动转码出 .mp4"
+        )
+    return raw
+
+
 def _instance_name_arg(value: str) -> str:
     """argparse type 校验：非法实例名 → ArgumentTypeError，触发 -1003/64 信封。"""
     from .daemon import DaemonError, validate_instance_name
@@ -2172,7 +2188,9 @@ def _add_daemon_flags(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--movie-path",
         default=None,
-        help="demo 输出路径，默认 .cli_control 下自动命名",
+        type=_movie_path_arg,
+        help="demo 输出路径，只接受 .avi/.png（Godot Movie Maker 所限；"
+        "stop 时自动转码出 .mp4）",
     )
     headless_grp = p.add_mutually_exclusive_group()
     headless_grp.add_argument(

--- a/python/godot_cli_control/daemon.py
+++ b/python/godot_cli_control/daemon.py
@@ -162,6 +162,15 @@ class Daemon:
             )
         if record and not movie_path:
             raise DaemonError("--record requires --movie-path")
+        # 扩展名 belt（CLI 层 argparse type 已先挡，这里护直接 API 调用方）：
+        # Godot Movie Maker 只认 .avi/.png，别的后缀 Godot 打 "Can't find movie
+        # writer" 后继续正常跑——exit 0 但什么都没录（#152 假成功）。
+        # 合法后缀集与 cli._movie_path_arg 对齐，改动需两处同步。
+        if record and Path(movie_path).suffix.lower() not in {".avi", ".png"}:
+            raise DaemonError(
+                f"Godot Movie Maker 只支持 .avi/.png，收到 {movie_path!r}；"
+                "传 .avi 即可，stop 时自动转码出 .mp4"
+            )
         # 录制无法在 headless 下跑：Godot Movie Maker 的 add_frame() 读 viewport
         # texture，headless dummy renderer 拿到 null 直接 SIGSEGV（首帧崩，
         # CultivationWorld #180）。CLI 侧 _resolve_headless 已把「没显式 --headless

--- a/python/godot_cli_control/templates/skill/SKILL.md
+++ b/python/godot_cli_control/templates/skill/SKILL.md
@@ -429,6 +429,7 @@ godot-cli-control daemon stop          # → produces out.mp4
 Key constraints:
 
 - `--record` **requires** `--movie-path` (daemon refuses to start otherwise).
+- `--movie-path` must end in **`.avi` or `.png`** (case-insensitive) — that's all Godot Movie Maker can write. Anything else (e.g. `.mp4`) used to make Godot log "Can't find movie writer" and keep running **without recording anything** (false-success exit 0); the CLI now rejects other extensions up front with a `-1003` usage error (exit 64). Want an `.mp4`? Pass `.avi` — the transcode at `daemon stop` produces it.
 - `--record` needs a **real renderer**, so it cannot run with `--headless`: Godot Movie Maker's `add_frame()` reads the viewport texture, which the headless dummy renderer leaves null → SIGSEGV on the first frame. The daemon therefore **rejects `--record --headless` with exit code 2** before launching Godot. You don't need to pass `--gui`: when `--record` is set the daemon auto-opens a window even in a non-TTY (subagent / pipe / CI) shell that would otherwise default to headless.
 - The `.mp4` is produced **only when `daemon stop` runs**; `kill -9` leaves the raw `.avi` behind.
 - `ffmpeg` must be on `PATH` for transcoding. If transcoding fails, the raw `.avi` is kept and `daemon stop` exits with code `2` (transcode log at `.cli_control/ffmpeg.log`).

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -2201,6 +2201,69 @@ def test_daemon_start_time_scale_rejects_bad_value(
     assert payload["error"]["code"] == -1003
 
 
+@pytest.mark.parametrize("bad_path", ["demo.mp4", "demo.mov", "demo"])
+def test_daemon_start_movie_path_rejects_bad_extension(
+    bad_path: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """daemon start --movie-path 非 .avi/.png → exit 64 + -1003 信封（#152）。
+
+    Godot Movie Maker 只认 .avi/.png；传 .mp4 时 Godot 静默不录、exit 0 假成功，
+    所以必须在启动前 argparse type 校验挡掉，错误信息要指路 .avi + 自动转码。"""
+    import json as _json
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["godot-cli-control", "daemon", "start", "--record", "--movie-path", bad_path],
+    )
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == EXIT_USAGE
+    payload = _json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert ".avi" in payload["error"]["message"]
+
+
+def test_run_movie_path_rejects_bad_extension(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """run 与 daemon start 共用 _add_daemon_flags，同样的扩展名校验（#152）。
+
+    断言信息含 .avi——必须在 argparse 层挡住，不能靠后面的「找不到脚本」
+    凑出同样的 64/-1003 假通过。"""
+    import json as _json
+    from godot_cli_control.cli import EXIT_USAGE, main
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["godot-cli-control", "run", "script.py", "--record", "--movie-path", "demo.mp4"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == EXIT_USAGE
+    payload = _json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == -1003
+    assert ".avi" in payload["error"]["message"]
+
+
+@pytest.mark.parametrize("good_path", ["demo.avi", "DEMO.AVI", "frames.png"])
+def test_daemon_start_movie_path_accepts_avi_png(good_path: str) -> None:
+    """.avi/.png（大小写不敏感）通过 argparse 校验，值原样保留。"""
+    from godot_cli_control.cli import build_parser
+
+    ns = build_parser().parse_args(
+        ["daemon", "start", "--record", "--movie-path", good_path]
+    )
+    assert ns.movie_path == good_path
+
+
 def test_tree_accepts_max_nodes_flag() -> None:
     from godot_cli_control.cli import build_parser
 

--- a/python/tests/test_daemon.py
+++ b/python/tests/test_daemon.py
@@ -81,6 +81,38 @@ def test_start_rejects_record_without_movie_path(tmp_path: Path) -> None:
         daemon.start(record=True, movie_path=None)
 
 
+@pytest.mark.parametrize("bad_name", ["demo.mp4", "demo.mov", "demo"])
+def test_start_rejects_record_with_bad_movie_extension(
+    tmp_path: Path, bad_name: str
+) -> None:
+    """--movie-path 后缀非 .avi/.png 必须在 spawn 前拒绝（#152）。
+
+    Godot Movie Maker 只认 .avi/.png，传 .mp4 时 Godot 打 "Can't find movie
+    writer" 后**继续正常跑**——脚本照常执行、断言全过、exit 0，但什么都没录。
+    CLI 层 argparse type 已先挡（-1003/64），这里是直接 API 调用方的 belt。"""
+    _touch_godot_project(tmp_path)
+    daemon = Daemon(tmp_path)
+    with pytest.raises(DaemonError, match=r"\.avi"):
+        daemon.start(record=True, movie_path=str(tmp_path / bad_name))
+
+
+@pytest.mark.parametrize("good_name", ["demo.avi", "DEMO.AVI", "frames.png"])
+def test_start_accepts_avi_png_movie_extension(
+    tmp_path: Path, good_name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """.avi/.png（大小写不敏感，Godot 侧 get_extension 同样 lower）放行——
+    校验不应误伤合法路径；用 find_godot_binary=None 让流程停在后面的
+    binary 查找报错，证明扩展名检查已通过。"""
+    _touch_godot_project(tmp_path)
+    monkeypatch.delenv("GODOT_BIN", raising=False)
+    monkeypatch.setattr(
+        "godot_cli_control.daemon.find_godot_binary", lambda: None
+    )
+    daemon = Daemon(tmp_path)
+    with pytest.raises(DaemonError, match="not found"):
+        daemon.start(record=True, movie_path=str(tmp_path / good_name))
+
+
 def test_start_rejects_record_with_headless(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #152

## 问题

`--movie-path` 传非 .avi/.png（典型 `.mp4`）时，Godot Movie Maker 打 "Can't find movie writer" 后**继续正常跑**——脚本照常执行、断言全过、exit 0，但什么都没录。「CLI 在 stop 时自动转码 .avi→.mp4」的设计让用户更容易直觉传 `.mp4`，下游 XGame 实测翻车。

## 方案

与 `_time_scale_arg` 同款双层防线：

- **cli.py**：新增 `_movie_path_arg` argparse type，校验后缀 ∈ {`.avi`, `.png`}（大小写不敏感，与 Godot 侧 `get_extension().to_lower()` 对齐）。挂在 `_add_daemon_flags` 上，`daemon start` / `run` 自动双覆盖；错误走 `-1003`/exit 64 信封，信息指路「传 .avi，stop 时自动转码出 .mp4」。
- **daemon.py**：`Daemon.start()` 加 belt 校验（`DaemonError`），护直接 API 调用方。
- 顺带修正 `--movie-path` help 的陈旧文案（「默认 .cli_control 下自动命名」并不存在——record 缺 movie-path 一直是启动拒绝）。

## 文档同步（契约 7）

- SKILL.md 模板录制约束段补 bullet；仓内渲染版已用 Python 3.12 + COLUMNS=80 重渲染
- CHANGELOG `[Unreleased]` 入账

## 测试

TDD：6 个 reject 用例（daemon belt ×3 + CLI 信封 ×3）+ run 子命令信封用例 + 3 个 accept 用例（.avi/.AVI/.png）均先 RED 后 GREEN。全量 690 passed / 4 skipped，覆盖率 91%（门槛 80），ruff 干净，test_skills_install 11 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)