### PR TITLE
fix: 同步 plugin.cfg 版本号 + release.sh 打 tag 前自动对齐 (#181)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,8 @@ release.sh                  # 发版脚本
 
 ## 发版 / CI
 
-- 版本由 `hatch-vcs` 从 git tag 派生，写到 `python/godot_cli_control/_version.py`。
+- 版本由 `hatch-vcs` 从 git tag 派生，写到 `python/godot_cli_control/_version.py`（CLI 版本唯一来源）。
+- addon `plugin.cfg` 的 `version=` 是**独立的元数据字段**（Godot 编辑器 / AssetLib 展示用，运行期无人解析）；committed 值即「上次发布版本」，`release.sh` 打 tag 前自动同步并入库。别手动改成 `[Unreleased]` 的目标版本——下个 `release.sh` 会把它对齐到实际 tag。CI 的 `release.yml` 里那条 `sed` 只兜 AssetLib zip（wheel 在 sed 前已打包），pip+init 路径靠的是 committed 值。
 - 改 SKILL.md 模板后想验证 `init` 注入正确：跑 `pytest python/tests/test_skills_install.py`。
 - 用户可见变更记入 CHANGELOG 的 `[Unreleased]`；`release.sh` 发版门禁会在该段非空时拒绝打 tag，`--roll-changelog` 自动滚动归档为版本段。
 - 遗留 issue 只记在 GitHub issues，本文件不镜像；落地历史看 CHANGELOG / git log。

--- a/addons/godot_cli_control/CHANGELOG.md
+++ b/addons/godot_cli_control/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **`plugin.cfg` 版本号不再僵在 `0.1.0`**：此前 addon 的 `plugin.cfg` 一直写死 `version="0.1.0"`，CI 仅在打包 AssetLib zip 时按 tag `sed` 修正，而 pip wheel 在那条 sed 之前就已构建——于是 `pip install godot-cli-control` + `init` 复制进下游项目的 addon、以及直接 clone addon 的用法，都拿到错误的 `0.1.0`（Godot 编辑器插件列表 / AssetLib 元数据里显示）。现把 committed 值对齐到上次发布版本，并让 `release.sh` 在打 tag 前自动同步 `plugin.cfg` 版本号并入库，三条取用路径（git-direct / pip+init / AssetLib）从此一致。纯元数据修正，不影响 CLI 行为（CLI 版本一直来自 hatch-vcs 的 `_version.py`）。
+
 ## [0.4.1] - 2026-06-14
 
 ### Fixed

--- a/addons/godot_cli_control/plugin.cfg
+++ b/addons/godot_cli_control/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot CLI Control"
 description="WebSocket bridge for headless / scripted control of Godot scenes (click / property / input simulation / screenshot / record)."
 author="kesar"
-version="0.1.0"
+version="0.4.1"
 script="plugin.gd"

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Tag and push a release. The version comes from the git tag (hatch-vcs reads
-# it for the wheel; CI patches plugin.cfg from GITHUB_REF_NAME).
+# it for the wheel). Before tagging, this script also syncs the addon's
+# plugin.cfg version to match and commits it, so the tag points at a tree where
+# the bundled addon already reports the right version — that's what the pip
+# wheel force-includes and `init` copies downstream (CI's wheel build runs
+# BEFORE its plugin.cfg sed, so that sed only ever fixes the AssetLib zip, not
+# pip+init). CI still re-seds plugin.cfg from GITHUB_REF_NAME as a safety net.
 #
 # Usage:
 #   ./release.sh                  # bump patch from latest tag (default)
@@ -26,6 +31,7 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 CHANGELOG="addons/godot_cli_control/CHANGELOG.md"
+PLUGIN_CFG="addons/godot_cli_control/plugin.cfg"
 
 DRY_RUN=0
 ROLL_CHANGELOG=0
@@ -102,12 +108,19 @@ fi
 
 # --- plan ---------------------------------------------------------------------
 
+if grep -q "^version=\"$NEW\"\$" "$PLUGIN_CFG"; then
+  PLUGIN_CFG_PLAN="already $NEW — nothing to sync"
+else
+  PLUGIN_CFG_PLAN="sync $(awk -F'"' '/^version=/{print $2}' "$PLUGIN_CFG") → $NEW, commit & push"
+fi
+
 cat <<EOF
 HEAD:        $LOCAL
 latest tag:  ${LATEST_TAG:-<none>}
 bump:        $ARG
 new tag:     $TAG
 changelog:   $CHANGELOG_PLAN
+plugin.cfg:  $PLUGIN_CFG_PLAN
 will push:   git push origin $TAG  →  triggers release.yml
 EOF
 
@@ -125,9 +138,22 @@ if [[ -n "$UNRELEASED_BODY" ]] && (( ROLL_CHANGELOG )); then
   ' "$CHANGELOG" > "$CHANGELOG.tmp"
   mv "$CHANGELOG.tmp" "$CHANGELOG"
   git add "$CHANGELOG"
-  git commit -m "docs(changelog): roll [Unreleased] → v$NEW"
+fi
+
+# Sync the addon's plugin.cfg version to the tag (see header). Folds into the
+# changelog-roll commit above when both change; commits on its own otherwise.
+if ! grep -q "^version=\"$NEW\"\$" "$PLUGIN_CFG"; then
+  awk -v v="$NEW" '/^version=/{print "version=\"" v "\""; next} {print}' \
+    "$PLUGIN_CFG" > "$PLUGIN_CFG.tmp"
+  mv "$PLUGIN_CFG.tmp" "$PLUGIN_CFG"
+  git add "$PLUGIN_CFG"
+fi
+
+if ! git diff --cached --quiet; then
+  STAGED="$(git diff --cached --name-only | sed 's#.*/##' | paste -sd, -)"
+  git commit -m "chore(release): sync $STAGED → v$NEW"
   git push origin main
-  echo "rolled changelog: [Unreleased] → [$NEW]"
+  echo "synced & pushed: $STAGED → v$NEW"
 fi
 
 git tag "$TAG"


### PR DESCRIPTION
## 问题（Closes #181）

`addons/godot_cli_control/plugin.cfg` 的 `version=` 自初始提取起恒为 `0.1.0`，从未随发布 bump。CI 只在打 AssetLib zip 时按 tag `sed` 修正，而 pip wheel 在那条 sed **之前**就已构建——于是 wheel force-include 的 addon、被 `init` 复制到下游项目的 addon、以及直接 clone addon 的用法，都拿到错误的 `0.1.0`（Godot 编辑器插件面板 / AssetLib 元数据显示）。纯元数据字段，运行期无人解析，CLI 版本一直来自 hatch-vcs 的 `_version.py`。

三条取用路径里只有 AssetLib zip 被 CI 修对，pip+init 与 git-direct 都漏修。

## 修复

- **`plugin.cfg`**: `0.1.0` → `0.4.1`（对齐最新 tag = 上次发布版本）。
- **`release.sh`**: 打 tag 前自动把 `plugin.cfg` 版本号同步到新版本并入库（与 changelog roll 合进同一 commit，否则单独成 commit）；tag 指向的树即正确，wheel force-include 自动跟随。`--dry-run` plan 增 `plugin.cfg:` 行。对应 #181 建议方案 ① 单一版本源 + ③ 本次补值，且自动化优于"纳入 checklist 靠人记得"。
- **CHANGELOG `[Unreleased]` / `CLAUDE.md` 发版段**: 记录该元数据修复与三路径一致性机制。

## 澄清 #181 一处认知偏差

issue 说 `addons/` 与 `_plugin/` 是"两份分离副本、各存一份"。实测 repo 里**没有**源码 `_plugin/` 目录——它只是 wheel 的 force-include 构建产物（`pyproject.toml:114-115`），源只有一份 `addons/godot_cli_control/plugin.cfg`。同步源即可，wheel 产物自动跟随，不存在"两份分别维护"。因此未采用方案 ②（CI 双向校验），方案 ① 已从源头防复发。

附带：plugin 版本恢复随发布更新后，`-32601` 文档里「client+plugin 版本漂移」诊断信号重新有效。

## 验证

- `bash -n release.sh` 通过；awk 同步 / grep 幂等守卫 / plan 版本提取三段逻辑离线单测确认正确。
- 全仓搜确认无代码/测试解析或断言 `plugin.cfg` 的 `version=`，零回归面。改动仅 shell + 元数据 + 文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)