### PR TITLE
test(gut): run_gut 判 PASS 前加两道假绿守卫，堵解析失败被静默跳过

### DIFF
--- a/addons/godot_cli_control/tests/run_gut.py
+++ b/addons/godot_cli_control/tests/run_gut.py
@@ -23,6 +23,7 @@ mktemp / cp -r / 路径分隔符这些平台差异，让 CI 能在 ubuntu / macO
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -56,6 +57,14 @@ renderer/rendering_method.mobile="gl_compatibility"
 """
 
 _SUCCESS_MARKER = "All tests passed!"
+
+# 假绿守卫（issue #188）：GUT 遇到解析失败的测试脚本只告警并跳过（不计入统计、
+# 不判失败），_SUCCESS_MARKER 对整文件被跳过是盲区。引擎/GUT 在跳过脚本时固定
+# 打这三类字样之一。
+_SILENT_SKIP_RE = re.compile(r"Parse Error|Failed to load script|Ignoring script")
+
+# GUT 汇总里 "Scripts" 一行：summary.gd 用 rpad(18) 对齐，形如 "Scripts           12"。
+_SCRIPTS_TOTAL_RE = re.compile(r"^Scripts\s+(\d+)", re.MULTILINE)
 
 
 def _log(msg: str) -> None:
@@ -175,7 +184,26 @@ def main() -> int:
         # 5) 跑 GUT
         output = _run_gut_cmdln(godot, proj)
 
-    # 6) Godot 在 cmdln 脚本加载失败时仍可能 exit 0 —— 额外断言 GUT 成功 marker。
+    # 6) 判 PASS 前两道独立守卫，任一命中即 FAIL（issue #188）。
+    if _SILENT_SKIP_RE.search(output):
+        _fail(
+            "检测到脚本解析失败被 GUT 静默跳过"
+            "（Parse Error / Failed to load script / Ignoring script）—— 看上面输出排查"
+        )
+
+    gut_dir = REPO_ROOT / "addons" / "godot_cli_control" / "tests" / "gut"
+    expected_scripts = len(list(gut_dir.glob("test_*.gd")))
+    match = _SCRIPTS_TOTAL_RE.search(output)
+    if match is None:
+        _fail("未能从 GUT 输出中解析出 'Scripts' 计数 —— 看上面输出排查")
+    actual_scripts = int(match.group(1))
+    if actual_scripts < expected_scripts:
+        _fail(
+            f"GUT 实际执行脚本数 ({actual_scripts}) 少于 tests/gut/test_*.gd "
+            f"文件数 ({expected_scripts}) —— 有脚本被静默跳过"
+        )
+
+    # 7) Godot 在 cmdln 脚本加载失败时仍可能 exit 0 —— 额外断言 GUT 成功 marker。
     if _SUCCESS_MARKER in output:
         _log("GUT PASS")
         return 0

--- a/addons/godot_cli_control/tests/run_gut.sh
+++ b/addons/godot_cli_control/tests/run_gut.sh
@@ -87,6 +87,29 @@ trap 'rm -rf "$PROJ" "$GUT_SRC" "$RUN_LOG"' EXIT
     -gdir=res://addons/godot_cli_control/tests/gut \
     -gexit 2>&1 | tee "$RUN_LOG"
 
+# 假绿守卫（issue #188）：GUT 遇到解析失败的测试脚本只告警并跳过（不计入统计、
+# 不判失败），"All tests passed!" marker 对整文件被跳过是盲区。判 PASS 前加两道
+# 独立检测，任一命中即 FAIL：
+
+# 1) 引擎/GUT 在跳过脚本时固定打这三类字样之一。
+if grep -qE 'Parse Error|Failed to load script|Ignoring script' "$RUN_LOG"; then
+    echo "FAIL: 检测到脚本解析失败被 GUT 静默跳过（Parse Error / Failed to load script / Ignoring script）—— 看上面输出排查" >&2
+    exit 1
+fi
+
+# 2) 比对 GUT 汇总的 "Scripts" 计数与 tests/gut/ 下实际的 test_*.gd 文件数
+#    （add_directory 不递归子目录，这里也用 -maxdepth 1 对齐）。
+EXPECTED_SCRIPTS="$(find "$REPO_ROOT/addons/godot_cli_control/tests/gut" -maxdepth 1 -name 'test_*.gd' | wc -l | tr -d ' ')"
+ACTUAL_SCRIPTS="$(grep -E '^Scripts[[:space:]]+[0-9]+' "$RUN_LOG" | grep -oE '[0-9]+' | tail -1)"
+if [[ -z "$ACTUAL_SCRIPTS" ]]; then
+    echo "FAIL: 未能从 GUT 输出中解析出 'Scripts' 计数 —— 看上面输出排查" >&2
+    exit 1
+fi
+if [[ "$ACTUAL_SCRIPTS" -lt "$EXPECTED_SCRIPTS" ]]; then
+    echo "FAIL: GUT 实际执行脚本数 ($ACTUAL_SCRIPTS) 少于 tests/gut/test_*.gd 文件数 ($EXPECTED_SCRIPTS) —— 有脚本被静默跳过" >&2
+    exit 1
+fi
+
 # Godot 在 cmdln 脚本加载失败时仍可能 exit 0；额外断言：GUT 的成功 marker。
 if grep -q "All tests passed!" "$RUN_LOG"; then
     echo "==> GUT PASS"


### PR DESCRIPTION
## Summary
- GUT 遇到解析失败的测试脚本只告警并跳过（不计入统计、不判失败），`run_gut.sh`/`run_gut.py` 此前只认 GUT 的 `"All tests passed!"` marker —— 被跳过的整个文件完全不影响结果，照样判 PASS。PR #186/#187 已两次真实咬人：产品代码解析都过不了，测试却是绿的。
- 在判 marker 前新增两道独立守卫（任一命中即 FAIL）：
  1. grep 输出中的 `Parse Error` / `Failed to load script` / `Ignoring script`（引擎/GUT 跳过脚本时固定打的字样）。
  2. 比对 GUT 汇总的 `Scripts` 计数与 `tests/gut/` 下 `test_*.gd` 文件数（非递归，对齐 GUT `add_directory` 不扫子目录的行为），实际执行数少于文件数即判有脚本被静默吞掉。
- `run_gut.sh` / `run_gut.py` 两个 runner 逻辑对齐（CLAUDE.md 既有约定）。

Fixes #188

## Test plan
- [x] 正常场景：本地跑 `run_gut.py`，10 个 `test_*.gd` 全部合法解析，`Scripts 10` 与文件数一致，退出码 0，两道新守卫无误报。
- [x] 故意在某个 test 文件里插入一行不闭合括号制造 Parse Error 后重跑：确认底层日志确实打出 `Parse Error` / `Failed to load script` / `Ignoring script`、`Scripts` 计数从 10 掉到 9，GUT 自身仍打印 `All tests passed!`（复现了 issue 描述的假绿），而新守卫在 marker 判定前抢先命中，正确拦成 FAIL、退出码非 0。验证完已 `git checkout` 还原该测试文件。
- [x] CI（ubuntu / macOS / windows 三格跑 `run_gut.py`）待绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)